### PR TITLE
Fix orderbook chart is not loading

### DIFF
--- a/lib/model/cex_provider.dart
+++ b/lib/model/cex_provider.dart
@@ -166,6 +166,9 @@ class CexProvider extends ChangeNotifier {
     if (chain.length > 1 && json1 == null) return;
 
     final Map<String, List<CandleData>> data = {};
+
+    json0.remove(
+        'last_updated'); // This field is not a list, so it makes forEach fail
     json0.forEach((String duration, dynamic list) {
       final List<CandleData> _durationData = [];
 

--- a/lib/model/cex_provider.dart
+++ b/lib/model/cex_provider.dart
@@ -167,8 +167,14 @@ class CexProvider extends ChangeNotifier {
 
     final Map<String, List<CandleData>> data = {};
 
-    json0.remove(
-        'last_updated'); // This field is not a list, so it makes forEach fail
+    // 'last_updated' field is not a list, so it makes upcoming forEach call fail
+    DateTime lastUpdated;
+    if (json0.containsKey('last_updated')) {
+      lastUpdated =
+          DateTime.fromMillisecondsSinceEpoch(json0['last_updated'] * 1000);
+      json0.remove('last_updated');
+    }
+
     json0.forEach((String duration, dynamic list) {
       final List<CandleData> _durationData = [];
 


### PR DESCRIPTION
OHLC endpoint has `last_updated` field next to the timestamps with lists in them. 

So `json0.forEach((String duration, dynamic list)` code fails because `last_updated` is not a list. That value is not used so simply removing it solves the issue.

<img width="324" alt="image" src="https://github.com/KomodoPlatform/atomicdex-mobile/assets/6732486/b108b695-8de6-4b5c-8455-95f756ef2847">
