### PR TITLE
Fix ZHTLC activation after restart

### DIFF
--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -44,8 +44,10 @@ class ZCoinActivationApi {
   }
 
   /// Creates a new activation task for the given coin.
-  Future<int> initiateActivation(String ticker,
-      {bool noSyncParams = false}) async {
+  Future<int> initiateActivation(
+    String ticker, {
+    bool noSyncParams = false,
+  }) async {
     await musicService.play(MusicMode.ACTIVE);
     await downloadZParams();
 
@@ -186,8 +188,10 @@ class ZCoinActivationApi {
     await storage.write(key: await taskIdKey(abbr), value: taskId.toString());
   }
 
-  Stream<ZCoinStatus> activateCoin(String ticker,
-      {bool firstLaunch = false}) async* {
+  Stream<ZCoinStatus> activateCoin(
+    String ticker, {
+    bool firstLaunch = false,
+  }) async* {
     int coinTaskId = await getTaskId(ticker);
     ZCoinStatus taskStatus;
     if (!firstLaunch) {
@@ -240,9 +244,6 @@ class ZCoinActivationApi {
         // yield taskStatus;
         yield taskStatus;
       }
-
-      final isTaskActive = taskStatus.status == ActivationTaskStatus.active;
-      final isTaskNotFound = taskStatus.status == ActivationTaskStatus.notFound;
 
       if (taskStatus.status == ActivationTaskStatus.active ||
           taskStatus.status == ActivationTaskStatus.notFound) {

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -170,6 +170,8 @@ class ZCoinActivationBloc
 
       if (!isAllCoinsEnabled && !isActivationInProgress) {
         add(ZCoinActivationRequested());
+      } else {
+        _repository.willInitialize = false;
       }
     } catch (e) {
       debugPrint('Failed to get activation status: $e');

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -24,10 +24,13 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
     try {
       if (zCoins.isEmpty) return;
 
+      bool firstLaunch = _firstLaunch;
+      _firstLaunch = false;
+
       while (zCoins.isNotEmpty) {
         final currentCoinTicker = zCoins.first;
-
-        await for (final update in api.activateCoin(currentCoinTicker)) {
+        await for (final update
+            in api.activateCoin(currentCoinTicker, firstLaunch: firstLaunch)) {
           Log(
             'ZCoinActivationRepository:activateZCoins',
             'Update received: ${update.toJson()}',

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -18,14 +18,14 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
   static Future<String> get taskIdKey async =>
       'activationTaskId_${(await Db.getCurrentWallet()).id}';
 
-  bool _firstLaunch = true;
+  bool willInitialize = true;
 
   Stream<ZCoinStatus> _activateZCoins(List<String> zCoins) async* {
     try {
-      if (zCoins.isEmpty) return;
+      bool firstLaunch = willInitialize;
+      willInitialize = false;
 
-      bool firstLaunch = _firstLaunch;
-      _firstLaunch = false;
+      if (zCoins.isEmpty) return;
 
       while (zCoins.isNotEmpty) {
         final currentCoinTicker = zCoins.first;
@@ -94,7 +94,7 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
   Future<List<String>> outstandingZCoinActivations() async {
     final requestedCoins = (await getRequestedActivatedCoins()).toSet();
 
-    if (_firstLaunch) return requestedCoins.toList();
+    if (willInitialize) return requestedCoins.toList();
 
     final activatedZCoins = (await getEnabledZCoins()).toSet();
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -18,6 +18,8 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
   static Future<String> get taskIdKey async =>
       'activationTaskId_${(await Db.getCurrentWallet()).id}';
 
+  bool _firstLaunch = true;
+
   Stream<ZCoinStatus> _activateZCoins(List<String> zCoins) async* {
     try {
       if (zCoins.isEmpty) return;
@@ -87,10 +89,11 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
 
   @override
   Future<List<String>> outstandingZCoinActivations() async {
-    final knownZCoins = await getKnownZCoins();
+    final requestedCoins = (await getRequestedActivatedCoins()).toSet();
+
+    if (_firstLaunch) return requestedCoins.toList();
 
     final activatedZCoins = (await getEnabledZCoins()).toSet();
-    final requestedCoins = (await getRequestedActivatedCoins()).toSet();
 
     final coinsAlreadyActivated = activatedZCoins.intersection(requestedCoins);
 


### PR DESCRIPTION
After restarting the application, ZHTLC coins are enabled but they don't activate/sync properly. So the basic wallet features like history and send are not working.

Changes:
- The "ZHTLC activated" checks at first launch is skipped to let it sync properly
- `sync_params` is not sent at the first launch, letting it continue the sync from where it was left 