### PR TITLE
ZHTLC coins as wallet only

### DIFF
--- a/lib/model/coin.dart
+++ b/lib/model/coin.dart
@@ -87,6 +87,10 @@ class Coin {
     colorCoin = config['colorCoin'] ?? '';
     isDefault = appConfig.defaultCoins.contains(abbr);
     walletOnly = appConfig.walletOnlyCoins.contains(abbr);
+
+    // Disable Orderbooks for ZHTLC coins for now
+    if (type == CoinType.zhtlc) walletOnly = true;
+
     if (config['serverList'] != null) {
       serverList = <Server>[];
       config['serverList'].forEach((v) {


### PR DESCRIPTION
ZHTLC orderbook operations are not functioning well at the moment for my tests. Tagging ZHTLC as Wallet Only disables the problematic features for now.