### PR TITLE
ZCoin Activation Improvements

### DIFF
--- a/lib/blocs/coins_bloc.dart
+++ b/lib/blocs/coins_bloc.dart
@@ -575,7 +575,7 @@ class CoinsBloc implements BlocBase {
     // await syncCoinsStateWithApi(!isZCash);
     await syncCoinsStateWithApi();
 
-    if (currentActiveCoin.coin.abbr == coin.abbr) {
+    if (currentActiveCoin?.coin?.abbr == coin.abbr) {
       currentCoinActivate(null);
     }
   }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -41,13 +41,12 @@ class ZCoinActivationApi {
     DateTime savedZhtlcSyncStartDate =
         zhtlcActivationPrefs['zhtlcSyncStartDate'];
 
-    int syncStartDateAsMsSinceEpoch = zhtlcSyncType == SyncType.fullSync
-        ? 0
-        : ((zhtlcSyncType == SyncType.specifiedDate
-                    ? savedZhtlcSyncStartDate
-                    : DateTime.now().subtract(Duration(minutes: 30)))
-                .millisecondsSinceEpoch ~/
-            1000);
+    // No SyncType.fullSync option for now
+    int syncStartDateAsMsSinceEpoch = (zhtlcSyncType == SyncType.specifiedDate
+                ? savedZhtlcSyncStartDate
+                : DateTime.now().subtract(Duration(days: 2)))
+            .millisecondsSinceEpoch ~/
+        1000;
 
     Map<String, dynamic> activationParams = {
       'mode': {

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -41,13 +41,13 @@ class ZCoinActivationApi {
     DateTime savedZhtlcSyncStartDate =
         zhtlcActivationPrefs['zhtlcSyncStartDate'];
 
-    int syncStartDateAsMsSinceEpoch = (zhtlcSyncType == SyncType.specifiedDate
-                ? savedZhtlcSyncStartDate
-                : zhtlcSyncType == SyncType.newTransactions
-                    ? DateTime.now().subtract(Duration(minutes: 30))
-                    : DateTime.utc(2000, 1, 1)) // TODO: Full-sync, invalid atm
-            .millisecondsSinceEpoch ~/
-        1000;
+    int syncStartDateAsMsSinceEpoch = zhtlcSyncType == SyncType.fullSync
+        ? 0
+        : ((zhtlcSyncType == SyncType.specifiedDate
+                    ? savedZhtlcSyncStartDate
+                    : DateTime.now().subtract(Duration(minutes: 30)))
+                .millisecondsSinceEpoch ~/
+            1000);
 
     Map<String, dynamic> activationParams = {
       'mode': {

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -372,7 +372,8 @@ class ZCoinActivationApi {
         int currentScannedBlock = currentDetails['current_scanned_block'];
 
         // If it's the first scan for this ticker, store the current block as the first scanned block
-        if (!firstScannedBlocks.containsKey(ticker)) {
+        if (!firstScannedBlocks.containsKey(ticker) ||
+            currentScannedBlock < firstScannedBlocks[ticker]) {
           firstScannedBlocks[ticker] = currentScannedBlock;
         }
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -110,8 +110,10 @@ class ZCoinActivationApi {
     if (response.statusCode == 200) {
       final responseBody = jsonDecode(response.body);
 
-      Log('z_coin_activation_api:cancelActivation',
-          'ZCoin Activation Cancel Response: ${responseBody.toString()}');
+      Log(
+        'z_coin_activation_api:cancelActivation',
+        'ZCoin Activation Cancel Response: ${responseBody.toString()}',
+      );
 
       // Success can give error as well, like:
       // "error": "Task is finished already",
@@ -159,8 +161,10 @@ class ZCoinActivationApi {
         firstScannedBlocks.remove(ticker);
         cancelledCoins.add(ticker);
       } catch (e) {
-        Log('z_coin_activation_api:cancelAllActivation',
-            'Failed to cancel activation for $ticker: $e');
+        Log(
+          'z_coin_activation_api:cancelAllActivation',
+          'Failed to cancel activation for $ticker: $e',
+        );
       }
     }
 
@@ -187,7 +191,8 @@ class ZCoinActivationApi {
             ticker,
             isAlreadyActivated
                 ? ActivationTaskStatus.active
-                : ActivationTaskStatus.notFound)
+                : ActivationTaskStatus.notFound,
+          )
         : await activationTaskStatus(coinTaskId, ticker: ticker);
 
     final isActivatedOnBackend = (isAlreadyActivated || taskStatus.isActivated);
@@ -289,8 +294,10 @@ class ZCoinActivationApi {
       await _removeCoinTaskId(ticker);
     }
 
-    Log('activationTaskStatus',
-        'Z Coin activation status (Progress=${status.progress}) ($apiStatus) response: ${result.toString()}');
+    Log(
+      'activationTaskStatus',
+      'Z Coin activation status (Progress=${status.progress}) ($apiStatus) response: ${result.toString()}',
+    );
 
     if (status != null) {
       return status;

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -107,10 +107,16 @@ class ZCoinActivationApi {
 
     if (response.statusCode == 200) {
       final responseBody = jsonDecode(response.body);
-      if (responseBody.containsKey('error')) {
-        throw Exception(
-            'Failed to cancel activation: ${responseBody['error']}');
-      }
+
+      Log('z_coin_activation_api:cancelActivation',
+          'ZCoin Activation Cancel Response: ${responseBody.toString()}');
+
+      // Success can give error as well, like:
+      // "error": "Task is finished already",
+      // if (responseBody.containsKey('error')) {
+      // Log('z_coin_activation_api:cancelActivation',
+      //     'ZCoin Activation Cancel Error: ${responseBody['error']}');
+      // }
     } else {
       throw Exception('Failed to cancel activation: ${response.toString()}');
     }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -44,7 +44,9 @@ class ZCoinActivationApi {
     // No SyncType.fullSync option for now
     int syncStartDateAsMsSinceEpoch = (zhtlcSyncType == SyncType.specifiedDate
                 ? savedZhtlcSyncStartDate
-                : DateTime.now().subtract(Duration(days: 2)))
+                : zhtlcSyncType == SyncType.fullSync
+                    ? DateTime.utc(2000, 1, 1)
+                    : DateTime.now().subtract(Duration(days: 2)))
             .millisecondsSinceEpoch ~/
         1000;
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -41,7 +41,6 @@ class ZCoinActivationApi {
     DateTime savedZhtlcSyncStartDate =
         zhtlcActivationPrefs['zhtlcSyncStartDate'];
 
-    // No SyncType.fullSync option for now
     int syncStartDateAsMsSinceEpoch = (zhtlcSyncType == SyncType.specifiedDate
                 ? savedZhtlcSyncStartDate
                 : zhtlcSyncType == SyncType.fullSync

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -384,7 +384,8 @@ class ZCoinActivationApi {
         int numBlocksScanned = currentScannedBlock - firstScannedBlock;
         int totalBlocks = latestBlock - firstScannedBlock;
 
-        if (totalBlocks == 0) totalBlocks = numBlocksScanned;
+        if (totalBlocks <= 0) totalBlocks = numBlocksScanned;
+        if (totalBlocks <= 0) totalBlocks = 1;
 
         _progress = isBuildingPhase
             ? (20 + ((numBlocksScanned / totalBlocks) * 80).toInt())

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -19,6 +19,7 @@ class ZCoinActivationBloc
     on<ZCoinActivationRequested>(_handleActivationRequested);
     on<ZCoinActivationSetRequestedCoins>(_handleSetRequestedCoins);
     on<ZCoinActivationStatusRequested>(_handleActivationStatusRequested);
+    on<ZCoinActivationCancelRequested>(_handleActivationCancelRequested);
   }
 
   final ZCoinActivationRepository _repository = ZCoinActivationRepository(
@@ -162,6 +163,12 @@ class ZCoinActivationBloc
         ZCoinActivationFailure('Failed to get activation status'),
       );
     }
+  }
+
+  Future<void> _handleActivationCancelRequested(
+      ZCoinActivationCancelRequested event,
+      Emitter<ZCoinActivationState> emit) async {
+    await _repository.cancelAllZCoinActivations();
   }
 
   Future<void> _updateNotification(

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -77,8 +77,7 @@ class ZCoinActivationBloc
 
         final eta = calculateETA(overallProgress);
 
-        if (zhtlcSyncType !=
-            SyncType.newTransactions /* && shouldShowNewProgress */) {
+        if (zhtlcSyncType != SyncType.newTransactions) {
           _updateNotification(
             coinStatus,
             overallProgress: overallProgress,
@@ -107,7 +106,6 @@ class ZCoinActivationBloc
         // emit(ZCoinActivationSuccess('ZHTLC coins activation process ended'));
       } else {
         emit(ZCoinActivationFailure('Failed to activate coins'));
-        // add(ZCoinActivationSetRequestedCoins(coins));
       }
     } catch (e) {
       debugPrint('Failed to start activation: $e');

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
@@ -15,3 +15,4 @@ class ZCoinActivationSetRequestedCoins extends ZCoinActivationEvent {
 
 class ZCoinActivationStatusRequested extends ZCoinActivationEvent {}
 
+class ZCoinActivationCancelRequested extends ZCoinActivationEvent {}

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -39,6 +39,10 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
             }
 
             await removeRequestedActivatedCoins([currentCoinTicker]);
+          } else if (update.status == ActivationTaskStatus.failed) {
+            await removeRequestedActivatedCoins([currentCoinTicker]);
+            await api.removeTaskId(currentCoinTicker);
+            await coinsBloc.syncCoinsStateWithApi();
           }
 
           yield update;

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -70,6 +70,19 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
     return enabledCoins;
   }
 
+  Future<void> cancelAllZCoinActivations() async {
+    try {
+      final cancelledCoins = await api.cancelAllActivation();
+      if (cancelledCoins.isNotEmpty) {
+        await removeRequestedActivatedCoins(cancelledCoins);
+      }
+      await coinsBloc.syncCoinsStateWithApi();
+    } catch (e) {
+      Log('z_coin_activation_repository:cancelAllZCoinActivations',
+          'Failed to cancel ZCoin activations: $e');
+    }
+  }
+
   @override
   Future<List<String>> outstandingZCoinActivations() async {
     final knownZCoins = await getKnownZCoins();

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -82,8 +82,10 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
       }
       await coinsBloc.syncCoinsStateWithApi();
     } catch (e) {
-      Log('z_coin_activation_repository:cancelAllZCoinActivations',
-          'Failed to cancel ZCoin activations: $e');
+      Log(
+        'z_coin_activation_repository:cancelAllZCoinActivations',
+        'Failed to cancel ZCoin activations: $e',
+      );
     }
   }
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
@@ -33,7 +33,11 @@ class ZCoinActivationInProgess extends ZCoinActivationState {
   final DateTime startTime; // nullable
 }
 
-class ZCoinActivationSuccess extends ZCoinActivationState {}
+class ZCoinActivationSuccess extends ZCoinActivationState {
+  ZCoinActivationSuccess(this.message);
+
+  final String message;
+}
 
 class ZCoinActivationFailure extends ZCoinActivationState {
   const ZCoinActivationFailure(this.message);

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -11,6 +11,7 @@ import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_notifications.
 import 'package:komodo_dex/packages/z_coin_activation/models/z_coin_activation_prefs.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/rotating_progress_indicator.dart';
 import 'package:komodo_dex/services/mm_service.dart';
+import 'package:komodo_dex/widgets/confirmation_dialog.dart';
 
 class ZCoinStatusWidget extends StatefulWidget {
   const ZCoinStatusWidget({Key key}) : super(key: key);
@@ -162,7 +163,7 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
             Icons.check_circle,
             color: theme.colorScheme.secondary,
           ),
-          content: Text('ZHTLC coins activated successfully'),
+          content: Text('ZHTLC coins activation process ended'),
           // backgroundColor: Colors.green,
           actions: [
             TextButton(
@@ -446,6 +447,23 @@ void _showInProgressDialog(BuildContext context) {
           ],
         ),
         actions: [
+          TextButton(
+            onPressed: () {
+              showConfirmationDialog(
+                context: context,
+                title: 'Stop Activation',
+                message:
+                    'Are you sure you want to stop the activation process?',
+                onConfirm: () {
+                  context
+                      .read<ZCoinActivationBloc>()
+                      .add(ZCoinActivationCancelRequested());
+                },
+                confirmButtonText: 'Stop',
+              );
+            },
+            child: Text('Stop'),
+          ),
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: Text(appL10n.close),

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -83,15 +83,12 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
 
         final bool isStatusLoading = state is ZCoinActivationStatusLoading;
 
-        final bool knownActivationStatus =
-            (state is ZCoinActivationStatusChecked ? state.isActivated : false);
-
         return ListTile(
           title: Text('ZCoin (ZHTLC) Activation'),
           tileColor: Theme.of(context).primaryColor,
           leading: isStatusLoading
               ? CircularProgressIndicator()
-              : knownActivationStatus
+              : state is ZCoinActivationStatusChecked && state.isActivated
                   ? Icon(
                       Icons.check_circle,
                       color: Colors.green,
@@ -99,11 +96,13 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
                   : null,
           subtitle: isStatusLoading
               ? null
-              : Text(
-                  knownActivationStatus
-                      ? 'ZHTLC coins are activated'
-                      : 'ZHTLC coins are not activated',
-                ),
+              : state is ZCoinActivationStatusChecked
+                  ? Text(
+                      state.isActivated
+                          ? 'ZHTLC coins are activated'
+                          : 'ZHTLC coins are not activated',
+                    )
+                  : null,
           selected: false,
           trailing: IconButton(
             icon: Icon(

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -264,8 +264,8 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                     },
                   ),
                   RadioListTile<SyncType>(
-                    title: const Text('Full sync'),
-                    value: SyncType.fullSync,
+                    title: const Text('Sync from specified date'),
+                    value: SyncType.specifiedDate,
                     groupValue: _syncType,
                     onChanged: (SyncType value) {
                       setState(() {
@@ -274,8 +274,8 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                     },
                   ),
                   RadioListTile<SyncType>(
-                    title: const Text('Sync from specified date'),
-                    value: SyncType.specifiedDate,
+                    title: const Text('Sync from sapling activation'),
+                    value: SyncType.fullSync,
                     groupValue: _syncType,
                     onChanged: (SyncType value) {
                       setState(() {

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -49,15 +49,11 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
   }
 
   bool apiReady = mmSe.running;
-// class _SetupZcoinButton extends StatelessWidget {
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ZCoinActivationBloc, ZCoinActivationState>(
-      // listenWhen: (previous, current) =>
-      //     previous.runtimeType != current.runtimeType,
-      // listener: listener,
       builder: (context, state) {
-        // bool coinActivated = state is ZCoinActivationSuccess;
         bool isActivationInProgress = state is ZCoinActivationInProgess;
 
         if (isActivationInProgress) {

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -409,7 +409,10 @@ void _showInProgressDialog(BuildContext context) {
       final state =
           context.watch<ZCoinActivationBloc>().state.asProgressOrNull();
 
-      if (state == null) return Container();
+      if (state == null) {
+        Navigator.pop(context);
+        return Container();
+      }
 
       final appL10n = AppLocalizations.of(context);
 

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -410,7 +410,9 @@ void _showInProgressDialog(BuildContext context) {
           context.watch<ZCoinActivationBloc>().state.asProgressOrNull();
 
       if (state == null) {
-        Navigator.pop(context);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          Navigator.pop(context);
+        });
         return Container();
       }
 

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -262,7 +262,6 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       });
                     },
                   ),
-                  /* // No SyncType.fullSync option for now
                   RadioListTile<SyncType>(
                     title: const Text('Full sync'),
                     value: SyncType.fullSync,
@@ -273,7 +272,6 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       });
                     },
                   ),
-                  */
                   RadioListTile<SyncType>(
                     title: const Text('Sync from specified date'),
                     value: SyncType.specifiedDate,

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -163,7 +163,7 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
             Icons.check_circle,
             color: theme.colorScheme.secondary,
           ),
-          content: Text('ZHTLC coins activation process ended'),
+          content: Text(state.message),
           // backgroundColor: Colors.green,
           actions: [
             TextButton(

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -262,6 +262,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       });
                     },
                   ),
+                  /* // No SyncType.fullSync option for now
                   RadioListTile<SyncType>(
                     title: const Text('Full sync'),
                     value: SyncType.fullSync,
@@ -272,6 +273,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       });
                     },
                   ),
+                  */
                   RadioListTile<SyncType>(
                     title: const Text('Sync from specified date'),
                     value: SyncType.specifiedDate,

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -23,7 +23,6 @@ import '../../../../model/cex_provider.dart';
 import '../../../../model/coin_balance.dart';
 import '../../../../services/mm_service.dart';
 import '../portfolio/loading_coin.dart';
-import 'add_coin_button.dart';
 import 'item_coin.dart';
 
 class CoinsPage extends StatefulWidget {
@@ -124,217 +123,222 @@ class _CoinsPageState extends State<CoinsPage> {
         _scrollController.offset > _heightSliver;
 
     return Scaffold(
-        body: NestedScrollView(
-            controller: _scrollController,
-            headerSliverBuilder:
-                (BuildContext context, bool innerBoxIsScrolled) {
-              return <Widget>[
-                SliverAppBar(
-                  backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                  expandedHeight: 130,
-                  pinned: true,
-                  actions: [
-                    AnimatedOpacity(
-                      opacity: isCollapsed ? 1 : 0,
-                      duration: Duration(milliseconds: 600),
-                      curve: Curves.easeInOutExpo,
-                      child: IgnorePointer(
-                        ignoring: !isCollapsed,
-                        child: AddCoinButton(
-                            key: Key('add-coin-button-collapsed'),
-                            isCollapsed: true,
-                            hideAddCoinLoading: hideAddCoinLoading,
-                            onShowAddCoinLoading: _showAddCoinLoading),
-                      ),
+      body: NestedScrollView(
+        controller: _scrollController,
+        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+          return <Widget>[
+            SliverAppBar(
+              backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+              expandedHeight: 130,
+              pinned: true,
+              actions: [
+                AnimatedOpacity(
+                  opacity: isCollapsed ? 1 : 0,
+                  duration: Duration(milliseconds: 600),
+                  curve: Curves.easeInOutExpo,
+                  child: IgnorePointer(
+                    ignoring: !isCollapsed,
+                    child: AddCoinButton(
+                      key: Key('add-coin-button-collapsed'),
+                      isCollapsed: true,
+                      hideAddCoinLoading: hideAddCoinLoading,
+                      onShowAddCoinLoading: _showAddCoinLoading,
                     ),
-                    SizedBox(width: 8),
-                  ],
-                  flexibleSpace: Builder(
-                    builder: (BuildContext context) {
-                      return Stack(
-                        children: <Widget>[
-                          FlexibleSpaceBar(
-                              collapseMode: CollapseMode.pin,
-                              centerTitle: true,
-                              titlePadding:
-                                  EdgeInsetsDirectional.only(bottom: 10),
-                              title: SizedBox(
-                                width: _widthScreen * 0.5,
-                                child: Center(
-                                  heightFactor: _heightFactor,
-                                  child: StreamBuilder<List<CoinBalance>>(
-                                      initialData: coinsBloc.coinBalance,
-                                      stream: coinsBloc.outCoins,
-                                      builder: (BuildContext context,
-                                          AsyncSnapshot<List<CoinBalance>>
-                                              snapshot) {
-                                        if (snapshot.data != null) {
-                                          double totalBalanceUSD = 0;
+                  ),
+                ),
+                SizedBox(width: 8),
+              ],
+              flexibleSpace: Builder(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      FlexibleSpaceBar(
+                        collapseMode: CollapseMode.pin,
+                        centerTitle: true,
+                        titlePadding: EdgeInsetsDirectional.only(bottom: 10),
+                        title: SizedBox(
+                          width: _widthScreen * 0.5,
+                          child: Center(
+                            heightFactor: _heightFactor,
+                            child: StreamBuilder<List<CoinBalance>>(
+                              initialData: coinsBloc.coinBalance,
+                              stream: coinsBloc.outCoins,
+                              builder: (
+                                BuildContext context,
+                                AsyncSnapshot<List<CoinBalance>> snapshot,
+                              ) {
+                                if (snapshot.data != null) {
+                                  double totalBalanceUSD = 0;
 
-                                          for (CoinBalance coinBalance
-                                              in snapshot.data) {
-                                            totalBalanceUSD +=
-                                                coinBalance.balanceUSD;
-                                          }
-                                          return StreamBuilder<bool>(
-                                            initialData:
-                                                settingsBloc.showBalance,
-                                            stream: settingsBloc.outShowBalance,
-                                            builder: (BuildContext context,
-                                                AsyncSnapshot<bool> snapshot) {
-                                              bool hidden = false;
-                                              if (snapshot.hasData &&
-                                                  !snapshot.data) {
-                                                hidden = true;
-                                              }
-                                              final String amountText =
-                                                  _cexProvider.convert(
-                                                totalBalanceUSD,
-                                                hidden: hidden,
-                                              );
-                                              return TextButton(
-                                                onPressed: () => _cexProvider
-                                                    .switchCurrency(),
-                                                style: TextButton.styleFrom(
-                                                  primary: isCollapsed
-                                                      ? Theme.of(context)
-                                                                  .brightness ==
-                                                              Brightness.light
-                                                          ? Colors.black
-                                                              .withOpacity(0.8)
-                                                          : Colors.white
-                                                      : Colors.white
-                                                          .withOpacity(0.8),
-                                                  textStyle: Theme.of(context)
-                                                      .textTheme
-                                                      .headline6,
-                                                ),
-                                                child: AutoSizeText(
-                                                  amountText,
-                                                  maxFontSize: 18,
-                                                  minFontSize: 12,
-                                                  maxLines: 1,
-                                                ),
-                                              );
-                                            },
-                                          );
-                                        } else {
-                                          return Center(
-                                              child:
-                                                  const CircularProgressIndicator());
-                                        }
-                                      }),
-                                ),
-                              ),
-                              background: Container(
-                                child: Padding(
-                                  padding: const EdgeInsets.only(bottom: 16),
-                                  child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.end,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: <Widget>[
-                                      const LoadAsset(),
-                                      const SizedBox(
-                                        height: 14.0,
-                                      ),
-                                      StreamBuilder<bool>(
-                                          initialData: settingsBloc.showBalance,
-                                          stream: settingsBloc.outShowBalance,
-                                          builder: (BuildContext context,
-                                              AsyncSnapshot<bool> snapshot) {
-                                            return snapshot.hasData &&
-                                                    snapshot.data
-                                                ? BarGraph()
-                                                : SizedBox();
-                                          })
-                                    ],
-                                  ),
-                                ),
-                                height: _heightScreen * 0.35,
-                                decoration: BoxDecoration(
-                                    gradient: LinearGradient(
-                                  begin: Alignment.bottomLeft,
-                                  end: Alignment.topRight,
-                                  stops: const <double>[0.01, 1],
-                                  colors: const <Color>[
-                                    Color.fromRGBO(98, 90, 229, 1),
-                                    Color.fromRGBO(45, 184, 240, 1),
-                                  ],
-                                )),
-                              )),
-                          Positioned(
-                            left: 0,
-                            right: 0,
-                            bottom: 0,
-                            child: _buildProgressIndicator(),
+                                  for (CoinBalance coinBalance
+                                      in snapshot.data) {
+                                    totalBalanceUSD += coinBalance.balanceUSD;
+                                  }
+                                  return StreamBuilder<bool>(
+                                    initialData: settingsBloc.showBalance,
+                                    stream: settingsBloc.outShowBalance,
+                                    builder: (
+                                      BuildContext context,
+                                      AsyncSnapshot<bool> snapshot,
+                                    ) {
+                                      bool hidden = false;
+                                      if (snapshot.hasData && !snapshot.data) {
+                                        hidden = true;
+                                      }
+                                      final String amountText =
+                                          _cexProvider.convert(
+                                        totalBalanceUSD,
+                                        hidden: hidden,
+                                      );
+                                      return TextButton(
+                                        onPressed: () =>
+                                            _cexProvider.switchCurrency(),
+                                        style: TextButton.styleFrom(
+                                          primary: isCollapsed
+                                              ? Theme.of(context).brightness ==
+                                                      Brightness.light
+                                                  ? Colors.black
+                                                      .withOpacity(0.8)
+                                                  : Colors.white
+                                              : Colors.white.withOpacity(0.8),
+                                          textStyle: Theme.of(context)
+                                              .textTheme
+                                              .headline6,
+                                        ),
+                                        child: AutoSizeText(
+                                          amountText,
+                                          maxFontSize: 18,
+                                          minFontSize: 12,
+                                          maxLines: 1,
+                                        ),
+                                      );
+                                    },
+                                  );
+                                } else {
+                                  return Center(
+                                    child: const CircularProgressIndicator(),
+                                  );
+                                }
+                              },
+                            ),
                           ),
-                        ],
-                      );
-                    },
-                  ),
-                  automaticallyImplyLeading: false,
-                ),
-                SliverAppBar(
-                  automaticallyImplyLeading: false,
-                  backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                  toolbarHeight: 48,
-                  flexibleSpace: Center(
-                    child: IntrinsicWidth(
-                      // Child has infite width. We want to change so that it
-                      // ignores the infinite width and takes up min width.
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: AddCoinButton(
-                            key: Key('add-coin-button'),
-                            hideAddCoinLoading: hideAddCoinLoading,
-                            onShowAddCoinLoading: _showAddCoinLoading),
+                        ),
+                        background: Container(
+                          child: Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: <Widget>[
+                                const LoadAsset(),
+                                const SizedBox(
+                                  height: 14.0,
+                                ),
+                                StreamBuilder<bool>(
+                                  initialData: settingsBloc.showBalance,
+                                  stream: settingsBloc.outShowBalance,
+                                  builder: (
+                                    BuildContext context,
+                                    AsyncSnapshot<bool> snapshot,
+                                  ) {
+                                    return snapshot.hasData && snapshot.data
+                                        ? BarGraph()
+                                        : SizedBox();
+                                  },
+                                )
+                              ],
+                            ),
+                          ),
+                          height: _heightScreen * 0.35,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.bottomLeft,
+                              end: Alignment.topRight,
+                              stops: const <double>[0.01, 1],
+                              colors: const <Color>[
+                                Color.fromRGBO(98, 90, 229, 1),
+                                Color.fromRGBO(45, 184, 240, 1),
+                              ],
+                            ),
+                          ),
+                        ),
                       ),
+                      Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: _buildProgressIndicator(),
+                      ),
+                    ],
+                  );
+                },
+              ),
+              automaticallyImplyLeading: false,
+            ),
+            SliverAppBar(
+              automaticallyImplyLeading: false,
+              backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+              toolbarHeight: 48,
+              flexibleSpace: Center(
+                child: IntrinsicWidth(
+                  // Child has infite width. We want to change so that it
+                  // ignores the infinite width and takes up min width.
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: AddCoinButton(
+                      key: Key('add-coin-button'),
+                      hideAddCoinLoading: hideAddCoinLoading,
+                      onShowAddCoinLoading: _showAddCoinLoading,
                     ),
                   ),
-                  pinned: false,
                 ),
-                BlocBuilder<ZCoinActivationBloc, ZCoinActivationState>(
-                  builder: (context, state) {
-                    final isActivationInProgress =
-                        state is ZCoinActivationInProgess;
+              ),
+              pinned: false,
+            ),
+            BlocBuilder<ZCoinActivationBloc, ZCoinActivationState>(
+              builder: (context, state) {
+                final isActivationInProgress =
+                    state is ZCoinActivationInProgess;
 
-                    return SliverVisibility(
-                      visible: isActivationInProgress,
-                      sliver: isActivationInProgress
-                          ? SliverAppBar(
-                              automaticallyImplyLeading: false,
-                              backgroundColor:
-                                  Theme.of(context).scaffoldBackgroundColor,
-                              flexibleSpace: Center(
-                                child: ZCoinStatusWidget(),
-                              ),
-                              pinned: false,
-                            )
-                          : SliverToBoxAdapter(child: SizedBox.shrink()),
-                    );
-                  },
-                ),
-              ];
-            },
-            body: Container(
-                color: Theme.of(context).scaffoldBackgroundColor,
-                child: const ListCoins())));
+                return SliverVisibility(
+                  visible: isActivationInProgress,
+                  sliver: isActivationInProgress
+                      ? SliverAppBar(
+                          automaticallyImplyLeading: false,
+                          backgroundColor:
+                              Theme.of(context).scaffoldBackgroundColor,
+                          flexibleSpace: Center(
+                            child: ZCoinStatusWidget(),
+                          ),
+                          pinned: false,
+                        )
+                      : SliverToBoxAdapter(child: SizedBox.shrink()),
+                );
+              },
+            ),
+          ];
+        },
+        body: Container(
+          color: Theme.of(context).scaffoldBackgroundColor,
+          child: const ListCoins(),
+        ),
+      ),
+    );
   }
 
   Widget _buildProgressIndicator() {
     return StreamBuilder<CoinToActivate>(
-        initialData: coinsBloc.currentActiveCoin,
-        stream: coinsBloc.outcurrentActiveCoin,
-        builder:
-            (BuildContext context, AsyncSnapshot<CoinToActivate> snapshot) {
-          return snapshot.data != null && !hideAddCoinLoading
-              ? const SizedBox(
-                  height: 2,
-                  child: LinearProgressIndicator(),
-                )
-              : SizedBox();
-        });
+      initialData: coinsBloc.currentActiveCoin,
+      stream: coinsBloc.outcurrentActiveCoin,
+      builder: (BuildContext context, AsyncSnapshot<CoinToActivate> snapshot) {
+        return snapshot.data != null && !hideAddCoinLoading
+            ? const SizedBox(
+                height: 2,
+                child: LinearProgressIndicator(),
+              )
+            : SizedBox();
+      },
+    );
   }
 }
 
@@ -368,11 +372,14 @@ class BarGraphState extends State<BarGraph> {
 
           for (CoinBalance coinBalance in snapshot.data) {
             if (coinBalance.balanceUSD > 0) {
-              barItem.add(Container(
-                color: Color(int.parse(coinBalance.coin.colorCoin)),
-                width: _widthBar *
-                    (((coinBalance.balanceUSD * 100) / sumOfAllBalances) / 100),
-              ));
+              barItem.add(
+                Container(
+                  color: Color(int.parse(coinBalance.coin.colorCoin)),
+                  width: _widthBar *
+                      (((coinBalance.balanceUSD * 100) / sumOfAllBalances) /
+                          100),
+                ),
+              );
             }
           }
         }
@@ -425,27 +432,34 @@ class LoadAssetState extends State<LoadAsset> {
             }
           }
 
-          listRet.add(Icon(
-            Icons.show_chart,
-            color: color.withOpacity(0.8),
-          ));
+          listRet.add(
+            Icon(
+              Icons.show_chart,
+              color: color.withOpacity(0.8),
+            ),
+          );
           listRet.add(
             Text(
               AppLocalizations.of(context).numberAssets(assetNumber.toString()),
               style: Theme.of(context).textTheme.caption.copyWith(color: color),
             ),
           );
-          listRet.add(Icon(
-            Icons.chevron_right,
-            color: color.withOpacity(0.8),
-          ));
+          listRet.add(
+            Icon(
+              Icons.chevron_right,
+              color: color.withOpacity(0.8),
+            ),
+          );
         } else {
-          listRet.add(SizedBox(
+          listRet.add(
+            SizedBox(
               height: 10,
               width: 10,
               child: const CircularProgressIndicator(
                 strokeWidth: 1.0,
-              )));
+              ),
+            ),
+          );
         }
         return SizedBox(
           height: 30,
@@ -487,39 +501,43 @@ class ListCoinsState extends State<ListCoins> {
       builder:
           (BuildContext context, AsyncSnapshot<List<CoinBalance>> snapshot) {
         return RefreshIndicator(
-            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-            color: Theme.of(context).colorScheme.secondary,
-            key: _refreshIndicatorKey,
-            onRefresh: () => coinsBloc.updateCoinBalances(),
-            child: Builder(builder: (BuildContext context) {
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          color: Theme.of(context).colorScheme.secondary,
+          key: _refreshIndicatorKey,
+          onRefresh: () => coinsBloc.updateCoinBalances(),
+          child: Builder(
+            builder: (BuildContext context) {
               if (snapshot.data != null && snapshot.data.isNotEmpty) {
                 final List<CoinBalance> _coinsSorted =
                     coinsBloc.sortCoins(snapshot.data);
 
                 return SlidableAutoCloseBehavior(
-                    child: ListView(
-                  padding: EdgeInsets.zero,
-                  children: [
-                    ListView.separated(
-                      padding: const EdgeInsets.all(0),
-                      key: const Key('list-view-coins'),
-                      itemCount: _coinsSorted.length,
-                      shrinkWrap: true,
-                      physics: ClampingScrollPhysics(),
-                      itemBuilder: (BuildContext context, int index) {
-                        return ItemCoin(
-                          key:
-                              Key('coin-list-${_coinsSorted[index].coin.abbr}'),
-                          mContext: context,
-                          coinBalance: _coinsSorted[index],
-                        );
-                        // }
-                      },
-                      separatorBuilder: (context, _) =>
-                          Divider(color: Theme.of(context).colorScheme.surface),
-                    ),
-                  ],
-                ));
+                  child: ListView(
+                    padding: EdgeInsets.zero,
+                    children: [
+                      ListView.separated(
+                        padding: const EdgeInsets.all(0),
+                        key: const Key('list-view-coins'),
+                        itemCount: _coinsSorted.length,
+                        shrinkWrap: true,
+                        physics: ClampingScrollPhysics(),
+                        itemBuilder: (BuildContext context, int index) {
+                          return ItemCoin(
+                            key: Key(
+                              'coin-list-${_coinsSorted[index].coin.abbr}',
+                            ),
+                            mContext: context,
+                            coinBalance: _coinsSorted[index],
+                          );
+                          // }
+                        },
+                        separatorBuilder: (context, _) => Divider(
+                          color: Theme.of(context).colorScheme.surface,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
               } else if (snapshot.connectionState == ConnectionState.waiting) {
                 return LoadingCoin();
               } else if (snapshot.data.isEmpty) {
@@ -540,7 +558,9 @@ class ListCoinsState extends State<ListCoins> {
               } else {
                 return SizedBox();
               }
-            }));
+            },
+          ),
+        );
       },
     );
   }

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -8,6 +8,8 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_event.dart';
+import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_state.dart';
+import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
 import 'package:provider/provider.dart';
 
 import 'package:komodo_dex/blocs/authenticate_bloc.dart';
@@ -291,6 +293,27 @@ class _CoinsPageState extends State<CoinsPage> {
                     ),
                   ),
                   pinned: false,
+                ),
+                BlocBuilder<ZCoinActivationBloc, ZCoinActivationState>(
+                  builder: (context, state) {
+                    final isActivationInProgress =
+                        state is ZCoinActivationInProgess;
+
+                    return SliverVisibility(
+                      visible: isActivationInProgress,
+                      sliver: isActivationInProgress
+                          ? SliverAppBar(
+                              automaticallyImplyLeading: false,
+                              backgroundColor:
+                                  Theme.of(context).scaffoldBackgroundColor,
+                              flexibleSpace: Center(
+                                child: ZCoinStatusWidget(),
+                              ),
+                              pinned: false,
+                            )
+                          : SliverToBoxAdapter(child: SizedBox.shrink()),
+                    );
+                  },
                 ),
               ];
             },


### PR DESCRIPTION
# Changes:
- Covered the case where a new block number was arriving before the older one, at progress calculation
- Added a missing null check to the activation
- Setting `sync_params.date` for `specified date` and `new transactions` sync options
- Better status text for the ZHTLC on the settings page
- Show ZHTLC sync progress on the portfolio page
- Cancel/Stop ZHTLC sync feature
- Full-sync is now called Sync since sapling activation
- Add sync/activation notifications
- Removing ZHTLC coin on sync failure so it can show up in the Add Coin list

# Known issues:
`Sync from sapling activation` issue:
- Timestamp of an old date like `2000-01-01` is sent. API responds with a `Too old` kind of an error so it fails but it needs to work with the sapling activation date. API team is on it.