### PR TITLE
Fix ARRR withdraw failing

### DIFF
--- a/lib/model/get_withdraw.dart
+++ b/lib/model/get_withdraw.dart
@@ -58,16 +58,19 @@ class GetWithdraw {
 class GetWithdrawTaskStatus {
   GetWithdrawTaskStatus({
     this.method = 'task::withdraw::status',
+    this.mmrpc = '2.0',
     @required this.taskId,
     @required this.userpass,
   });
 
   String method;
+  String mmrpc;
   int taskId;
   String userpass;
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'method': method,
+        'mmrpc': mmrpc,
         'userpass': userpass,
         'params': {
           'task_id': taskId,

--- a/lib/services/mm.dart
+++ b/lib/services/mm.dart
@@ -865,8 +865,6 @@ class ApiProvider {
     _assert200(r);
     _logRes('postWithdraw', r);
 
-    final parsedBody = _parseResponse(r);
-
     return withdrawResponseFromJson(res.body);
   }
 
@@ -885,9 +883,6 @@ class ApiProvider {
     }
 
     while (true) {
-      // TODO: Handle "In progress" status. Currently we are only emitting
-      // the initial and completed status.
-
       client ??= mmSe.client;
 
       final userBody = await _assertUserpass(
@@ -909,18 +904,20 @@ class ApiProvider {
       final status = result['status'] as String;
       dynamic details = result['details']; // String or Map<String, dynamic>
 
-      if (status == 'Ok') {
+      if (status == 'InProgress') {
+        // Would be a real shame if we DDOSed ourselves.
+        await Future.delayed(const Duration(seconds: 3));
+
+        continue; // No-op, continue the loop.
+      }
+
+      if (status == 'Ok' && details is Map<String, dynamic>) {
         yield WithdrawResponse.fromJson(details);
         return;
       }
 
-      if (status == 'InProgress') {
-        // No-op, continue the loop.
-      } else {
-        throw ErrorString('Withdraw failed with unknown status: $status');
-      }
-
-      await Future.delayed(const Duration(seconds: 3));
+      Log('mm:withdrawTaskStream', 'status: $status, details: $details');
+      throw ErrorString('Withdraw failed with unknown status: $status');
     }
   }
 

--- a/lib/services/mm.dart
+++ b/lib/services/mm.dart
@@ -907,7 +907,7 @@ class ApiProvider {
       final result = parsedBody['result'] as Map<String, dynamic>;
 
       final status = result['status'] as String;
-      final details = result['details'] as Map<String, dynamic>;
+      dynamic details = result['details']; // String or Map<String, dynamic>
 
       if (status == 'Ok') {
         yield WithdrawResponse.fromJson(details);


### PR DESCRIPTION
- `task::withdraw::status` now uses `mmrpc 2.0`.
- `result['details']` in `WithdrawResponse` is being `String` sometimes and the code tries to handle that as a Map, so it fails. Now it's `dynamic`. `WithdrawResponse.fromJson(details);` function does that Map conversion automatically.

### Note: 
I tested only ARRR. Other coins also need testing since there isn't any ARRR-specific code change. These changes are on the general withdraw code.