### PR TITLE
Upgrade orderbook call mmrpc version to 2.0

### DIFF
--- a/lib/model/get_orderbook.dart
+++ b/lib/model/get_orderbook.dart
@@ -13,6 +13,7 @@ class GetOrderbook {
   GetOrderbook({
     this.userpass,
     this.method = 'orderbook',
+    this.mmrpc = '2.0',
     this.base,
     this.rel,
   });
@@ -20,19 +21,24 @@ class GetOrderbook {
   factory GetOrderbook.fromJson(Map<String, dynamic> json) => GetOrderbook(
         userpass: json['userpass'] ?? '',
         method: json['method'] ?? '',
-        base: json['base'] ?? '',
-        rel: json['rel'] ?? '',
+        mmrpc: json['mmrpc'] ?? '',
+        base: json['params']['base'] ?? '',
+        rel: json['params']['rel'] ?? '',
       );
 
   String userpass;
   String method;
+  String mmrpc;
   String base;
   String rel;
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'userpass': userpass ?? '',
         'method': method ?? '',
-        'base': base ?? '',
-        'rel': rel ?? '',
+        'mmrpc': mmrpc,
+        'params': {
+          'base': base ?? '',
+          'rel': rel ?? '',
+        }
       };
 }

--- a/lib/model/orderbook.dart
+++ b/lib/model/orderbook.dart
@@ -98,17 +98,17 @@ class Ask {
 
   factory Ask.fromJson(Map<String, dynamic> json, [String coin]) {
     if (isInfinite(json['price']['decimal'])) return null;
-    if (isInfinite(json['maxvolume'])) return null;
+    if (isInfinite(json['base_min_volume']['decimal'])) return null;
 
     return Ask(
       coin: coin ?? json['coin'] ?? '',
       address: json['address'] ?? '',
       price: json['price']['decimal'] ?? 0.0,
       priceFract: json['price']['fraction'],
-      maxvolume: deci(json['maxvolume']),
-      maxvolumeFract: json['max_volume_fraction'],
-      minVolume: fract2rat(json['min_volume_fraction']) ??
-          Rational.parse(json['min_volume']),
+      maxvolume: deci(json['base_max_volume']['decimal']),
+      maxvolumeFract: json['base_max_volume']['fraction'],
+      minVolume: fract2rat(json['base_min_volume']['fraction']) ??
+          Rational.parse(json['base_min_volume']['decimal']),
       pubkey: json['pubkey'] ?? '',
       age: json['age'] ?? 0,
       zcredits: json['zcredits'] ?? 0,
@@ -134,9 +134,13 @@ class Ask {
         'coin': coin ?? '',
         'address': address ?? '',
         'price': {'decimal': price ?? 0.0, 'fraction': priceFract},
-        'maxvolume': maxvolume.toString(),
-        'max_volume_fraction': maxvolumeFract,
-        'min_volume_fraction': rat2fract(minVolume),
+        'base_max_volume': {
+          'decimal': maxvolume.toString(),
+          'fraction': maxvolumeFract,
+        },
+        'base_min_volume': {
+          'fraction': rat2fract(minVolume),
+        },
         'pubkey': pubkey ?? '',
         'age': age ?? 0,
         'zcredits': zcredits ?? 0,

--- a/lib/model/orderbook.dart
+++ b/lib/model/orderbook.dart
@@ -97,14 +97,14 @@ class Ask {
   });
 
   factory Ask.fromJson(Map<String, dynamic> json, [String coin]) {
-    if (isInfinite(json['price'])) return null;
+    if (isInfinite(json['price']['decimal'])) return null;
     if (isInfinite(json['maxvolume'])) return null;
 
     return Ask(
       coin: coin ?? json['coin'] ?? '',
       address: json['address'] ?? '',
-      price: json['price'] ?? 0.0,
-      priceFract: json['price_fraction'],
+      price: json['price']['decimal'] ?? 0.0,
+      priceFract: json['price']['fraction'],
       maxvolume: deci(json['maxvolume']),
       maxvolumeFract: json['max_volume_fraction'],
       minVolume: fract2rat(json['min_volume_fraction']) ??
@@ -133,8 +133,7 @@ class Ask {
   Map<String, dynamic> toJson() => <String, dynamic>{
         'coin': coin ?? '',
         'address': address ?? '',
-        'price': price ?? 0.0,
-        'price_fraction': priceFract,
+        'price': {'decimal': price ?? 0.0, 'fraction': priceFract},
         'maxvolume': maxvolume.toString(),
         'max_volume_fraction': maxvolumeFract,
         'min_volume_fraction': rat2fract(minVolume),

--- a/lib/model/orderbook.dart
+++ b/lib/model/orderbook.dart
@@ -40,19 +40,19 @@ class Orderbook {
                     .map((dynamic x) => Ask.fromJson(x, json['rel'])))
                 .where((Ask bid) => bid != null)
                 .toList(),
-        numbids: json['numbids'] ?? 0,
+        numbids: json['num_bids'] ?? 0,
         asks: json['asks'] == null
             ? null
             : List<Ask>.from(json['asks']
                     .map((dynamic x) => Ask.fromJson(x, json['base'])))
                 .where((Ask ask) => ask != null)
                 .toList(),
-        numasks: json['numasks'] ?? 0,
+        numasks: json['num_asks'] ?? 0,
         askdepth: json['askdepth'] ?? 0,
         base: json['base'] ?? '',
         rel: json['rel'] ?? '',
         timestamp: json['timestamp'] ?? DateTime.now().millisecond,
-        netid: json['netid'] ?? 0,
+        netid: json['net_id'] ?? 0,
       );
 
   List<Ask> bids;
@@ -69,16 +69,16 @@ class Orderbook {
         'bids': bids == null
             ? null
             : List<dynamic>.from(bids.map<dynamic>((Ask x) => x.toJson())),
-        'numbids': numbids ?? 0,
+        'num_bids': numbids ?? 0,
         'asks': asks == null
             ? null
             : List<dynamic>.from(asks.map<dynamic>((Ask x) => x.toJson())),
-        'numasks': numasks ?? 0,
+        'num_asks': numasks ?? 0,
         'askdepth': askdepth ?? 0,
         'base': base ?? '',
         'rel': rel ?? '',
         'timestamp': timestamp ?? DateTime.now().millisecond,
-        'netid': netid ?? 0,
+        'net_id': netid ?? 0,
       };
 }
 

--- a/lib/model/orderbook.dart
+++ b/lib/model/orderbook.dart
@@ -102,7 +102,7 @@ class Ask {
 
     return Ask(
       coin: coin ?? json['coin'] ?? '',
-      address: json['address'] ?? '',
+      address: json['address']['address_data'] ?? 'Shielded',
       price: json['price']['decimal'] ?? 0.0,
       priceFract: json['price']['fraction'],
       maxvolume: deci(json['base_max_volume']['decimal']),
@@ -132,7 +132,9 @@ class Ask {
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'coin': coin ?? '',
-        'address': address ?? '',
+        'address': address == 'Shielded'
+            ? {'address_type': 'Shielded'}
+            : {'address_data': address},
         'price': {'decimal': price ?? 0.0, 'fraction': priceFract},
         'base_max_volume': {
           'decimal': maxvolume.toString(),

--- a/lib/services/mm.dart
+++ b/lib/services/mm.dart
@@ -453,7 +453,9 @@ class ApiProvider {
             )
             .then<dynamic>((Response res) {
           _assert200(res);
-          return orderbookFromJson(res.body);
+          return orderbookFromJson(
+            json.encode(json.decode(res.body)['result']),
+          );
         }),
       );
     } catch (e) {


### PR DESCRIPTION
Upgrading Orderbook mmrpc version to 2.0

Notes:
- Dart side variable names are unchanged to keep it easy to review. Those can be polished later on.
- Some fields like `age` do not exist in the 2.0 version so they default to 0. But all the visual information is there.
- This change is done essentially to make orderbooks work for ARRR/ZHTLC but there isn't any ARR/ZHTLC-specific code change. 
- All these changes are affecting the orderbook functionality of all coins. Therefore, if somehow there is a coin not compatible with 2.0, that will be broken.

Please test super carefully and validate that the field/structure mapping at serialization is correct. Highly critical change.