### PR TITLE
Localise hard-coded strings

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -3621,6 +3621,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "Aktivierung von {coinAbbr} konnte nicht abgebrochen werden",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} ist nicht verfügbar :(",
     "@isUnavailable": {
         "type": "text",
@@ -5460,6 +5470,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "Münzaktivierung abgebrochen",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "{coin} erfolgreich aktiviert",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "Aktivierung von {coin} abgebrochen",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Bitte akzeptieren Sie alle speziellen Münzaktivierungsanfragen oder heben Sie die Auswahl der Münzen auf.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "Aktivierung abbrechen",
     "@cancelActivation": {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,3660 +1,3726 @@
 {
-    "accepteula": "EULA akzeptieren",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "Allgemeine Geschäftsbedingungen akzeptieren",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Biometrischen Schutz aktivieren",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "PIN-Schutz aktivieren",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "{protocolName}-Münzen aktivieren?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "{coinName} wird aktiviert",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName}-Aktivierung",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} Aktivierung wird ausgeführt",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Aktiv",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Coin aktivieren",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} erfolgreich aktiviert!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Adresse hinzufügen",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Adressbuch",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "Adressbuch ist leer",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Nur Kontakte mit {title} Adressen anzeigen",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Adressbuch",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "Sie können kein Guthaben an die {abbr} Adresse senden, da {abbr} nicht aktiviert ist. Bitte gehen Sie zum Portfolio.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Nichts gefunden",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Coin auswählen",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Empfängeradresse",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Fortgeschritten",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "Alle",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Benutzerdefinierten Seed erlauben",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "Ist bereits vorhanden",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Menge",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Zu verkaufende Menge",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "Nein! {appName} hat keine Vormundschaft. Wir speichern niemals sensible Daten, einschließlich Ihrer privaten Schlüssel, Seed-Phrasen oder PINs. Diese Daten werden nur auf dem Gerät des Benutzers gespeichert und verlassen es nie. Sie haben die volle Kontrolle über Ihr Vermögen.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName} ist für Mobilgeräte auf Android und iPhone sowie für Desktops auf <a href=\"https://komodoplatform.com/\">Windows-, Mac- und Linux-Betriebssystemen</a> verfügbar.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Bei anderen DEXs können Sie im Allgemeinen nur Assets handeln, die auf einem einzigen Blockchain-Netzwerk basieren, Proxy-Token verwenden und nur einen einzigen Auftrag mit denselben Geldmitteln aufgeben.\n\n{appName} ermöglicht Ihnen den nativen Handel über zwei verschiedene Blockchain-Netzwerke ohne Proxy-Tokens. Sie können auch mehrere Aufträge mit demselben Guthaben platzieren. Sie können zum Beispiel 0,1 BTC für KMD, QTUM oder VRSC verkaufen - der erste Auftrag, der ausgeführt wird, storniert automatisch alle anderen Aufträge.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Mehrere Faktoren bestimmen die Bearbeitungszeit für einen Swap. Die Blockzeit der gehandelten Assets hängt vom jeweiligen Netzwerk ab (Bitcoin ist normalerweise das langsamste). Außerdem kann der Benutzer die Sicherheitseinstellungen anpassen. Zum Beispiel (können Sie {appName} bitten, eine KMD-Transaktion nach nur 3 Bestätigungen als endgültig zu betrachten, wodurch die Swap-Zeit kürzer wird als beim Warten auf eine <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">Beglaubigung</a>",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Ja. Sie müssen mit dem Internet verbunden bleiben und die App ausführen, um jeden Atomic Swap erfolgreich abzuschließen (sehr kurze Verbindungsunterbrechungen sind normalerweise in Ordnung). Andernfalls besteht das Risiko einer Auftragsstornierung, wenn Sie ein Maker sind, und das Risiko eines Geldverlusts, wenn Sie ein Taker sind.\n\nDas Atomic-Swap-Protokoll erfordert, dass beide Teilnehmer online bleiben und die beteiligten Blockchains überwachen, damit der Prozess atomar bleibt.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "Beim Handel auf {appName} sind zwei Gebührenkategorien zu berücksichtigen.\n\n1. {appName} berechnet ungefähr 0,13 % (1/777 des Handelsvolumens, aber nicht weniger als 0,0001) als Handelsgebühr für Taker-Aufträge, Maker-Aufträge haben keine Gebühren.\n\n2. Sowohl Maker als auch Taker müssen normale Netzwerkgebühren an die beteiligten Blockchains zahlen, wenn sie Atomic-Swap-Transaktionen durchführen.\n\nDie Netzwerkgebühren können je nach ausgewähltem Handelspaar stark variieren.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "Ja! {appName} bietet Support über den <a href=\"{link}\">{appCompanyShort} {name}</a>. Das Team und die Community helfen Euch gerne weiter!\n",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "Nein! {appName} ist vollständig dezentralisiert. Es ist nicht möglich, den Benutzerzugang durch Dritte zu beschränken.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} wird vom {appCompanyShort}-Team entwickelt. {appCompanyShort} ist eines der etabliertesten Blockchain-Projekte, das an innovativen Lösungen wie Atomic Swaps, Delayed Proof of Work und einer interoperablen Multi-Chain-Architektur arbeitet.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "Absolut! Weitere Informationen finden Sie in unserer <a href=\"https://developers.komodoplatform.com/\">Entwicklerdokumentation</a> oder kontaktieren Sie uns mit Ihren Partnerschaftsanfragen. Haben Sie eine spezielle technische Frage? Die {appName}-Entwickler-Community ist immer bereit zu helfen!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Beifall",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "BIST DU SICHER?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "ein Swap ist fehlgeschlagen",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "ein Swap läuft bis zur Fertigstellung",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "authentifizieren",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Sie werden automatisch zur Portfolio-Seite weitergeleitet, wenn der erneute Aktivierungsprozess abgeschlossen ist.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "max vol",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "zurück",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Sicherung",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "basierend auf {coinName1}/{coinName2}",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "Der Akkustand ist kritisch ({batteryLevelCritical}%) um einen Swap sicher auszuführen. Bitte laden Sie ihr Handy auf und versuchen es später noch einmal.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "Ihre Akkuladung ist niedriger als {batteryLevelLow} %. Bitte denken Sie an das Aufladen des Telefons.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "Ihr  Handy ist im Energissparmodus. Bitte deaktivieren Sie diesen Modus oder gehen Sie mit der App NICHT im Hintergrundmodus. Andernfalls könnte die App durch das Betriebssystem beendet werden und der Swap schlägt fehl.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "Wechselkurs",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Auf Komodo aufgebaut",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Auf Komodo aufgebaut",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Kaufen",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "In Maker-Auftrag umwandeln, wenn kein match stattgefunden hat",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Swap gestartet, bitte warten!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "Auftragsvermittlung läuft, bitte warten Sie {seconde} Sekunden!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "Warnung, Sie möchten Test-Coins ohne tatsächlichen Wert kaufen!",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "Tarnungs-PIN und Bio-Schutz können nicht gleichzeitig aktiviert werden.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Konflikt zwischen Carmo-PIN und Bio-Schutz.",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Tarnungs-PIN ändern",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Tarnungs-PIN erstellen",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Wenn Sie die App mit der Tarnungs-PIN entsperren, wird ein gefälschtes NIEDRIGERES Guthaben angezeigt und die Konfigurationsoption Tarnungs-PIN ist in den Einstellungen NICHT sichtbar.",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "ungültiger Tarnungs-PIN",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Tarnungs-PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "Tarnungs-PIN nicht gefunden",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Aus",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "An",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "Tarnungs-PIN gespeichert",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Tarnungs-PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Neuen Tarnungs-PIN eingeben",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Tarnungs-PIN Einrichtung",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Tarnungs-PIN Einrichtung",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "stornieren",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "stornieren",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Auftrag stornieren",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ok",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "ist ein Standard-Coin. Standard-Coins können nicht deaktiviert werden.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "Kann nicht deaktiviert werden",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "Kann nicht abgespielt werden",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEX-Tauschrate",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "CEX-Daten",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Die mit diesem Symbol gekennzeichneten Marktdaten (Kurse, Charts usw.) stammen aus Drittquellen (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "CEX-Kurs",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "PIN-Code ändern",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Nach Updates suchen",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Abmelden",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "Seed-Phrase überprüfen",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "WEITER",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "ZURÜCK UND ERNEUT ÜBERPRÜFEN",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "{index} Wort eingeben",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "Ihr Seed ist wichtig - deshalb stellen wir Ihnen drei verschiedene Fragen, um sicherzustellen, dass dieser korrekt ist und Sie Ihr Wallet jederzeit problemlos wiederherstellen können.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "Was ist das {index}.Wort in Ihrer Seed?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "LASSEN SIE UNS IHREN SEED DOPPELT ÜBERPRÜFEN",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Chinesisch",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "Anfordern",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "KMD Prämie anfordern?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Zum Anzeigen klicken",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "In die Zwischenablage kopiert",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "In die Zwischenablage kopieren",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Schließen",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Fehlermeldung schließen",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Vorschau schließen",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Code:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Sie haben die maximale Anzahl an Assets ausgewählt",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "{protocolName}-Münzen sind aktiviert",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName}-Münzen wurden erfolgreich aktiviert",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "{protocolName}-Münzen sind nicht aktiviert",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Löschen",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "keine aktivierten Coins",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Coin auswählen",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "Demnächst...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "TX Details folgen in Kürze!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "Details folgen in Kürze!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "Provision",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "im Vergleich zum Durchschnitt. 24h CEX-Preis",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "im Vergleich zu CEX",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "Bitte warten, ihre Wallet wird konfiguriert...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "Bestätigen",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Tarnungs-PIN bestätigen",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "Wollen Sie die Order wirklich stornieren?",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "Durch Klicken auf die folgenden Schaltflächen bestätigen Sie, dass Sie die \"EULA\" und die \"Allgemeinen Geschäftsbedingungen\" gelesen haben und diese akzeptieren",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Kennwort bestätigen",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "PIN-Code bestätigen",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "Seed-Phrase bestätigen",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Verbindung wird hergestellt ...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "Abbrechen",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Kontakt löschen",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "Löschen",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "Möchten Sie den Kontakt {name} wirklich löschen?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Verwerfen",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Bearbeiten",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Beenden",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Änderungen verwerfen?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "Keine Kontakte gefunden",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Sichern",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Kontaktdetails",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "Name",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Vertrag",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Umwandeln",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "URL konnte nicht gestartet werden",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "Konnte nicht importiert werden:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "Handeln",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "Wallet erstellen",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Kontakt erstellen",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "PIN erstellen",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Währung",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Währung",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Aktueller Wert:",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Individuelle Gebühr",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "Individuelle Gebühr nur nutzen, wenn Sie wissen was darunter zu verstehen ist!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Benutzerdefinierte Seed-Phrasen sind möglicherweise weniger sicher und leichter zu knacken als eine generierte BIP39-konforme Seed-Phrase oder ein privater Schlüssel (WIF). Um zu bestätigen, dass Sie das Risiko verstehen und wissen was Sie tun, geben Sie \"{iUnderstand}\" im Kasten unten an.\n",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Datum",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Wallet entschlüsseln",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Löschen",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Deaktivierung bestätigen",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "Möchten Sie",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "von ihrem Portfolio entfernen? Alle offenen Aufträge werden storniert.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " wird ebenfalls deaktiviert",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Wallet löschen",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Wallet wird gelöscht...",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "Erhalten Sie die Transaktionsgebühr {coinName}",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "Transaktionsgebühr für {coinName} senden",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "Handelsgebühr senden Transaktionsgebühr",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "Handelsgebühr",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "Details",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Deutsch",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Entwickler/in",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX ist für diesen Coin nicht verfügbar",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Deaktivieren Sie Screenshots/Vorschau",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Haftungsausschluss & AGB",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Erledigt",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "Schließen Sie die App nicht. Für weitere Informationen tippen ...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "Nicht mehr nachfragen",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "Ich möchte kein Kennwort",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo dPoW Sicherheit",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Dauer",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Kontakt bearbeiten",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "Geben Sie die {abbr}  Adresse ein",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "Verschlüsselungskennwort darf nicht leer sein",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "Kennwort darf nicht leer sein",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "Kontakt-Name darf nicht leer sein",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "Wallet-Name darf nicht leer sein",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "Sie können {remains} weiterhin aktivieren, Ausgewählt: {selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "Bitte aktivieren Sie Benachrichtigungen, um Updates zum Aktivierungsfortschritt zu erhalten.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Test-Coins aktivieren",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "Sie haben",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "Assets aktivert und versuchen",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "weitere zu aktivieren. Das Maximallimit beträgt",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": ". Bitte deaktivieren sie welche, bevor neue aktiviert werden.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Es wurde versucht, zu viele Assets zu aktivieren",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Wallet verschlüsseln",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "Englisch",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Geben Sie ihren neuen PIN ein",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Geben Sie ihren alten PIN ein",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Bitte Kennwort eingeben um fortzufahren.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "Geben Sie Ihren PIN-Code ein",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Geben Sie Ihre Seed-Phrase ein",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Sie müssen zuerst die Verkaufsmenge eingeben",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "Guthaben unzureichend",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "Ungültige Adresse",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Segwit-Adressen werden (noch) nicht unterstützt",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "Nicht genug Gas - verwenden Sie mindestens {gas} Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Fehler, bitte versuchen Sie es erneut",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Fehler, bitte versuchen Sie es später",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "Wert ist zu hoch oder zu niedrig",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "Bitte Daten eintippen",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Geschätzter Gesamtwert",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "Um abgeschlossen zu werden, {appCompanyLong}muss jede virtuelle Währungstransaktion, die mit dem erstellt wurde, bestätigt und im Ledger für virtuelle Währungen aufgezeichnet werden, das dem jeweiligen virtuellen Währungsnetzwerk zugeordnet ist. {appCompanyLong}Bei solchen Netzwerken handelt es sich um dezentrale Peer-to-Peer-Netzwerke, die von unabhängigen Dritten unterstützt werden, die sich nicht im Besitz, unter der Kontrolle oder unter der Kontrolle von ihnen befinden.\n{appCompanyLong}hat keine Kontrolle über virtuelle Währungsnetzwerke und kann und wird daher nicht sicherstellen, dass alle Transaktionsdetails, die Sie über unsere Dienste einreichen, im jeweiligen Netzwerk für virtuelle Währungen bestätigt werden. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionsdetails, die Sie über unsere Dienste übermitteln, durch das zur Bearbeitung der Transaktion verwendete virtuelle Währungsnetzwerk möglicherweise nicht abgeschlossen oder erheblich verzögert werden können. Wir garantieren nicht, dass das Wallet das Eigentum oder die Rechte an einer virtuellen Währung übertragen kann, und geben auch keine Garantie in Bezug auf den Titel.\nSobald Transaktionsdetails an ein virtuelles Währungsnetzwerk übermittelt wurden, können wir Ihnen nicht helfen, Ihre Transaktion oder Transaktionsdetails zu stornieren oder anderweitig zu ändern. {appCompanyLong}hat keine Kontrolle über ein Netzwerk für virtuelle Währungen und ist nicht in der Lage, Stornierungs- oder Änderungsanfragen zu bearbeiten.\nIm Falle eines Forks {appCompanyLong}kann es sein, dass wir Aktivitäten im Zusammenhang mit Ihrer virtuellen Währung nicht unterstützen können. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionen im Falle einer Fork möglicherweise nicht, teilweise, falsch abgeschlossen oder erheblich verzögert werden. {appCompanyLong}ist nicht verantwortlich für Verluste, die Ihnen ganz oder teilweise, direkt oder indirekt, durch einen Fork entstehen.\nIn keinem Fall {appCompanyLong}haften ihre verbundenen Unternehmen und Dienstleister oder ihre jeweiligen leitenden Angestellten, Direktoren, Agenten, Mitarbeiter oder Vertreter für entgangene Gewinne oder besondere, zufällige, indirekte, immaterielle oder Folgeschäden, unabhängig davon, ob sie auf Vertrag, unerlaubter Handlung, Fahrlässigkeit, verschuldensunabhängiger Haftung oder auf andere Weise beruhen, die sich aus oder in Verbindung mit der autorisierten oder unbefugten Nutzung der Dienste oder dieser Vereinbarung ergeben, auch wenn ein bevollmächtigter Vertreter {appCompanyLong}von darauf hingewiesen wurde, hat davon gewusst oder hätte von der Möglichkeit solcher Schäden bekannt. \nBeispielsweise (und ohne den Umfang des vorstehenden Satzes einzuschränken) dürfen Sie sich nicht für entgangene Gewinne, entgangene Geschäftschancen oder andere Arten von besonderen, zufälligen, indirekten, immateriellen oder Folgeschäden zurückfordern. In einigen Rechtsordnungen ist der Ausschluss oder die Beschränkung von Neben- oder Folgeschäden nicht zulässig, sodass die obige Beschränkung möglicherweise nicht für Sie gilt. \nWir sind Ihnen gegenüber nicht verantwortlich oder haftbar für Verluste und übernehmen keine Verantwortung für Schäden oder Ansprüche, die sich ganz oder teilweise, direkt oder indirekt ergeben aus: \n(a) Benutzerfehler wie vergessene Passwörter, falsch erstellte Transaktionen oder falsch eingegebene Adressen für virtuelle Währungen; \n(b) Serverausfall oder Datenverlust; \n(c) beschädigte oder anderweitig nicht funktionierende Wallets oder Wallet-Dateien; \n(d) unbefugter Zugriff auf Anwendungen; \n(e) alle nicht autorisierten Aktivitäten, einschließlich, aber nicht beschränkt auf den Einsatz von Hacking, Viren, Phishing, Brute-Forcing oder anderen Angriffsmethoden gegen die Dienste.\n\n",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Beispiel: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Sinnvoll",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Teuer",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "Identisch mit CEX",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Wechselkurs:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "TAUSCHEN",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Exportieren",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Kontakte",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Bitte wählen Sie die Elemente aus, die in eine verschlüsselte Datei exportiert werden sollen.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Exportieren",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Hinweise",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "Die Elemente wurden erfolgreich exportiert:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Swaps",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Exportieren",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Fehlgeschlagen",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Gefälschter Guthaben:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Häufig gestellte Fragen",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Fehler",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "Anfrage an {coin} faucet senden...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "FAUCET",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Erfolg",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "Zeitüberschreitung der Anfrage",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Protokolldatei teilen",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Neuigkeiten",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Hier gibt es nichts",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} Neuigkeiten",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Mehr lesen...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Feed",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Newsfeed",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "Aktualisierung der Nachrichten kann nicht fortgesetzt werden",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "Nachrichten können nicht aktualisiert werden",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Newsfeed aktualisiert",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Bereits auf dem neuesten Stand",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "Die Gebühren müssen bis zu {value} betragen.",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Alle",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Filter",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Alle Filter löschen",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Fehlgeschlagen",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "Von Datum",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Maker",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Coin erhalten",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Coin verkaufen",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Status",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Erfolgreich",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Taker",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "Bis Datum",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Taker/Maker",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Fingerabdruck",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Bitte warten Sie, bis der Vorgang abgeschlossen ist",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "QR-Code gefunden",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Französisch",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "Von",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin}-Gebühr",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "Gas-Limit",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Bitte aktivieren Sie {coin}.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "Gas-Preis",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "Der allgemeine PIN-Schutz ist nicht aktiv.\nDer Tarnungsmodus ist nicht verfügbar.\nBitte aktivieren Sie den PIN-Schutz.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Wichtig: Sichern Sie Ihren Seed bevor Sie fortfahren!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "Die Transaktion wird ausgeführt. Bitte warten Sie",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Zum Portfolio gehen",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Gwei muss bis zu {value} sein",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "Hilfe",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Hilfe und Support",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Guthaben ausblenden",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Kennwort bestätigen",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Kennwort erstellen",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Aktuelles Kennwort",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Geben Sie Ihr Kennwort ein",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Geben Sie Ihren Seed ein",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Benennen Sie Ihr Wallet",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Kennwort",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "Verlauf",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "h",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Ungarisch",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "Importieren",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Ungültiges Kennwort oder beschädigte Daten",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "Zu importierende Gegenstände:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Datei nicht gefunden",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Ungültige Swap-Daten. Bitte geben Sie eine gültige Swap-Status JSON-Datei an.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "Importieren",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Bitte wählen Sie eine verschlüsselte Datei zum Importieren aus.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Öffnung...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Bitte wählen Sie eine einfache Textauslagerungsdatei zum Importieren aus.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "Abbrechen",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Ok",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Kennwort",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Einzigen Swap importieren",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Swaps importieren",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Einige Elemente wurden übersprungen",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "Die Elemente wurden erfolgreich importiert:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "Import von Swaps fehlgeschlagen",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Fehler beim Dekodieren der json-Datei",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "Importieren",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Eingehende {coinName}-TXS-Schutzeinstellungen",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Verwenden Sie ein sicheres Kennwort und speichern Sie es nicht auf demselben Gerät",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "Der Swap kann nicht rückgängig gemacht werden und ist ein endgültiges Ereignis!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "Der Swap kann bis zu 60 Minuten dauern. Schließen Sie diese Anwendung NICHT!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Aus Sicherheitsgründen müssen Sie ein Kennwort für die Verschlüsselung ihres Wallets angeben.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} Guthaben reicht nicht aus, um die Handelsgebühr zu bezahlen",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "Die Mindestmenge, die für diesen Auftrag erforderlich ist, beträgt",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Unzureichendes Volumen",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Aktualisieren",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "Internetverbindung wiederhergestellt",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "Swap kann nicht durchgeführt werden",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Details",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} ist nicht verfügbar :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "Ich habe verstanden",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Japanisch",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Koreanisch",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Sprache",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Letzte Transaktionen",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Rechtliches",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "Weniger",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗Vorsicht! Der Markt für {coinName} hat ein 24-Stunden-Handelsvolumen von weniger als 10.000 US-Dollar!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "Das Limit muss bis zu {value} betragen",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "Wird geladen...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Auftragsbuch wird geladen...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "Bildschirm ist gesperrt",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "Bitte authentifizieren!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "Anmeldung",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Ausloggen",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Beim Beenden abmelden",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Abmelde-Einstellungen",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "Sind Sie sicher, dass Sie sich jetzt abmelden möchten?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "Minuten",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "Einen Auftrag erstellen",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Maker",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Auftrag stornieren",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "Erstellt am",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Erhalten",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "Auftrags-ID",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Durch diesen Auftrag wurden keine Swaps gestartet",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Preis",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Verkauf",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "Durch diesen Auftrag gestartete Swaps",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Details des Maker-Auftrag",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Maker-Auftrag",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Marktplatz",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "Chart",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Tiefe",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "Keine Anfragen gefunden",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "Keine Angebote gefunden",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "AUFTRAGSBUCH",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Details zum Auftrag",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "PREIS",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Bitte Coins auswählen",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Märkte",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "MÄRKTE",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "Kennwörter müssen übereinstimmen",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Ändern",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Ihre allgemeine PIN und die Tarnungs-PIN sind identisch.\nDer Tarnmodus wird nicht verfügbar sein.\nBitte ändern Sie die Tarnungs-PIN.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "Ungültige PIN",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "MAX",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Max Auftragsvolumen:",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Neuigkeiten",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "DURCHBLÄTTERN",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "FEED DURCHBLÄTTERN",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "Von",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "SIE HABEN KEINE GESPEICHERTEN ARTIKEL",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "GESPEICHERT",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Memo",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Zusammenfassen",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Zusammengefasster Wert:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "ms",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "MIN",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Warnung: Durch das Minimieren der App auf iOS wird der Aktivierungsprozess abgebrochen.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "Min Auftragsvolumen:",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "m",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "Die Mindestmenge für den Kauf ist {number} {coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "Die Mindestmenge des Auftrags ist {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "Muss größer sein als {minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Muss niedriger als die Verkaufsmenge sein",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Erforderliches Mindestvolumen",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "Benutzerdefiniertes Mindestvolumen verwenden",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Bitte beachten Sie, dass Sie jetzt Mobilfunkdaten verwenden und die Teilnahme am P2P-Netzwerk von {appName} Internetverkehr verbraucht. Es ist besser, ein WiFi-Netzwerk zu verwenden, wenn Ihr mobiler Datentarif kostspielig ist.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Mehr Info",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "Mehr",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Aktivieren Sie {coin} und laden Sie zuerst Ihr Guthaben auf",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Menge",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Coin",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Verkaufen",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "Abbrechen",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Bestätigen",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "{number} Auftrag/Aufträge erstellen:",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Erstellen",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Auftrag",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Aufträge",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "Gebühr",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "Abbrechen",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Bitte geben Sie den gewünschten Fiat-Betrag ein:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Automatisch ausfüllen",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Bitte beheben Sie alle Fehler, bevor Sie fortfahren",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Ungültige Menge",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Ungültige Verkaufsmenge",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "Nicht genug {coin} vorhanden, um die Gebühren zu zahlen. MIN Guthaben beträgt {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin} Guthaben ist zu niedrig",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "Max Verkaufsmenge beträgt",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "Der Mindestbetrag, den Sie erhalten, beträgt",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "Min Verkaufsmenge beträgt",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Erhalten:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Verkaufen:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Mehrfach",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Menge erhalten",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "Preis/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Netzwerkgebühr",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "neues Konto",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Neues Konto",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Newsfeed",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Neuer Wert:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "Weiter",
-    "@next": {
-        "type": "text"
-    },
-    "no": "Nein",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "Keine Neuigkeiten - bitte versuchen Sie es später erneut!",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "Kein Coin gefunden",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Kein Guthaben",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "Kein Guthaben vorhanden - bitte zuerst einzahlen.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "Keine Internetverbindung",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "Keine Elemente ausgewählt",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "Keine Elemente ausgewählt",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "Keine übereinstimmenden Aufträge gefunden",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Keiner",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "Der Wert muss numerisch sein",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Bitte geben Sie die {coinName} Menge ein.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Klicken Sie hier, um einen Auftrag zu erstellen",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "Keine Aufträge, bitte gehen Sie zum Handel.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "Keine anforderungsfähigen Belohnungen",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "Keine Belohnung verfügbar. Bitte versuchen Sie es in 1 Stunde erneut.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "Diese Münze gibt es nicht",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "Kein Verlauf vorhanden",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "Nicht genug {coin} für die Transaktion!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "Nicht genügend Guthaben für Gebühren - handeln Sie einen kleinere Menge",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Hinweis: Übereinstimmende Aufträge können nicht mehr storniert werden.",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Notiz hinzufügen",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Notiz",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Nichts gefunden",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "{sell}/{buy} swap wurde erfolgreich abgeschlossen",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "Swap abgeschlossen",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} swap fehlgeschlagen",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "Swap fehlgeschlagen",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} swap gestartet",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Neuer swap gestartet",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Swap-Status geändert",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} swap ist abgelaufen(Zeitüberschreitung)",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Swap ist abgelaufen(Zeitüberschreitung)",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "Du hast eine {coin} Transaktion erhalten!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Eingehende Transaktion",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "Keine Transaktionen vorhanden",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} Assets",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "Offizielle Pressemitteilung",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Ok",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Löschen",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Alte Protokolle",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Genutzter Speicher",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Fehlermeldung öffnen",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "Optional",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "Weniger",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "Mehr",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Alle {coin} Aufträge werden storniert.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Auftrag erstellt",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Auftrag erfolgreich erstellt",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Adresse",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "Abbrechen",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "Sinnvoll: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "Teuer: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "für",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "Identisch mit CEX",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "min.",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Preis",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Erhalten",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Auswählen",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Verkäufe",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Durch einmaliges antippen öffnen Sie die Details, durch langes antippen wählen Sie einen Auftrag",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Ausgegeben",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Details",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% ausgefüllt",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Auftrag gematched!",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Auftrag wird gematched",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "Aufträge",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Aktiv",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "Verlauf",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "({coin}) Menge",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "({coin}) Preis",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "({coin}) Gesamt",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Auftrag",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Unbekannter Auftragstyp",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Überschreiben",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "Dies ist Ihr eigener Auftrag!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Bezahlt aus dem Guthaben:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Bezahlt aus dem eingegangenen Volumen:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Bezahlt mit",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "Das Kennwort muss mindestens 12 Zeichen enthalten, davon ein Kleinbuchstabe, ein Großbuchstabe und ein Sonderzeichen.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Bezahlen",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "Akzeptieren Sie diese Transaktion?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "Nach Adresse",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "Menge:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Coin:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "Abbrechen",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Zahlung angefordert",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} ist nicht aktiviert. Bitte aktivieren und erneut versuchen.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Auftrag platzieren",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "In voller Lautstärke abspielen",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Bitte fügen Sie einen Coin hinzu",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Bitte starten Sie die App neu, um es erneut zu versuchen, oder drücken Sie die Schaltfläche unten.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Portfolio",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Unterstützt von Komodo",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "Preis",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Privater Schlüssel",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Private Schlüssel",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Bestätigungen",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Individuelle Schutzeinstellungen verwenden",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "AUS",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "AN",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Achtung, dieser Atomic Swap ist nicht durch dPoW geschützt.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Öffentlicher Schlüssel (Pubkey)",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "QR-Code-Scanner",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "Speichern Sie meine privaten Schlüssel?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "Auf welchen Geräten kann ich {appName} verwenden?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "Wie unterscheidet sich der Handel auf {appName} vom Handel auf anderen DEXs?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "Wie lange dauert ein Atomic Swap?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "Muss ich für die Dauer des Swaps online sein?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "Wie werden die Gebühren für {appName} berechnet?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "Bieten Sie einen Support für die Nutzer an?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "Gibt es länderspezifische Einschränkungen?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "Wer steckt hinter {appName}?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "Ist es möglich, meine eigene White-Label-Börse auf {appName} zu entwickeln?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "Es ist eine neue Ära! Wir haben unseren Namen offiziell von „AtomicDEX“ in „Komodo Wallet“ geändert.",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "ERHALTEN",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Erhalten",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Wir empfehlen die Offline-Sicherung.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Deaktivieren",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Angeforderter Handel",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "LÖSCHEN",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Formular zurücksetzen",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "WIEDERHERSTELLEN",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Erneuter Versuch, alle Münzen zu aktivieren...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Erneuter Versuch, alle zu aktivieren",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Belohnungen beantragen",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Stornieren",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "Transaktion ist in Bearbeitung",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "in Bearbeitung",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXO-Menge ist geringer als 10 KMD",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Eine Stunde ist noch nicht vergangen",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 Stunde",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "Ok",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Belohnungsstatus:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "Lesen Sie mehr über KMD-Belohnungen für aktive Nutzer",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Empfangen",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "Erfolgreich! {amount} KMD erhalten",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "Fiat",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "Belohnungen,\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Status",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Verbleibende Zeit",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Informationen zu den Belohnungen:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO Menge,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} Tag(e)",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}h {minutes}m",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}min",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "Informationen zu den Belohnungen",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Russisch",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Zusammenfassung speichern",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "Scrollen Sie nach unten, um fortzufahren...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Coin suchen",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Alle Avax tokens auswählen",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Alle BEP tokens auswählen",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Wählen Sie alle Cosmos Network aus",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Alle ERC tokens auswählen",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Alle ETC tokens auswählen",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Alle Fantom tokens auswählen",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Alle HecoChain tokens auswählen",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Alle Harmony tokens auswählen",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Wählen Sie alle Iris-Netzwerke aus",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Alle Kucoin tokens auswählen",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Alle Moonriver tokens auswählen",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Alle Polygon tokens auswählen",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Alle QRC tokens auswählen",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Alle SmartBCH tokens auswählen",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Wählen Sie alle SLP-Tokens aus",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Alle SmartChains auswählen",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Alle Test Assets auswählen",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Alle Ubiq coins auswählen",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Alle UTXO coins auswählen",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Wählen Sie alle ZHTLC-Münzen aus",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Ticker suchen",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Sicherheit",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "Seed-Phrase",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Ihr neuer Seed",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "Klicken Sie hier, um {amount} Aufträge zu sehen",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "Transaktionsverlauf anzeigen",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Coin auswählen",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Wählen Sie die Coins aus, die Sie Ihrem Portfolio hinzufügen möchten.",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Coins aktivieren:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "Wählen Sie den zu kaufenden Coin aus",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "Wählen Sie den zu verkaufenden Coin",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Ausgewählter Auftrag:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Datei auswählen",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Sprache wählen",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Wählen Sie eine Bezahlart",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Verkaufen",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "Achtung, Sie sind bereit, Testmünzen OHNE realen Wert zu verkaufen!",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "SENDEN",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Sind Sie sicher, dass Sie die",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "Wallet löschen möchten?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Wenn ja, stellen Sie sicher, dass Sie",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "Ihren Seed sichern,",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "um Ihre Wallet in Zukunft wiederherzustellen.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Sprachen",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Einstellungen",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "KENNWORT EINRICHTEN",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "Teilen",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "Meine {coinName} Adresse:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Adresse anzeigen",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Details anzeigen",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "Es werden {count} von {maxCount} Bestellungen angezeigt.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "MEINE AUFTRÄGE ANZEIGEN",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Mit Kennwort anmelden",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "Kennwort vergessen? Wallet mit der Seed wiederherstellen",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Einfach",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Aktivieren",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Bitte geben Sie die {coin} Menge an, die Sie kaufen möchten",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Kaufen",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Schließen",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "Maximum an aktivierbaren Coins ist {maxCoins}. Bitte deaktivieren Sie welche.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} ist nicht aktiviert!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Erhalten",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Bitte geben Sie die {coin} Menge an, die Sie verkaufen möchten",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Verkaufen",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Senden",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Weniger anzeigen",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Mehr anzeigen",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "{coin} kann nicht aktiviert werden",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Überspringen",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Ablehnen",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Sound",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Wählen Sie bitte eine mp3- oder wav-Datei aus. Wir spielen es, wenn {description}.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "Abgespielt, wenn {description}",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Sounds",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Verstanden, nicht mehr zeigen",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Sound",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Sound-Einstellungen",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "Während des Swap-Prozesses und wenn ein aktiver Maker-Auftrag erteilt wird, hören Sie akustische Benachrichtigungen.\nDas Atomic-Swap-Protokoll erfordert, dass die Teilnehmer für einen erfolgreichen Handel online sind, und akustische Benachrichtigungen helfen dabei.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Beachten Sie, dass Sie Ihre eigenen Sounds in den Anwendungseinstellungen festlegen können.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "Spanisch",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Starten Sie den Tausch",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Schritt",
-    "@step": {
-        "type": "text"
-    },
-    "success": "Erfolgreich!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Support",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Wenn Sie Fragen haben oder glauben, dass Sie ein technisches Problem mit der {appName} App gefunden haben, können Sie dies melden und Unterstützung von unserem Team erhalten.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "swap",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Aktuell",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "TAUSCH-DETAILS BESTÄTIGEN",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "Schätzung",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "Swap fehlgeschlagen",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Bitte aktivieren Sie zuerst {coin} und laden Sie Ihr Guthaben auf",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen. {coin} {amount} sind erforderlich.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Swap läuft",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "Fortschrittdetails",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "Gestartet",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Swap erfolgreich",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Gesamt",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "Swap UUID",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Thema ändern",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Taker",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Taker-Auftrag",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Zeitüberschreitung",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "PASSWORT ERSTELLEN",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Auftrag ausgewählt",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "An",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "An Adresse:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "Sie haben",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "Assets aktiviert. Max Limit aktivierbarer Assets ist",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ". Bitte deaktivieren Sie welche, bevor Sie neue hinzufügen.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Zu viele Assets aktiviert",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Gesamtgebühren:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "HANDEL",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "SWAP ABGESCHLOSSEN!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "HANDELSDETAILS",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Handelsgebühren konnten nicht berechnet werden",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "Handelsgebühr:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Handelsart:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "Transaktionsadresse",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "Transaktion ausgeblendet",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Diese Transaktion wurde aufgrund eines möglichen Phishing-Versuchs ausgeblendet.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "Wenn auch dann noch einige Coins nicht aktiviert sind, versuchen Sie, die App neu zu starten.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Türkisch",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Block",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Bestätigungen",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "BESTÄTIGT",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Gebühr",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "Transaktionsgebühr:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "Transaktions ID",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Verbleibende Transaktionen: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Zu viele Anfragen.\nDas Limit für Anfragen zur Transaktionshistorie wurde überschritten.\nBitte versuchen Sie es später noch einmal.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "UNBESTÄTIGT",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Ukrainisch",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "Freischalten",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Geldmittel freischalten",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "{amnt} Geldmittel wurden erfolgreich freigeschaltet - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "Nicht verwendbar",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Neue Version verfügbar",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Nach Updates suchen...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "Sie nutzen Version {version}",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Neue Version verfügbar. Bitte updaten.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "Version {version} verfügbar. Bitte updaten.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Update verfügbar",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Vorerst überspringen",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "{appName} Update",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Update",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Bereits auf dem neuesten Stand",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "Nicht genug Guthaben für die gescannte",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "Zahlungsaufforderung.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Unzureichendes Guthaben",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Wert:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "Version",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Explorer",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Seed & Private Schlüssel",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Volumen",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "Wallet-Name existiert bereits",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "Wallet-Name darf maximal 40 Zeichen lang sein",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Nur Wallet",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "Achtung!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Ok",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Achtung - in besonderen Fällen enthalten diese Protokolldaten sensible Informationen, die dazu verwendet werden können, Coins aus fehlgeschlagenen Swaps auszugeben!",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "Wir konnten {coinAbbr} nicht aktivieren",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "Wir konnten {coinAbbr} nicht aktivieren.\nBitte starten Sie die App neu, um es erneut zu versuchen.",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} ist eine Multi-Coin-Wallet der nächsten Generation mit nativer DEX-Funktionalität der dritten Generation und mehr.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "AUF GEHT'S!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "WILLKOMMEN",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "Wallet",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "Nach Fertigstellung werden Sie zur Portfolio-Seite weitergeleitet.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Dies dauert eine Weile und die App muss im Vordergrund bleiben.\nDas Beenden der App während der Aktivierung kann zu Problemen führen.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Auszahlung",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "Sie haben {appName} zuvor den Zugriff auf die Kamera verweigert.\nBitte ändern Sie die Kamerazugriffsrechte manuell in den Telefoneinstellungen, um mit dem QR-Code-Scan fortzufahren.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Zugriff verweigert",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Auszahlung bestätigen",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "{amount} {coinName} ABHEBEN",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "Sie versuchen, einen QR-Code für eine Zahlung zu scannen",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "aber Sie sind auf dem",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "Auszahlungs-Bildschirm",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Falscher Coin",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "Die Kennwörter stimmen nicht überein. Bitte versuche es erneut.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Ja",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Sie senden:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "Sie haben einen neuen Auftrag, der  einem bestehenden Auftrag zugeordnet werden soll",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "Sie haben einen aktiven Swap in Arbeit",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "Sie haben einen Auftrag, dem neue Aufträge zugeordnet werden können",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "Ihr Wallet",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "Sie erhalten {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Sie erhalten:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "de",
+  "accepteula": "EULA akzeptieren",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "Allgemeine Geschäftsbedingungen akzeptieren",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Biometrischen Schutz aktivieren",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "PIN-Schutz aktivieren",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "{protocolName}-Münzen aktivieren?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "{coinName} wird aktiviert",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName}-Aktivierung",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} Aktivierung wird ausgeführt",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Aktiv",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Coin aktivieren",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} erfolgreich aktiviert!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Adresse hinzufügen",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Adressbuch",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "Adressbuch ist leer",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Nur Kontakte mit {title} Adressen anzeigen",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Adressbuch",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "Sie können kein Guthaben an die {abbr} Adresse senden, da {abbr} nicht aktiviert ist. Bitte gehen Sie zum Portfolio.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Nichts gefunden",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Coin auswählen",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Empfängeradresse",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Fortgeschritten",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "Alle",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Benutzerdefinierten Seed erlauben",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "In Ihrem Wallet werden alle vergangenen Transaktionen angezeigt. Dies wird viel Speicherplatz und Zeit in Anspruch nehmen, da alle Blöcke heruntergeladen und gescannt werden.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "Ist bereits vorhanden",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Menge",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Zu verkaufende Menge",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "Nein! {appName} hat keine Vormundschaft. Wir speichern niemals sensible Daten, einschließlich Ihrer privaten Schlüssel, Seed-Phrasen oder PINs. Diese Daten werden nur auf dem Gerät des Benutzers gespeichert und verlassen es nie. Sie haben die volle Kontrolle über Ihr Vermögen.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} ist für Mobilgeräte auf Android und iPhone sowie für Desktops auf <a href=\"https://komodoplatform.com/\">Windows-, Mac- und Linux-Betriebssystemen</a> verfügbar.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Bei anderen DEXs können Sie im Allgemeinen nur Assets handeln, die auf einem einzigen Blockchain-Netzwerk basieren, Proxy-Token verwenden und nur einen einzigen Auftrag mit denselben Geldmitteln aufgeben.\n\n{appName} ermöglicht Ihnen den nativen Handel über zwei verschiedene Blockchain-Netzwerke ohne Proxy-Tokens. Sie können auch mehrere Aufträge mit demselben Guthaben platzieren. Sie können zum Beispiel 0,1 BTC für KMD, QTUM oder VRSC verkaufen - der erste Auftrag, der ausgeführt wird, storniert automatisch alle anderen Aufträge.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Mehrere Faktoren bestimmen die Bearbeitungszeit für einen Swap. Die Blockzeit der gehandelten Assets hängt vom jeweiligen Netzwerk ab (Bitcoin ist normalerweise das langsamste). Außerdem kann der Benutzer die Sicherheitseinstellungen anpassen. Zum Beispiel (können Sie {appName} bitten, eine KMD-Transaktion nach nur 3 Bestätigungen als endgültig zu betrachten, wodurch die Swap-Zeit kürzer wird als beim Warten auf eine <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">Beglaubigung</a>",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Ja. Sie müssen mit dem Internet verbunden bleiben und die App ausführen, um jeden Atomic Swap erfolgreich abzuschließen (sehr kurze Verbindungsunterbrechungen sind normalerweise in Ordnung). Andernfalls besteht das Risiko einer Auftragsstornierung, wenn Sie ein Maker sind, und das Risiko eines Geldverlusts, wenn Sie ein Taker sind.\n\nDas Atomic-Swap-Protokoll erfordert, dass beide Teilnehmer online bleiben und die beteiligten Blockchains überwachen, damit der Prozess atomar bleibt.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "Beim Handel auf {appName} sind zwei Gebührenkategorien zu berücksichtigen.\n\n1. {appName} berechnet ungefähr 0,13 % (1/777 des Handelsvolumens, aber nicht weniger als 0,0001) als Handelsgebühr für Taker-Aufträge, Maker-Aufträge haben keine Gebühren.\n\n2. Sowohl Maker als auch Taker müssen normale Netzwerkgebühren an die beteiligten Blockchains zahlen, wenn sie Atomic-Swap-Transaktionen durchführen.\n\nDie Netzwerkgebühren können je nach ausgewähltem Handelspaar stark variieren.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "Ja! {appName} bietet Support über den <a href=\"{link}\">{appCompanyShort} {name}</a>. Das Team und die Community helfen Euch gerne weiter!\n",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "Nein! {appName} ist vollständig dezentralisiert. Es ist nicht möglich, den Benutzerzugang durch Dritte zu beschränken.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} wird vom {appCompanyShort}-Team entwickelt. {appCompanyShort} ist eines der etabliertesten Blockchain-Projekte, das an innovativen Lösungen wie Atomic Swaps, Delayed Proof of Work und einer interoperablen Multi-Chain-Architektur arbeitet.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "Absolut! Weitere Informationen finden Sie in unserer <a href=\"https://developers.komodoplatform.com/\">Entwicklerdokumentation</a> oder kontaktieren Sie uns mit Ihren Partnerschaftsanfragen. Haben Sie eine spezielle technische Frage? Die {appName}-Entwickler-Community ist immer bereit zu helfen!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Beifall",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "BIST DU SICHER?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "ein Swap ist fehlgeschlagen",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "ein Swap läuft bis zur Fertigstellung",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "authentifizieren",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Sie werden automatisch zur Portfolio-Seite weitergeleitet, wenn der erneute Aktivierungsprozess abgeschlossen ist.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "max vol",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "zurück",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Sicherung",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "basierend auf {coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "Der Akkustand ist kritisch ({batteryLevelCritical}%) um einen Swap sicher auszuführen. Bitte laden Sie ihr Handy auf und versuchen es später noch einmal.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "Ihre Akkuladung ist niedriger als {batteryLevelLow} %. Bitte denken Sie an das Aufladen des Telefons.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Ihr  Handy ist im Energissparmodus. Bitte deaktivieren Sie diesen Modus oder gehen Sie mit der App NICHT im Hintergrundmodus. Andernfalls könnte die App durch das Betriebssystem beendet werden und der Swap schlägt fehl.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "Wechselkurs",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Auf Komodo aufgebaut",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Auf Komodo aufgebaut",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Kaufen",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "In Maker-Auftrag umwandeln, wenn kein match stattgefunden hat",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Swap gestartet, bitte warten!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "Auftragsvermittlung läuft, bitte warten Sie {seconde} Sekunden!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "Warnung, Sie möchten Test-Coins ohne tatsächlichen Wert kaufen!",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "Tarnungs-PIN und Bio-Schutz können nicht gleichzeitig aktiviert werden.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Konflikt zwischen Carmo-PIN und Bio-Schutz.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Tarnungs-PIN ändern",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Tarnungs-PIN erstellen",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Wenn Sie die App mit der Tarnungs-PIN entsperren, wird ein gefälschtes NIEDRIGERES Guthaben angezeigt und die Konfigurationsoption Tarnungs-PIN ist in den Einstellungen NICHT sichtbar.",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "ungültiger Tarnungs-PIN",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Tarnungs-PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "Tarnungs-PIN nicht gefunden",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Aus",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "An",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "Tarnungs-PIN gespeichert",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Tarnungs-PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Neuen Tarnungs-PIN eingeben",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Tarnungs-PIN Einrichtung",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Tarnungs-PIN Einrichtung",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "stornieren",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Aktivierung abbrechen",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "stornieren",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Auftrag stornieren",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ok",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "ist ein Standard-Coin. Standard-Coins können nicht deaktiviert werden.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "Kann nicht deaktiviert werden",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "Kann nicht abgespielt werden",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEX-Tauschrate",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "CEX-Daten",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Die mit diesem Symbol gekennzeichneten Marktdaten (Kurse, Charts usw.) stammen aus Drittquellen (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "CEX-Kurs",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "PIN-Code ändern",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Nach Updates suchen",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Abmelden",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "Seed-Phrase überprüfen",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "WEITER",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "ZURÜCK UND ERNEUT ÜBERPRÜFEN",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "{index} Wort eingeben",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "Ihr Seed ist wichtig - deshalb stellen wir Ihnen drei verschiedene Fragen, um sicherzustellen, dass dieser korrekt ist und Sie Ihr Wallet jederzeit problemlos wiederherstellen können.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "Was ist das {index}.Wort in Ihrer Seed?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "LASSEN SIE UNS IHREN SEED DOPPELT ÜBERPRÜFEN",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Chinesisch",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "Anfordern",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "KMD Prämie anfordern?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Zum Anzeigen klicken",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "In die Zwischenablage kopiert",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "In die Zwischenablage kopieren",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Schließen",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Fehlermeldung schließen",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Vorschau schließen",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Code:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Sie haben die maximale Anzahl an Assets ausgewählt",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "{protocolName}-Münzen sind aktiviert",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName}-Münzen wurden erfolgreich aktiviert",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "{protocolName}-Münzen sind nicht aktiviert",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Löschen",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "keine aktivierten Coins",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Coin auswählen",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "Demnächst...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "TX Details folgen in Kürze!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "Details folgen in Kürze!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "Provision",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "im Vergleich zum Durchschnitt. 24h CEX-Preis",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "im Vergleich zu CEX",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "Bitte warten, ihre Wallet wird konfiguriert...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "Bestätigen",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Tarnungs-PIN bestätigen",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "Wollen Sie die Order wirklich stornieren?",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "Durch Klicken auf die folgenden Schaltflächen bestätigen Sie, dass Sie die \"EULA\" und die \"Allgemeinen Geschäftsbedingungen\" gelesen haben und diese akzeptieren",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Kennwort bestätigen",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "PIN-Code bestätigen",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "Seed-Phrase bestätigen",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Verbindung wird hergestellt ...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "Abbrechen",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Kontakt löschen",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "Löschen",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "Möchten Sie den Kontakt {name} wirklich löschen?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Verwerfen",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Bearbeiten",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Beenden",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Änderungen verwerfen?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "Keine Kontakte gefunden",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Sichern",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Kontaktdetails",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "Name",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Vertrag",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Umwandeln",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "URL konnte nicht gestartet werden",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "Konnte nicht importiert werden:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "Handeln",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "Wallet erstellen",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Kontakt erstellen",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "PIN erstellen",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Währung",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Währung",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Aktueller Wert:",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Individuelle Gebühr",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "Individuelle Gebühr nur nutzen, wenn Sie wissen was darunter zu verstehen ist!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Benutzerdefinierte Seed-Phrasen sind möglicherweise weniger sicher und leichter zu knacken als eine generierte BIP39-konforme Seed-Phrase oder ein privater Schlüssel (WIF). Um zu bestätigen, dass Sie das Risiko verstehen und wissen was Sie tun, geben Sie \"{iUnderstand}\" im Kasten unten an.\n",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Datum",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Wallet entschlüsseln",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Löschen",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Deaktivierung bestätigen",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "Möchten Sie",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "von ihrem Portfolio entfernen? Alle offenen Aufträge werden storniert.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " wird ebenfalls deaktiviert",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Wallet löschen",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Wallet wird gelöscht...",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "Erhalten Sie die Transaktionsgebühr {coinName}",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "Transaktionsgebühr für {coinName} senden",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "Handelsgebühr senden Transaktionsgebühr",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "Handelsgebühr",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "Details",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Deutsch",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Entwickler/in",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX ist für diesen Coin nicht verfügbar",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Deaktivieren Sie Screenshots/Vorschau",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Haftungsausschluss & AGB",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Erledigt",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Schließen Sie die App nicht. Für weitere Informationen tippen ...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "Nicht mehr nachfragen",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "Ich möchte kein Kennwort",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo dPoW Sicherheit",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Dauer",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Kontakt bearbeiten",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "Geben Sie die {abbr}  Adresse ein",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "Verschlüsselungskennwort darf nicht leer sein",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "Kennwort darf nicht leer sein",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "Kontakt-Name darf nicht leer sein",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "Wallet-Name darf nicht leer sein",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Sie können {remains} weiterhin aktivieren, Ausgewählt: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Bitte aktivieren Sie Benachrichtigungen, um Updates zum Aktivierungsfortschritt zu erhalten.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Test-Coins aktivieren",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "Sie haben",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "Assets aktivert und versuchen",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "weitere zu aktivieren. Das Maximallimit beträgt",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": ". Bitte deaktivieren sie welche, bevor neue aktiviert werden.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Es wurde versucht, zu viele Assets zu aktivieren",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Wallet verschlüsseln",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "Englisch",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Geben Sie ihren neuen PIN ein",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Geben Sie ihren alten PIN ein",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Bitte Kennwort eingeben um fortzufahren.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "Geben Sie Ihren PIN-Code ein",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Geben Sie Ihre Seed-Phrase ein",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Sie müssen zuerst die Verkaufsmenge eingeben",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "Guthaben unzureichend",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "Ungültige Adresse",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Segwit-Adressen werden (noch) nicht unterstützt",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "Nicht genug Gas - verwenden Sie mindestens {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Fehler, bitte versuchen Sie es erneut",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Fehler, bitte versuchen Sie es später",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "Wert ist zu hoch oder zu niedrig",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "Bitte Daten eintippen",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Geschätzter Gesamtwert",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "Um abgeschlossen zu werden, {appCompanyLong}muss jede virtuelle Währungstransaktion, die mit dem erstellt wurde, bestätigt und im Ledger für virtuelle Währungen aufgezeichnet werden, das dem jeweiligen virtuellen Währungsnetzwerk zugeordnet ist. {appCompanyLong}Bei solchen Netzwerken handelt es sich um dezentrale Peer-to-Peer-Netzwerke, die von unabhängigen Dritten unterstützt werden, die sich nicht im Besitz, unter der Kontrolle oder unter der Kontrolle von ihnen befinden.\n{appCompanyLong}hat keine Kontrolle über virtuelle Währungsnetzwerke und kann und wird daher nicht sicherstellen, dass alle Transaktionsdetails, die Sie über unsere Dienste einreichen, im jeweiligen Netzwerk für virtuelle Währungen bestätigt werden. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionsdetails, die Sie über unsere Dienste übermitteln, durch das zur Bearbeitung der Transaktion verwendete virtuelle Währungsnetzwerk möglicherweise nicht abgeschlossen oder erheblich verzögert werden können. Wir garantieren nicht, dass das Wallet das Eigentum oder die Rechte an einer virtuellen Währung übertragen kann, und geben auch keine Garantie in Bezug auf den Titel.\nSobald Transaktionsdetails an ein virtuelles Währungsnetzwerk übermittelt wurden, können wir Ihnen nicht helfen, Ihre Transaktion oder Transaktionsdetails zu stornieren oder anderweitig zu ändern. {appCompanyLong}hat keine Kontrolle über ein Netzwerk für virtuelle Währungen und ist nicht in der Lage, Stornierungs- oder Änderungsanfragen zu bearbeiten.\nIm Falle eines Forks {appCompanyLong}kann es sein, dass wir Aktivitäten im Zusammenhang mit Ihrer virtuellen Währung nicht unterstützen können. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionen im Falle einer Fork möglicherweise nicht, teilweise, falsch abgeschlossen oder erheblich verzögert werden. {appCompanyLong}ist nicht verantwortlich für Verluste, die Ihnen ganz oder teilweise, direkt oder indirekt, durch einen Fork entstehen.\nIn keinem Fall {appCompanyLong}haften ihre verbundenen Unternehmen und Dienstleister oder ihre jeweiligen leitenden Angestellten, Direktoren, Agenten, Mitarbeiter oder Vertreter für entgangene Gewinne oder besondere, zufällige, indirekte, immaterielle oder Folgeschäden, unabhängig davon, ob sie auf Vertrag, unerlaubter Handlung, Fahrlässigkeit, verschuldensunabhängiger Haftung oder auf andere Weise beruhen, die sich aus oder in Verbindung mit der autorisierten oder unbefugten Nutzung der Dienste oder dieser Vereinbarung ergeben, auch wenn ein bevollmächtigter Vertreter {appCompanyLong}von darauf hingewiesen wurde, hat davon gewusst oder hätte von der Möglichkeit solcher Schäden bekannt. \nBeispielsweise (und ohne den Umfang des vorstehenden Satzes einzuschränken) dürfen Sie sich nicht für entgangene Gewinne, entgangene Geschäftschancen oder andere Arten von besonderen, zufälligen, indirekten, immateriellen oder Folgeschäden zurückfordern. In einigen Rechtsordnungen ist der Ausschluss oder die Beschränkung von Neben- oder Folgeschäden nicht zulässig, sodass die obige Beschränkung möglicherweise nicht für Sie gilt. \nWir sind Ihnen gegenüber nicht verantwortlich oder haftbar für Verluste und übernehmen keine Verantwortung für Schäden oder Ansprüche, die sich ganz oder teilweise, direkt oder indirekt ergeben aus: \n(a) Benutzerfehler wie vergessene Passwörter, falsch erstellte Transaktionen oder falsch eingegebene Adressen für virtuelle Währungen; \n(b) Serverausfall oder Datenverlust; \n(c) beschädigte oder anderweitig nicht funktionierende Wallets oder Wallet-Dateien; \n(d) unbefugter Zugriff auf Anwendungen; \n(e) alle nicht autorisierten Aktivitäten, einschließlich, aber nicht beschränkt auf den Einsatz von Hacking, Viren, Phishing, Brute-Forcing oder anderen Angriffsmethoden gegen die Dienste.\n\n",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Beispiel: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Sinnvoll",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Teuer",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "Identisch mit CEX",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Wechselkurs:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "TAUSCHEN",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Exportieren",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Kontakte",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Bitte wählen Sie die Elemente aus, die in eine verschlüsselte Datei exportiert werden sollen.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Exportieren",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Hinweise",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "Die Elemente wurden erfolgreich exportiert:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Swaps",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Exportieren",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Fehlgeschlagen",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Gefälschter Guthaben:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Häufig gestellte Fragen",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Fehler",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "Anfrage an {coin} faucet senden...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "FAUCET",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Erfolg",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "Zeitüberschreitung der Anfrage",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Protokolldatei teilen",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Neuigkeiten",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Hier gibt es nichts",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} Neuigkeiten",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Mehr lesen...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Feed",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Newsfeed",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "Aktualisierung der Nachrichten kann nicht fortgesetzt werden",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "Nachrichten können nicht aktualisiert werden",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Newsfeed aktualisiert",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Bereits auf dem neuesten Stand",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "Die Gebühren müssen bis zu {value} betragen.",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Alle",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Filter",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Alle Filter löschen",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Fehlgeschlagen",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "Von Datum",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Maker",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Coin erhalten",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Coin verkaufen",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Status",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Erfolgreich",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Taker",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "Bis Datum",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Taker/Maker",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Fingerabdruck",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Bitte warten Sie, bis der Vorgang abgeschlossen ist",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "QR-Code gefunden",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Französisch",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "Von",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "Wir synchronisieren zukünftige Transaktionen, die nach der Aktivierung in Verbindung mit Ihrem öffentlichen Schlüssel durchgeführt werden. Dies ist die schnellste Option und beansprucht am wenigsten Speicherplatz.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin}-Gebühr",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "Gas-Limit",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Bitte aktivieren Sie {coin}.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "Gas-Preis",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "Der allgemeine PIN-Schutz ist nicht aktiv.\nDer Tarnungsmodus ist nicht verfügbar.\nBitte aktivieren Sie den PIN-Schutz.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Wichtig: Sichern Sie Ihren Seed bevor Sie fortfahren!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "Die Transaktion wird ausgeführt. Bitte warten Sie",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Zum Portfolio gehen",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei muss bis zu {value} sein",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Hilfe",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Hilfe und Support",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Guthaben ausblenden",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Kennwort bestätigen",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Kennwort erstellen",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Aktuelles Kennwort",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Geben Sie Ihr Kennwort ein",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Geben Sie Ihren Seed ein",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Benennen Sie Ihr Wallet",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Kennwort",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "Verlauf",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "h",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Ungarisch",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "Importieren",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Ungültiges Kennwort oder beschädigte Daten",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "Zu importierende Gegenstände:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Datei nicht gefunden",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Ungültige Swap-Daten. Bitte geben Sie eine gültige Swap-Status JSON-Datei an.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "Importieren",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Bitte wählen Sie eine verschlüsselte Datei zum Importieren aus.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Öffnung...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Bitte wählen Sie eine einfache Textauslagerungsdatei zum Importieren aus.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "Abbrechen",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Ok",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Kennwort",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Einzigen Swap importieren",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Swaps importieren",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Einige Elemente wurden übersprungen",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "Die Elemente wurden erfolgreich importiert:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "Import von Swaps fehlgeschlagen",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Fehler beim Dekodieren der json-Datei",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "Importieren",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Eingehende {coinName}-TXS-Schutzeinstellungen",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Verwenden Sie ein sicheres Kennwort und speichern Sie es nicht auf demselben Gerät",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "Der Swap kann nicht rückgängig gemacht werden und ist ein endgültiges Ereignis!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "Der Swap kann bis zu 60 Minuten dauern. Schließen Sie diese Anwendung NICHT!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Aus Sicherheitsgründen müssen Sie ein Kennwort für die Verschlüsselung ihres Wallets angeben.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} Guthaben reicht nicht aus, um die Handelsgebühr zu bezahlen",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "Die Mindestmenge, die für diesen Auftrag erforderlich ist, beträgt",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Unzureichendes Volumen",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Aktualisieren",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "Internetverbindung wiederhergestellt",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Ungültige {coin}-Adresse",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "Swap kann nicht durchgeführt werden",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Details",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} ist nicht verfügbar :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "Ich habe verstanden",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Japanisch",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Koreanisch",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Sprache",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Letzte Transaktionen",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Rechtliches",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "Weniger",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗Vorsicht! Der Markt für {coinName} hat ein 24-Stunden-Handelsvolumen von weniger als 10.000 US-Dollar!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "Das Limit muss bis zu {value} betragen",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Wird geladen...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Auftragsbuch wird geladen...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "Bildschirm ist gesperrt",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "Bitte authentifizieren!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "Anmeldung",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Ausloggen",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Beim Beenden abmelden",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Abmelde-Einstellungen",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "Sind Sie sicher, dass Sie sich jetzt abmelden möchten?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "Minuten",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "Einen Auftrag erstellen",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Maker",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Auftrag stornieren",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "Erstellt am",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Erhalten",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "Auftrags-ID",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Durch diesen Auftrag wurden keine Swaps gestartet",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Preis",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Verkauf",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "Durch diesen Auftrag gestartete Swaps",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Details des Maker-Auftrag",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Maker-Auftrag",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Marktplatz",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "Chart",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Tiefe",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "Keine Anfragen gefunden",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "Keine Angebote gefunden",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "AUFTRAGSBUCH",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Details zum Auftrag",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "PREIS",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Bitte Coins auswählen",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Märkte",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "MÄRKTE",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "Kennwörter müssen übereinstimmen",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Ändern",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Ihre allgemeine PIN und die Tarnungs-PIN sind identisch.\nDer Tarnmodus wird nicht verfügbar sein.\nBitte ändern Sie die Tarnungs-PIN.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "Ungültige PIN",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "MAX",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Max Auftragsvolumen:",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Neuigkeiten",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "DURCHBLÄTTERN",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "FEED DURCHBLÄTTERN",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "Von",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "SIE HABEN KEINE GESPEICHERTEN ARTIKEL",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "GESPEICHERT",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Memo",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Zusammenfassen",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Zusammengefasster Wert:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "ms",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "MIN",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Warnung: Durch das Minimieren der App auf iOS wird der Aktivierungsprozess abgebrochen.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "Min Auftragsvolumen:",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "m",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "Die Mindestmenge für den Kauf ist {number} {coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "Die Mindestmenge des Auftrags ist {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "Muss größer sein als {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Muss niedriger als die Verkaufsmenge sein",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Erforderliches Mindestvolumen",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "Benutzerdefiniertes Mindestvolumen verwenden",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Bitte beachten Sie, dass Sie jetzt Mobilfunkdaten verwenden und die Teilnahme am P2P-Netzwerk von {appName} Internetverkehr verbraucht. Es ist besser, ein WiFi-Netzwerk zu verwenden, wenn Ihr mobiler Datentarif kostspielig ist.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Mehr Info",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "Mehr",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Aktivieren Sie {coin} und laden Sie zuerst Ihr Guthaben auf",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Menge",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Coin",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Verkaufen",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "Abbrechen",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Bestätigen",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "{number} Auftrag/Aufträge erstellen:",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Erstellen",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Auftrag",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Aufträge",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "Gebühr",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "Abbrechen",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Bitte geben Sie den gewünschten Fiat-Betrag ein:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Automatisch ausfüllen",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Bitte beheben Sie alle Fehler, bevor Sie fortfahren",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Ungültige Menge",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Ungültige Verkaufsmenge",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "Nicht genug {coin} vorhanden, um die Gebühren zu zahlen. MIN Guthaben beträgt {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin} Guthaben ist zu niedrig",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "Max Verkaufsmenge beträgt",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "Der Mindestbetrag, den Sie erhalten, beträgt",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "Min Verkaufsmenge beträgt",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Erhalten:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Verkaufen:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Mehrfach",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Menge erhalten",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "Preis/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Netzwerkgebühr",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "neues Konto",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Neues Konto",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Newsfeed",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Neuer Wert:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "Weiter",
+  "@next": {
+    "type": "text"
+  },
+  "no": "Nein",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "Keine Neuigkeiten - bitte versuchen Sie es später erneut!",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "Kein Coin gefunden",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Kein Guthaben",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "Kein Guthaben vorhanden - bitte zuerst einzahlen.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "Keine Internetverbindung",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "Keine Elemente ausgewählt",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "Keine Elemente ausgewählt",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "Keine übereinstimmenden Aufträge gefunden",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Keiner",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "Der Wert muss numerisch sein",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Bitte geben Sie die {coinName} Menge ein.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Klicken Sie hier, um einen Auftrag zu erstellen",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "Keine Aufträge, bitte gehen Sie zum Handel.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "Keine anforderungsfähigen Belohnungen",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "Keine Belohnung verfügbar. Bitte versuchen Sie es in 1 Stunde erneut.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "Diese Münze gibt es nicht",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "Kein Verlauf vorhanden",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "Nicht genug {coin} für die Transaktion!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "Nicht genügend Guthaben für Gebühren - handeln Sie einen kleinere Menge",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Hinweis: Übereinstimmende Aufträge können nicht mehr storniert werden.",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Notiz hinzufügen",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Notiz",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Nichts gefunden",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "{sell}/{buy} swap wurde erfolgreich abgeschlossen",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Swap abgeschlossen",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} swap fehlgeschlagen",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Swap fehlgeschlagen",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} swap gestartet",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Neuer swap gestartet",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Swap-Status geändert",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} swap ist abgelaufen(Zeitüberschreitung)",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Swap ist abgelaufen(Zeitüberschreitung)",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "Du hast eine {coin} Transaktion erhalten!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Eingehende Transaktion",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "Keine Transaktionen vorhanden",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} Assets",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "Offizielle Pressemitteilung",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Ok",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Löschen",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Alte Protokolle",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Genutzter Speicher",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Fehlermeldung öffnen",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "Optional",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "Weniger",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "Mehr",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Alle {coin} Aufträge werden storniert.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Auftrag erstellt",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Auftrag erfolgreich erstellt",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Adresse",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "Abbrechen",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "Sinnvoll: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "Teuer: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "für",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "Identisch mit CEX",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "min.",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Preis",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Erhalten",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Auswählen",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Verkäufe",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Durch einmaliges antippen öffnen Sie die Details, durch langes antippen wählen Sie einen Auftrag",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Ausgegeben",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Details",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% ausgefüllt",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Auftrag gematched!",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Auftrag wird gematched",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "Aufträge",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Aktiv",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "Verlauf",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "({coin}) Menge",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "({coin}) Preis",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "({coin}) Gesamt",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Auftrag",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Unbekannter Auftragstyp",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Überschreiben",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "Dies ist Ihr eigener Auftrag!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Bezahlt aus dem Guthaben:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Bezahlt aus dem eingegangenen Volumen:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Bezahlt mit",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "Das Kennwort muss mindestens 12 Zeichen enthalten, davon ein Kleinbuchstabe, ein Großbuchstabe und ein Sonderzeichen.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "In Ihrem Wallet werden Ihre vergangenen Transaktionen angezeigt, die nach dem angegebenen Datum getätigt wurden.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Bezahlen",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "Akzeptieren Sie diese Transaktion?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "Nach Adresse",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "Menge:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Coin:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "Abbrechen",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Zahlung angefordert",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} ist nicht aktiviert. Bitte aktivieren und erneut versuchen.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Auftrag platzieren",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "In voller Lautstärke abspielen",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Bitte fügen Sie einen Coin hinzu",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Bitte starten Sie die App neu, um es erneut zu versuchen, oder drücken Sie die Schaltfläche unten.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Portfolio",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Unterstützt von Komodo",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "Preis",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Privater Schlüssel",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Private Schlüssel",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Bestätigungen",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Individuelle Schutzeinstellungen verwenden",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "AUS",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "AN",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Achtung, dieser Atomic Swap ist nicht durch dPoW geschützt.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Öffentlicher Schlüssel (Pubkey)",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "QR-Code-Scanner",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "Speichern Sie meine privaten Schlüssel?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "Auf welchen Geräten kann ich {appName} verwenden?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "Wie unterscheidet sich der Handel auf {appName} vom Handel auf anderen DEXs?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "Wie lange dauert ein Atomic Swap?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "Muss ich für die Dauer des Swaps online sein?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "Wie werden die Gebühren für {appName} berechnet?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Bieten Sie einen Support für die Nutzer an?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "Gibt es länderspezifische Einschränkungen?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "Wer steckt hinter {appName}?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "Ist es möglich, meine eigene White-Label-Börse auf {appName} zu entwickeln?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "Es ist eine neue Ära! Wir haben unseren Namen offiziell von „AtomicDEX“ in „Komodo Wallet“ geändert.",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "ERHALTEN",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Erhalten",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Wir empfehlen die Offline-Sicherung.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Deaktivieren",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Angeforderter Handel",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "LÖSCHEN",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Formular zurücksetzen",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "WIEDERHERSTELLEN",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Erneuter Versuch, alle Münzen zu aktivieren...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Erneuter Versuch, alle zu aktivieren",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Belohnungen beantragen",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Stornieren",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "Transaktion ist in Bearbeitung",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "in Bearbeitung",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXO-Menge ist geringer als 10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Eine Stunde ist noch nicht vergangen",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 Stunde",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "Ok",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Belohnungsstatus:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "Lesen Sie mehr über KMD-Belohnungen für aktive Nutzer",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Empfangen",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "Erfolgreich! {amount} KMD erhalten",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "Fiat",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "Belohnungen,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Status",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Verbleibende Zeit",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Informationen zu den Belohnungen:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO Menge,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} Tag(e)",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}h {minutes}m",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}min",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Informationen zu den Belohnungen",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Russisch",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Zusammenfassung speichern",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "Scrollen Sie nach unten, um fortzufahren...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Coin suchen",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Alle Avax tokens auswählen",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Alle BEP tokens auswählen",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Wählen Sie alle Cosmos Network aus",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Alle ERC tokens auswählen",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Alle ETC tokens auswählen",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Alle Fantom tokens auswählen",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Alle HecoChain tokens auswählen",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Alle Harmony tokens auswählen",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Wählen Sie alle Iris-Netzwerke aus",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Alle Kucoin tokens auswählen",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Alle Moonriver tokens auswählen",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Alle Polygon tokens auswählen",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Alle QRC tokens auswählen",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Alle SmartBCH tokens auswählen",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Wählen Sie alle SLP-Tokens aus",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Alle SmartChains auswählen",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Alle Test Assets auswählen",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Alle Ubiq coins auswählen",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Alle UTXO coins auswählen",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Wählen Sie alle ZHTLC-Münzen aus",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Ticker suchen",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Sicherheit",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "Seed-Phrase",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Ihr neuer Seed",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "Klicken Sie hier, um {amount} Aufträge zu sehen",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "Transaktionsverlauf anzeigen",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Coin auswählen",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Wählen Sie die Coins aus, die Sie Ihrem Portfolio hinzufügen möchten.",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Coins aktivieren:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "Wählen Sie den zu kaufenden Coin aus",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "Wählen Sie den zu verkaufenden Coin",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Wählen Sie ein Datum aus",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Ausgewählter Auftrag:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Datei auswählen",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Sprache wählen",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Wählen Sie eine Bezahlart",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Verkaufen",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "Achtung, Sie sind bereit, Testmünzen OHNE realen Wert zu verkaufen!",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "SENDEN",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Sind Sie sicher, dass Sie die",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "Wallet löschen möchten?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Wenn ja, stellen Sie sicher, dass Sie",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "Ihren Seed sichern,",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "um Ihre Wallet in Zukunft wiederherzustellen.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Sprachen",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Einstellungen",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "KENNWORT EINRICHTEN",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "Teilen",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "Meine {coinName} Adresse:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "Nach vergangenen {coin}-Transaktionen suchen?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Adresse anzeigen",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Details anzeigen",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "Es werden {count} von {maxCount} Bestellungen angezeigt.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "MEINE AUFTRÄGE ANZEIGEN",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Mit Kennwort anmelden",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "Kennwort vergessen? Wallet mit der Seed wiederherstellen",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Einfach",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Aktivieren",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Bitte geben Sie die {coin} Menge an, die Sie kaufen möchten",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Kaufen",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Schließen",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "Maximum an aktivierbaren Coins ist {maxCoins}. Bitte deaktivieren Sie welche.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} ist nicht aktiviert!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Erhalten",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Bitte geben Sie die {coin} Menge an, die Sie verkaufen möchten",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Verkaufen",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Senden",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Weniger anzeigen",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Mehr anzeigen",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "{coin} kann nicht aktiviert werden",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Überspringen",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Ablehnen",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Sound",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Wählen Sie bitte eine mp3- oder wav-Datei aus. Wir spielen es, wenn {description}.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "Abgespielt, wenn {description}",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Sounds",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Verstanden, nicht mehr zeigen",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Sound",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Sound-Einstellungen",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "Während des Swap-Prozesses und wenn ein aktiver Maker-Auftrag erteilt wird, hören Sie akustische Benachrichtigungen.\nDas Atomic-Swap-Protokoll erfordert, dass die Teilnehmer für einen erfolgreichen Handel online sind, und akustische Benachrichtigungen helfen dabei.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Beachten Sie, dass Sie Ihre eigenen Sounds in den Anwendungseinstellungen festlegen können.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "Spanisch",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Startdatum",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Starten Sie den Tausch",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Schritt",
+  "@step": {
+    "type": "text"
+  },
+  "success": "Erfolgreich!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Support",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Wenn Sie Fragen haben oder glauben, dass Sie ein technisches Problem mit der {appName} App gefunden haben, können Sie dies melden und Unterstützung von unserem Team erhalten.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "swap",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Aktuell",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "TAUSCH-DETAILS BESTÄTIGEN",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "Schätzung",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "Swap fehlgeschlagen",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Bitte aktivieren Sie zuerst {coin} und laden Sie Ihr Guthaben auf",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen. {coin} {amount} sind erforderlich.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Swap läuft",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "Fortschrittdetails",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "Gestartet",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Swap erfolgreich",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Gesamt",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "Swap UUID",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Thema ändern",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Ab dem angegebenen Datum synchronisieren",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Synchronisierung durch Setzlingsaktivierung",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Synchronisieren Sie neue Transaktionen",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "Welche {name}-Transaktionen möchten Sie synchronisieren?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Taker",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Taker-Auftrag",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Zeitüberschreitung",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "PASSWORT ERSTELLEN",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Auftrag ausgewählt",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "An",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "An Adresse:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "Sie haben",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "Assets aktiviert. Max Limit aktivierbarer Assets ist",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ". Bitte deaktivieren Sie welche, bevor Sie neue hinzufügen.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Zu viele Assets aktiviert",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Gesamtgebühren:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "HANDEL",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "SWAP ABGESCHLOSSEN!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "HANDELSDETAILS",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Handelsgebühren konnten nicht berechnet werden",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "Handelsgebühr:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Handelsart:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "Transaktionsadresse",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "Transaktion ausgeblendet",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Diese Transaktion wurde aufgrund eines möglichen Phishing-Versuchs ausgeblendet.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "Wenn auch dann noch einige Coins nicht aktiviert sind, versuchen Sie, die App neu zu starten.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Türkisch",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Block",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Bestätigungen",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "BESTÄTIGT",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Gebühr",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "Transaktionsgebühr:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "Transaktions ID",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Verbleibende Transaktionen: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Zu viele Anfragen.\nDas Limit für Anfragen zur Transaktionshistorie wurde überschritten.\nBitte versuchen Sie es später noch einmal.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "UNBESTÄTIGT",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Ukrainisch",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "Freischalten",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Geldmittel freischalten",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "{amnt} Geldmittel wurden erfolgreich freigeschaltet - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "Nicht verwendbar",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Neue Version verfügbar",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Nach Updates suchen...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "Sie nutzen Version {version}",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Neue Version verfügbar. Bitte updaten.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "Version {version} verfügbar. Bitte updaten.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Update verfügbar",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Vorerst überspringen",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "{appName} Update",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Update",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Bereits auf dem neuesten Stand",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "Nicht genug Guthaben für die gescannte",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "Zahlungsaufforderung.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Unzureichendes Guthaben",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Wert:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "Version",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Explorer",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Seed & Private Schlüssel",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Volumen",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "Wallet-Name existiert bereits",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "Wallet-Name darf maximal 40 Zeichen lang sein",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Nur Wallet",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "Achtung!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Ok",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Achtung - in besonderen Fällen enthalten diese Protokolldaten sensible Informationen, die dazu verwendet werden können, Coins aus fehlgeschlagenen Swaps auszugeben!",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "Wir konnten {coinAbbr} nicht aktivieren",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "Wir konnten {coinAbbr} nicht aktivieren.\nBitte starten Sie die App neu, um es erneut zu versuchen.",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} ist eine Multi-Coin-Wallet der nächsten Generation mit nativer DEX-Funktionalität der dritten Generation und mehr.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "AUF GEHT'S!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "WILLKOMMEN",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "Wallet",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "Nach Fertigstellung werden Sie zur Portfolio-Seite weitergeleitet.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Dies dauert eine Weile und die App muss im Vordergrund bleiben.\nDas Beenden der App während der Aktivierung kann zu Problemen führen.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Auszahlung",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "Sie haben {appName} zuvor den Zugriff auf die Kamera verweigert.\nBitte ändern Sie die Kamerazugriffsrechte manuell in den Telefoneinstellungen, um mit dem QR-Code-Scan fortzufahren.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Zugriff verweigert",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Auszahlung bestätigen",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "{amount} {coinName} ABHEBEN",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "Sie versuchen, einen QR-Code für eine Zahlung zu scannen",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "aber Sie sind auf dem",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "Auszahlungs-Bildschirm",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Falscher Coin",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "Die Kennwörter stimmen nicht überein. Bitte versuche es erneut.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Ja",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Sie senden:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "Sie haben einen neuen Auftrag, der  einem bestehenden Auftrag zugeordnet werden soll",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "Sie haben einen aktiven Swap in Arbeit",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "Sie haben einen Auftrag, dem neue Aufträge zugeordnet werden können",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "Ihr Wallet",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "Sie erhalten {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Sie erhalten:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,3726 +1,5540 @@
 {
-  "@@locale": "de",
-  "accepteula": "EULA akzeptieren",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Allgemeine Geschäftsbedingungen akzeptieren",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Biometrischen Schutz aktivieren",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "PIN-Schutz aktivieren",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "{protocolName}-Münzen aktivieren?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Bitte beachten Sie, dass Sie jetzt Mobilfunkdaten verwenden und die Teilnahme am P2P-Netzwerk von {appName} Internetverkehr verbraucht. Es ist besser, ein WiFi-Netzwerk zu verwenden, wenn Ihr mobiler Datentarif kostspielig ist.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Zugriff verweigert",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "Sie haben {appName} zuvor den Zugriff auf die Kamera verweigert.\nBitte ändern Sie die Kamerazugriffsrechte manuell in den Telefoneinstellungen, um mit dem QR-Code-Scan fortzufahren.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "WILLKOMMEN",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "Wallet",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} ist eine Multi-Coin-Wallet der nächsten Generation mit nativer DEX-Funktionalität der dritten Generation und mehr.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "AUF GEHT'S!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "Um abgeschlossen zu werden, {appCompanyLong}muss jede virtuelle Währungstransaktion, die mit dem erstellt wurde, bestätigt und im Ledger für virtuelle Währungen aufgezeichnet werden, das dem jeweiligen virtuellen Währungsnetzwerk zugeordnet ist. {appCompanyLong}Bei solchen Netzwerken handelt es sich um dezentrale Peer-to-Peer-Netzwerke, die von unabhängigen Dritten unterstützt werden, die sich nicht im Besitz, unter der Kontrolle oder unter der Kontrolle von ihnen befinden.\n{appCompanyLong}hat keine Kontrolle über virtuelle Währungsnetzwerke und kann und wird daher nicht sicherstellen, dass alle Transaktionsdetails, die Sie über unsere Dienste einreichen, im jeweiligen Netzwerk für virtuelle Währungen bestätigt werden. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionsdetails, die Sie über unsere Dienste übermitteln, durch das zur Bearbeitung der Transaktion verwendete virtuelle Währungsnetzwerk möglicherweise nicht abgeschlossen oder erheblich verzögert werden können. Wir garantieren nicht, dass das Wallet das Eigentum oder die Rechte an einer virtuellen Währung übertragen kann, und geben auch keine Garantie in Bezug auf den Titel.\nSobald Transaktionsdetails an ein virtuelles Währungsnetzwerk übermittelt wurden, können wir Ihnen nicht helfen, Ihre Transaktion oder Transaktionsdetails zu stornieren oder anderweitig zu ändern. {appCompanyLong}hat keine Kontrolle über ein Netzwerk für virtuelle Währungen und ist nicht in der Lage, Stornierungs- oder Änderungsanfragen zu bearbeiten.\nIm Falle eines Forks {appCompanyLong}kann es sein, dass wir Aktivitäten im Zusammenhang mit Ihrer virtuellen Währung nicht unterstützen können. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionen im Falle einer Fork möglicherweise nicht, teilweise, falsch abgeschlossen oder erheblich verzögert werden. {appCompanyLong}ist nicht verantwortlich für Verluste, die Ihnen ganz oder teilweise, direkt oder indirekt, durch einen Fork entstehen.\nIn keinem Fall {appCompanyLong}haften ihre verbundenen Unternehmen und Dienstleister oder ihre jeweiligen leitenden Angestellten, Direktoren, Agenten, Mitarbeiter oder Vertreter für entgangene Gewinne oder besondere, zufällige, indirekte, immaterielle oder Folgeschäden, unabhängig davon, ob sie auf Vertrag, unerlaubter Handlung, Fahrlässigkeit, verschuldensunabhängiger Haftung oder auf andere Weise beruhen, die sich aus oder in Verbindung mit der autorisierten oder unbefugten Nutzung der Dienste oder dieser Vereinbarung ergeben, auch wenn ein bevollmächtigter Vertreter {appCompanyLong}von darauf hingewiesen wurde, hat davon gewusst oder hätte von der Möglichkeit solcher Schäden bekannt. \nBeispielsweise (und ohne den Umfang des vorstehenden Satzes einzuschränken) dürfen Sie sich nicht für entgangene Gewinne, entgangene Geschäftschancen oder andere Arten von besonderen, zufälligen, indirekten, immateriellen oder Folgeschäden zurückfordern. In einigen Rechtsordnungen ist der Ausschluss oder die Beschränkung von Neben- oder Folgeschäden nicht zulässig, sodass die obige Beschränkung möglicherweise nicht für Sie gilt. \nWir sind Ihnen gegenüber nicht verantwortlich oder haftbar für Verluste und übernehmen keine Verantwortung für Schäden oder Ansprüche, die sich ganz oder teilweise, direkt oder indirekt ergeben aus: \n(a) Benutzerfehler wie vergessene Passwörter, falsch erstellte Transaktionen oder falsch eingegebene Adressen für virtuelle Währungen; \n(b) Serverausfall oder Datenverlust; \n(c) beschädigte oder anderweitig nicht funktionierende Wallets oder Wallet-Dateien; \n(d) unbefugter Zugriff auf Anwendungen; \n(e) alle nicht autorisierten Aktivitäten, einschließlich, aber nicht beschränkt auf den Einsatz von Hacking, Viren, Phishing, Brute-Forcing oder anderen Angriffsmethoden gegen die Dienste.\n\n",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "{appName} Update",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "Sie nutzen Version {version}",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Nach Updates suchen...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Bereits auf dem neuesten Stand",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Neue Version verfügbar",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Update",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Vorerst überspringen",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Update verfügbar",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Neue Version verfügbar. Bitte updaten.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "Version {version} verfügbar. Bitte updaten.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Hilfe",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Hilfe und Support",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Häufig gestellte Fragen",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Support",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Wenn Sie Fragen haben oder glauben, dass Sie ein technisches Problem mit der {appName} App gefunden haben, können Sie dies melden und Unterstützung von unserem Team erhalten.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "Speichern Sie meine privaten Schlüssel?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "Nein! {appName} hat keine Vormundschaft. Wir speichern niemals sensible Daten, einschließlich Ihrer privaten Schlüssel, Seed-Phrasen oder PINs. Diese Daten werden nur auf dem Gerät des Benutzers gespeichert und verlassen es nie. Sie haben die volle Kontrolle über Ihr Vermögen.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "Wie unterscheidet sich der Handel auf {appName} vom Handel auf anderen DEXs?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Bei anderen DEXs können Sie im Allgemeinen nur Assets handeln, die auf einem einzigen Blockchain-Netzwerk basieren, Proxy-Token verwenden und nur einen einzigen Auftrag mit denselben Geldmitteln aufgeben.\n\n{appName} ermöglicht Ihnen den nativen Handel über zwei verschiedene Blockchain-Netzwerke ohne Proxy-Tokens. Sie können auch mehrere Aufträge mit demselben Guthaben platzieren. Sie können zum Beispiel 0,1 BTC für KMD, QTUM oder VRSC verkaufen - der erste Auftrag, der ausgeführt wird, storniert automatisch alle anderen Aufträge.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "Wie lange dauert ein Atomic Swap?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Mehrere Faktoren bestimmen die Bearbeitungszeit für einen Swap. Die Blockzeit der gehandelten Assets hängt vom jeweiligen Netzwerk ab (Bitcoin ist normalerweise das langsamste). Außerdem kann der Benutzer die Sicherheitseinstellungen anpassen. Zum Beispiel (können Sie {appName} bitten, eine KMD-Transaktion nach nur 3 Bestätigungen als endgültig zu betrachten, wodurch die Swap-Zeit kürzer wird als beim Warten auf eine <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">Beglaubigung</a>",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "Muss ich für die Dauer des Swaps online sein?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Ja. Sie müssen mit dem Internet verbunden bleiben und die App ausführen, um jeden Atomic Swap erfolgreich abzuschließen (sehr kurze Verbindungsunterbrechungen sind normalerweise in Ordnung). Andernfalls besteht das Risiko einer Auftragsstornierung, wenn Sie ein Maker sind, und das Risiko eines Geldverlusts, wenn Sie ein Taker sind.\n\nDas Atomic-Swap-Protokoll erfordert, dass beide Teilnehmer online bleiben und die beteiligten Blockchains überwachen, damit der Prozess atomar bleibt.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "Wie werden die Gebühren für {appName} berechnet?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "Beim Handel auf {appName} sind zwei Gebührenkategorien zu berücksichtigen.\n\n1. {appName} berechnet ungefähr 0,13 % (1/777 des Handelsvolumens, aber nicht weniger als 0,0001) als Handelsgebühr für Taker-Aufträge, Maker-Aufträge haben keine Gebühren.\n\n2. Sowohl Maker als auch Taker müssen normale Netzwerkgebühren an die beteiligten Blockchains zahlen, wenn sie Atomic-Swap-Transaktionen durchführen.\n\nDie Netzwerkgebühren können je nach ausgewähltem Handelspaar stark variieren.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "Bieten Sie einen Support für die Nutzer an?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "Ja! {appName} bietet Support über den <a href=\"{link}\">{appCompanyShort} {name}</a>. Das Team und die Community helfen Euch gerne weiter!\n",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "Gibt es länderspezifische Einschränkungen?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "Nein! {appName} ist vollständig dezentralisiert. Es ist nicht möglich, den Benutzerzugang durch Dritte zu beschränken.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "Wer steckt hinter {appName}?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} wird vom {appCompanyShort}-Team entwickelt. {appCompanyShort} ist eines der etabliertesten Blockchain-Projekte, das an innovativen Lösungen wie Atomic Swaps, Delayed Proof of Work und einer interoperablen Multi-Chain-Architektur arbeitet.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "Ist es möglich, meine eigene White-Label-Börse auf {appName} zu entwickeln?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "Absolut! Weitere Informationen finden Sie in unserer <a href=\"https://developers.komodoplatform.com/\">Entwicklerdokumentation</a> oder kontaktieren Sie uns mit Ihren Partnerschaftsanfragen. Haben Sie eine spezielle technische Frage? Die {appName}-Entwickler-Community ist immer bereit zu helfen!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "Auf welchen Geräten kann ich {appName} verwenden?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName} ist für Mobilgeräte auf Android und iPhone sowie für Desktops auf <a href=\"https://komodoplatform.com/\">Windows-, Mac- und Linux-Betriebssystemen</a> verfügbar.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Feed",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Newsfeed",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Mehr lesen...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Hier gibt es nichts",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Newsfeed aktualisiert",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Ablehnen",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Neuigkeiten",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Dauer",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "Nachrichten können nicht aktualisiert werden",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "Aktualisierung der Nachrichten kann nicht fortgesetzt werden",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Bereits auf dem neuesten Stand",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Datum",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} Neuigkeiten",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "PIN erstellen",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "Geben Sie Ihren PIN-Code ein",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "Anmeldung",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "neues Konto",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Neues Konto",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} erfolgreich aktiviert!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Verbindung wird hergestellt ...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Coin aktivieren",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} Assets",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Geben Sie Ihre Seed-Phrase ein",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Beispiel: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "Bestätigen",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "Warnung, Sie möchten Test-Coins ohne tatsächlichen Wert kaufen!",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "Der Akkustand ist kritisch ({batteryLevelCritical}%) um einen Swap sicher auszuführen. Bitte laden Sie ihr Handy auf und versuchen es später noch einmal.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "Ihre Akkuladung ist niedriger als {batteryLevelLow} %. Bitte denken Sie an das Aufladen des Telefons.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "Ihr  Handy ist im Energissparmodus. Bitte deaktivieren Sie diesen Modus oder gehen Sie mit der App NICHT im Hintergrundmodus. Andernfalls könnte die App durch das Betriebssystem beendet werden und der Swap schlägt fehl.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "Achtung, Sie sind bereit, Testmünzen OHNE realen Wert zu verkaufen!",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Kaufen",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Verkaufen",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "Meine {coinName} Adresse:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Auszahlung",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "Wert ist zu hoch oder zu niedrig",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Menge",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Empfängeradresse",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "{amount} {coinName} ABHEBEN",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Auszahlung bestätigen",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Schließen",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "Seed-Phrase bestätigen",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Ihr neuer Seed",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Wichtig: Sichern Sie Ihren Seed bevor Sie fortfahren!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Wir empfehlen die Offline-Sicherung.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "Weiter",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "PIN-Code bestätigen",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Tarnungs-PIN Einrichtung",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Tarnungs-PIN bestätigen",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Fehler, bitte versuchen Sie es erneut",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Einstellungen",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Sicherheit",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "PIN-Schutz aktivieren",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Deaktivieren Sie Screenshots/Vorschau",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "Bildschirm ist gesperrt",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "PIN-Code ändern",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Ausloggen",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "MAX",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "MIN",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Gesamtgebühren:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Bezahlt aus dem Guthaben:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Handelsart:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Überspringen",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Zusammenfassen",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Überschreiben",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Aktueller Wert:",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Neuer Wert:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Zusammengefasster Wert:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Zusammenfassung speichern",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "Ist bereits vorhanden",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Einfach",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Fortgeschritten",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Bezahlt aus dem eingegangenen Volumen:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Zu verkaufende Menge",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Sie erhalten:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "Wählen Sie den zu verkaufenden Coin",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "Wählen Sie den zu kaufenden Coin aus",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "swap",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Swap gestartet, bitte warten!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "Auftragsvermittlung läuft, bitte warten Sie {seconde} Sekunden!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Netzwerkgebühr",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "Provision",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Portfolio",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Abmelden",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Geschätzter Gesamtwert",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Wählen Sie eine Bezahlart",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Volumen",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Auftrag platzieren",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "Demnächst...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Marktplatz",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Sie senden:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Code:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Wert:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Bezahlt mit",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "Bitte Daten eintippen",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "Guthaben unzureichend",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Gwei muss bis zu {value} sein",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "Die Gebühren müssen bis zu {value} betragen.",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "Das Limit muss bis zu {value} betragen",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "Ungültige Adresse",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Segwit-Adressen werden (noch) nicht unterstützt",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "An Adresse:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "ERHALTEN",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "SENDEN",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Öffentlicher Schlüssel (Pubkey)",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "zurück",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "stornieren",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "Details",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Ja",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "Nein",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Hinweis: Übereinstimmende Aufträge können nicht mehr storniert werden.",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "Nicht mehr nachfragen",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Auftrag stornieren",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "Wollen Sie die Order wirklich stornieren?",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "Nicht verwendbar",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "TX Details folgen in Kürze!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "Verlauf",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "Handeln",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "Details folgen in Kürze!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Auftrag wird gematched",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Auftrag gematched!",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Swap läuft",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Swap erfolgreich",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Zeitüberschreitung",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Umwandeln",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "Swap fehlgeschlagen",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Fehler, bitte versuchen Sie es später",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Letzte Transaktionen",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "Die Transaktion wird ausgeführt. Bitte warten Sie",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Bitte warten Sie, bis der Vorgang abgeschlossen ist",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Protokolldatei teilen",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Auftragsbuch wird geladen...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "Anfordern",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "KMD Prämie anfordern?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "Erfolgreich!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "Keine Belohnung verfügbar. Bitte versuchen Sie es in 1 Stunde erneut.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Wird geladen...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Verbleibende Transaktionen: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} Guthaben reicht nicht aus, um die Handelsgebühr zu bezahlen",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Neuigkeiten",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Newsfeed",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "In die Zwischenablage kopiert",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "Von",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "An",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "BESTÄTIGT",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "UNBESTÄTIGT",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Block",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Bestätigungen",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Gebühr",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "Transaktions ID",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Memo",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "Kein Verlauf vorhanden",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "HANDEL",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "LÖSCHEN",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Formular zurücksetzen",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "SWAP ABGESCHLOSSEN!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Schritt",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "HANDELSDETAILS",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Angeforderter Handel",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "Swap UUID",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "DURCHBLÄTTERN",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "GESPEICHERT",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "Sie können {remains} weiterhin aktivieren, Ausgewählt: {selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "SIE HABEN KEINE GESPEICHERTEN ARTIKEL",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "FEED DURCHBLÄTTERN",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "Von",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "Bitte authentifizieren!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "Keine Transaktionen vorhanden",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Erledigt",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Coins aktivieren:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Wählen Sie die Coins aus, die Sie Ihrem Portfolio hinzufügen möchten.",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "Keine Neuigkeiten - bitte versuchen Sie es später erneut!",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "Der Swap kann nicht rückgängig gemacht werden und ist ein endgültiges Ereignis!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "Der Swap kann bis zu 60 Minuten dauern. Schließen Sie diese Anwendung NICHT!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "TAUSCH-DETAILS BESTÄTIGEN",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Erforderliches Mindestvolumen",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "Benutzerdefiniertes Mindestvolumen verwenden",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "Der Wert muss numerisch sein",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Muss niedriger als die Verkaufsmenge sein",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "Muss größer sein als {minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "Seed-Phrase überprüfen",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "LASSEN SIE UNS IHREN SEED DOPPELT ÜBERPRÜFEN",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "Ihr Seed ist wichtig - deshalb stellen wir Ihnen drei verschiedene Fragen, um sicherzustellen, dass dieser korrekt ist und Sie Ihr Wallet jederzeit problemlos wiederherstellen können.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "Was ist das {index}.Wort in Ihrer Seed?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "{index} Wort eingeben",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "WEITER",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "ZURÜCK UND ERNEUT ÜBERPRÜFEN",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Explorer",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Biometrischen Schutz aktivieren",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Benutzerdefinierten Seed erlauben",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "Achtung!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "Ich habe verstanden",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Benutzerdefinierte Seed-Phrasen sind möglicherweise weniger sicher und leichter zu knacken als eine generierte BIP39-konforme Seed-Phrase oder ein privater Schlüssel (WIF). Um zu bestätigen, dass Sie das Risiko verstehen und wissen was Sie tun, geben Sie \"{iUnderstand}\" im Kasten unten an.\n",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Geben Sie Ihr Kennwort ein",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "Ihr Wallet",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "Kennwort vergessen? Wallet mit der Seed wiederherstellen",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Mit Kennwort anmelden",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Geben Sie Ihren Seed ein",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "Die Kennwörter stimmen nicht überein. Bitte versuche es erneut.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Benennen Sie Ihr Wallet",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Aus Sicherheitsgründen müssen Sie ein Kennwort für die Verschlüsselung ihres Wallets angeben.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Kennwort bestätigen",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "Ich möchte kein Kennwort",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "BIST DU SICHER?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Verwenden Sie ein sicheres Kennwort und speichern Sie es nicht auf demselben Gerät",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "KENNWORT EINRICHTEN",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "Wallet erstellen",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "WIEDERHERSTELLEN",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Kennwort",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "Das Kennwort muss mindestens 12 Zeichen enthalten, davon ein Kleinbuchstabe, ein Großbuchstabe und ein Sonderzeichen.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Kennwort erstellen",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Kennwort bestätigen",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Aktuelles Kennwort",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Abmelde-Einstellungen",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Beim Beenden abmelden",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Wallet löschen",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Löschen",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Sind Sie sicher, dass Sie die",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "Wallet löschen möchten?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Wenn ja, stellen Sie sicher, dass Sie",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "Ihren Seed sichern,",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "um Ihre Wallet in Zukunft wiederherzustellen.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Sicherung",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "Version",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Seed & Private Schlüssel",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "Seed-Phrase",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Private Schlüssel",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Privater Schlüssel",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Bitte Kennwort eingeben um fortzufahren.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "In die Zwischenablage kopieren",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "Freischalten",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "{amnt} Geldmittel wurden erfolgreich freigeschaltet - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Geldmittel freischalten",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "Keine Aufträge, bitte gehen Sie zum Handel.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Bitte geben Sie die {coinName} Menge ein.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "Wechselkurs",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Erhalten",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "Einen Auftrag erstellen",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "TAUSCHEN",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "Aufträge",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Coin auswählen",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗Vorsicht! Der Markt für {coinName} hat ein 24-Stunden-Handelsvolumen von weniger als 10.000 US-Dollar!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Sprache wählen",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Kein Guthaben",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "Kein Guthaben vorhanden - bitte zuerst einzahlen.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Zum Portfolio gehen",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Klicken Sie hier, um einen Auftrag zu erstellen",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Unzureichendes Volumen",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "Die Mindestmenge, die für diesen Auftrag erforderlich ist, beträgt",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Auftrag erstellt",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Auftrag erfolgreich erstellt",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "MEINE AUFTRÄGE ANZEIGEN",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "PASSWORT ERSTELLEN",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "Die Mindestmenge für den Kauf ist {number} {coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "Die Mindestmenge des Auftrags ist {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Sie müssen zuerst die Verkaufsmenge eingeben",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Wallet verschlüsseln",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Wallet entschlüsseln",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "Nicht genügend Guthaben für Gebühren - handeln Sie einen kleinere Menge",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "Keine Internetverbindung",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Auf Komodo aufgebaut",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Bitte fügen Sie einen Coin hinzu",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "Internetverbindung wiederhergestellt",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Aktualisieren",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Rechtliches",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Haftungsausschluss & AGB",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "EULA akzeptieren",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "Allgemeine Geschäftsbedingungen akzeptieren",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "Durch Klicken auf die folgenden Schaltflächen bestätigen Sie, dass Sie die \"EULA\" und die \"Allgemeinen Geschäftsbedingungen\" gelesen haben und diese akzeptieren",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin}-Gebühr",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "Nicht genug {coin} für die Transaktion!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Bitte aktivieren Sie {coin}.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "Sie erhalten {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "Klicken Sie hier, um {amount} Aufträge zu sehen",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Zum Anzeigen klicken",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "Preis",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "max vol",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "Bitte warten, ihre Wallet wird konfiguriert...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Auftrag ausgewählt",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "Transaktionsgebühr:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "Handelsgebühr:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen. {coin} {amount} sind erforderlich.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "Swap kann nicht durchgeführt werden",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Details anzeigen",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Wechselkurs:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Ausgewählter Auftrag:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "Min Auftragsvolumen:",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Max Auftragsvolumen:",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Details",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Bitte aktivieren Sie zuerst {coin} und laden Sie Ihr Guthaben auf",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Handelsgebühren konnten nicht berechnet werden",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Deaktivieren",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Nur Wallet",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "Wallet-Name darf nicht leer sein",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "Wallet-Name darf maximal 40 Zeichen lang sein",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "Wallet-Name existiert bereits",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX ist für diesen Coin nicht verfügbar",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Coin suchen",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Alle SmartChains auswählen",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Alle Test Assets auswählen",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Alle ERC tokens auswählen",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Wählen Sie alle SLP-Tokens aus",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Wählen Sie alle Cosmos Network aus",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Wählen Sie alle Iris-Netzwerke aus",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Alle Kucoin tokens auswählen",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Alle Harmony tokens auswählen",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Alle ETC tokens auswählen",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Alle SmartBCH tokens auswählen",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Alle Avax tokens auswählen",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Alle Ubiq coins auswählen",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Alle BEP tokens auswählen",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Alle Polygon tokens auswählen",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Alle QRC tokens auswählen",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Alle HecoChain tokens auswählen",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Wählen Sie alle ZHTLC-Münzen aus",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Alle Fantom tokens auswählen",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Alle Moonriver tokens auswählen",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Individuelle Gebühr",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "Gas-Limit",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "Gas-Preis",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "Individuelle Gebühr nur nutzen, wenn Sie wissen was darunter zu verstehen ist!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Alle UTXO coins auswählen",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Auf Komodo aufgebaut",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Unterstützt von Komodo",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "Nicht genug Gas - verwenden Sie mindestens {gas} Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Alle {coin} Aufträge werden storniert.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Deaktivierung bestätigen",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "Möchten Sie",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "von ihrem Portfolio entfernen? Alle offenen Aufträge werden storniert.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " wird ebenfalls deaktiviert",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "Kann nicht deaktiviert werden",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "ist ein Standard-Coin. Standard-Coins können nicht deaktiviert werden.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ok",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "Teilen",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Achtung - in besonderen Fällen enthalten diese Protokolldaten sensible Informationen, die dazu verwendet werden können, Coins aus fehlgeschlagenen Swaps auszugeben!",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Geben Sie ihren alten PIN ein",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Geben Sie ihren neuen PIN ein",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "authentifizieren",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Sprachen",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "Englisch",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Französisch",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Deutsch",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Chinesisch",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Russisch",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Japanisch",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Türkisch",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Ungarisch",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "Spanisch",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Koreanisch",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Ukrainisch",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "FAUCET",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Erfolg",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Fehler",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "Zeitüberschreitung der Anfrage",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "Anfrage an {coin} faucet senden...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "Optional",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Sound",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "In voller Lautstärke abspielen",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Taker",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "Sie haben einen neuen Auftrag, der  einem bestehenden Auftrag zugeordnet werden soll",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Maker",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "Sie haben einen Auftrag, dem neue Aufträge zugeordnet werden können",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Aktiv",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "Sie haben einen aktiven Swap in Arbeit",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Fehlgeschlagen",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "ein Swap ist fehlgeschlagen",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Beifall",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "ein Swap läuft bis zur Fertigstellung",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "Kann nicht abgespielt werden",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Wählen Sie bitte eine mp3- oder wav-Datei aus. Wir spielen es, wenn {description}.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "Abgespielt, wenn {description}",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Sounds",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "Während des Swap-Prozesses und wenn ein aktiver Maker-Auftrag erteilt wird, hören Sie akustische Benachrichtigungen.\nDas Atomic-Swap-Protokoll erfordert, dass die Teilnehmer für einen erfolgreichen Handel online sind, und akustische Benachrichtigungen helfen dabei.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Beachten Sie, dass Sie Ihre eigenen Sounds in den Anwendungseinstellungen festlegen können.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Verstanden, nicht mehr zeigen",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Sound-Einstellungen",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Sound",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Märkte",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "MÄRKTE",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "PREIS",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "AUFTRAGSBUCH",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "Chart",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Tiefe",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Preis",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Verkäufe",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "für",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "min.",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Adresse",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "Sinnvoll: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "Teuer: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "Identisch mit CEX",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Erhalten",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Ausgegeben",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "Dies ist Ihr eigener Auftrag!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Bitte Coins auswählen",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Coin auswählen",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "keine aktivierten Coins",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Löschen",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "({coin}) Preis",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "({coin}) Menge",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "({coin}) Gesamt",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "Keine Angebote gefunden",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "Keine Anfragen gefunden",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Details zum Auftrag",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Informationen zu den Belohnungen",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "Lesen Sie mehr über KMD-Belohnungen für aktive Nutzer",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Stornieren",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Empfangen",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "Keine anforderungsfähigen Belohnungen",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Informationen zu den Belohnungen:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO Menge,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "Belohnungen,\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "Fiat",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Verbleibende Zeit",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Status",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Belohnungsstatus:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "Ok",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} Tag(e)",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}h {minutes}m",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}min",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "Erfolgreich! {amount} KMD erhalten",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXO-Menge ist geringer als 10 KMD",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "in Bearbeitung",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "Transaktion ist in Bearbeitung",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 Stunde",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Eine Stunde ist noch nicht vergangen",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Belohnungen beantragen",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "Transaktionsverlauf anzeigen",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Erneuter Versuch, alle Münzen zu aktivieren...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "Nach Fertigstellung werden Sie zur Portfolio-Seite weitergeleitet.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "Wenn auch dann noch einige Coins nicht aktiviert sind, versuchen Sie, die App neu zu starten.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "Wir konnten {coinAbbr} nicht aktivieren",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Bitte starten Sie die App neu, um es erneut zu versuchen, oder drücken Sie die Schaltfläche unten.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Erneuter Versuch, alle zu aktivieren",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Sie werden automatisch zur Portfolio-Seite weitergeleitet, wenn der erneute Aktivierungsprozess abgeschlossen ist.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "Wir konnten {coinAbbr} nicht aktivieren.\nBitte starten Sie die App neu, um es erneut zu versuchen.",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} ist nicht verfügbar :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Mehrfach",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Bitte beheben Sie alle Fehler, bevor Sie fortfahren",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Erstellen",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Auftrag",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Aufträge",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Coin",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Verkaufen:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Verkaufen",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Menge",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Erhalten:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "Preis/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Menge erhalten",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Bitte geben Sie den gewünschten Fiat-Betrag ein:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "Abbrechen",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Automatisch ausfüllen",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "Gebühr",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "Nicht genug {coin} vorhanden, um die Gebühren zu zahlen. MIN Guthaben beträgt {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "{number} Auftrag/Aufträge erstellen:",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "Abbrechen",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Bestätigen",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Ungültige Verkaufsmenge",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "Max Verkaufsmenge beträgt",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "Min Verkaufsmenge beträgt",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Ungültige Menge",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "Ungültige {coin}-Adresse",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "Aktivieren Sie {coin} und laden Sie zuerst Ihr Guthaben auf",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin} Guthaben ist zu niedrig",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "Der Mindestbetrag, den Sie erhalten, beträgt",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Adressbuch",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Adressbuch",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Kontaktdetails",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "Adressbuch ist leer",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Nur Kontakte mit {title} Adressen anzeigen",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Kontakt erstellen",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "Name",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Kontakt bearbeiten",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "Abbrechen",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Sichern",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Verwerfen",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Beenden",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Änderungen verwerfen?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Adresse hinzufügen",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Coin auswählen",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Ticker suchen",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Kontakt löschen",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "Möchten Sie den Kontakt {name} wirklich löschen?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "Löschen",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "Keine Kontakte gefunden",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Bearbeiten",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Nichts gefunden",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "Diese Münze gibt es nicht",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "Sie können kein Guthaben an die {abbr} Adresse senden, da {abbr} nicht aktiviert ist. Bitte gehen Sie zum Portfolio.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Ok",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "Kontakt-Name darf nicht leer sein",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "Geben Sie die {abbr}  Adresse ein",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Tarnungs-PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Tarnungs-PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "An",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Aus",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "Ungültige PIN",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Ändern",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Wenn Sie die App mit der Tarnungs-PIN entsperren, wird ein gefälschtes NIEDRIGERES Guthaben angezeigt und die Konfigurationsoption Tarnungs-PIN ist in den Einstellungen NICHT sichtbar.",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Ihre allgemeine PIN und die Tarnungs-PIN sind identisch.\nDer Tarnmodus wird nicht verfügbar sein.\nBitte ändern Sie die Tarnungs-PIN.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "Tarnungs-PIN und Bio-Schutz können nicht gleichzeitig aktiviert werden.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Konflikt zwischen Carmo-PIN und Bio-Schutz.",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "Der allgemeine PIN-Schutz ist nicht aktiv.\nDer Tarnungsmodus ist nicht verfügbar.\nBitte aktivieren Sie den PIN-Schutz.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Gefälschter Guthaben:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "Tarnungs-PIN nicht gefunden",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Tarnungs-PIN erstellen",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "Tarnungs-PIN gespeichert",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "ungültiger Tarnungs-PIN",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Tarnungs-PIN ändern",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Tarnungs-PIN Einrichtung",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Neuen Tarnungs-PIN eingeben",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "AN",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "AUS",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Bestätigungen",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo dPoW Sicherheit",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Individuelle Schutzeinstellungen verwenden",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Achtung, dieser Atomic Swap ist nicht durch dPoW geschützt.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "In Maker-Auftrag umwandeln, wenn kein match stattgefunden hat",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEX-Tauschrate",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Sinnvoll",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Teuer",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "Identisch mit CEX",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "im Vergleich zu CEX",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "im Vergleich zum Durchschnitt. 24h CEX-Preis",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Aktiv",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "Verlauf",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Details",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Durch einmaliges antippen öffnen Sie die Details, durch langes antippen wählen Sie einen Auftrag",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "Abbrechen",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Auswählen",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "Keine übereinstimmenden Aufträge gefunden",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Maker-Auftrag",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Taker-Auftrag",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Aktuell",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "Schätzung",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "Gestartet",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Gesamt",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "Fortschrittdetails",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Fehlermeldung schließen",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Fehlermeldung öffnen",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Eingehende Transaktion",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "Du hast eine {coin} Transaktion erhalten!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "Swap abgeschlossen",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "{sell}/{buy} swap wurde erfolgreich abgeschlossen",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "Swap fehlgeschlagen",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} swap fehlgeschlagen",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Swap ist abgelaufen(Zeitüberschreitung)",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} swap ist abgelaufen(Zeitüberschreitung)",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Swap-Status geändert",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Neuer swap gestartet",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} swap gestartet",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Sprache",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Währung",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Guthaben ausblenden",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Thema ändern",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "CEX-Daten",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Die mit diesem Symbol gekennzeichneten Marktdaten (Kurse, Charts usw.) stammen aus Drittquellen (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Nach Updates suchen",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "Sind Sie sicher, dass Sie sich jetzt abmelden möchten?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Währung",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Zu viele Anfragen.\nDas Limit für Anfragen zur Transaktionshistorie wurde überschritten.\nBitte versuchen Sie es später noch einmal.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "ms",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "m",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "Minuten",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "h",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "Mehr",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "Weniger",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Alte Protokolle",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Löschen",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Wallet wird gelöscht...",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Genutzter Speicher",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Ok",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Vorschau schließen",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "stornieren",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "Scrollen Sie nach unten, um fortzufahren...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Entwickler/in",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Test-Coins aktivieren",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Details des Maker-Auftrag",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Verkauf",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Erhalten",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Preis",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Auftrag stornieren",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "Auftrags-ID",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "Erstellt am",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Durch diesen Auftrag wurden keine Swaps gestartet",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "Durch diesen Auftrag gestartete Swaps",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% ausgefüllt",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Notiz",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Notiz hinzufügen",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "Importieren",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Einzigen Swap importieren",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Exportieren",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "Importieren",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Swaps importieren",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Exportieren",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Bitte wählen Sie die Elemente aus, die in eine verschlüsselte Datei exportiert werden sollen.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Bitte wählen Sie eine verschlüsselte Datei zum Importieren aus.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Bitte wählen Sie eine einfache Textauslagerungsdatei zum Importieren aus.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Öffnung...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "Zu importierende Gegenstände:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Hinweise",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Kontakte",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Swaps",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Nichts gefunden",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Exportieren",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "Importieren",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "Verschlüsselungskennwort darf nicht leer sein",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "Kennwort darf nicht leer sein",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "Kennwörter müssen übereinstimmen",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "Keine Elemente ausgewählt",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "Keine Elemente ausgewählt",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Datei auswählen",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Datei nicht gefunden",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Fingerabdruck",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Kennwort",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "Abbrechen",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Ok",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "Die Elemente wurden erfolgreich exportiert:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "Die Elemente wurden erfolgreich importiert:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Ungültiges Kennwort oder beschädigte Daten",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Fehler beim Dekodieren der json-Datei",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Auftrag",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Unbekannter Auftragstyp",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "Konnte nicht importiert werden:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Einige Elemente wurden übersprungen",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "Import von Swaps fehlgeschlagen",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Ungültige Swap-Daten. Bitte geben Sie eine gültige Swap-Status JSON-Datei an.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "{coinName} wird aktiviert",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "Schließen Sie die App nicht. Für weitere Informationen tippen ...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName}-Aktivierung",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "{protocolName}-Münzen sind aktiviert",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "{protocolName}-Münzen sind nicht aktiviert",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName}-Münzen wurden erfolgreich aktiviert",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} Aktivierung wird ausgeführt",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "{protocolName}-Münzen aktivieren?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Mehr Info",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Adresse anzeigen",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Diese Transaktion wurde aufgrund eines möglichen Phishing-Versuchs ausgeblendet.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "Transaktionsadresse",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "Transaktion ausgeblendet",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "URL konnte nicht gestartet werden",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Dies dauert eine Weile und die App muss im Vordergrund bleiben.\nDas Beenden der App während der Aktivierung kann zu Problemen führen.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Warnung: Durch das Minimieren der App auf iOS wird der Aktivierungsprozess abgebrochen.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Bitte aktivieren Sie Benachrichtigungen, um Updates zum Aktivierungsfortschritt zu erhalten.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "QR-Code-Scanner",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "QR-Code gefunden",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Vertrag",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Starten Sie den Tausch",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Keiner",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "CEX-Kurs",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Eingehende {coinName}-TXS-Schutzeinstellungen",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "Es werden {count} von {maxCount} Bestellungen angezeigt.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "Weniger",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "Mehr",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "basierend auf {coinName1}/{coinName2}",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "Handelsgebühr senden Transaktionsgebühr",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "Handelsgebühr",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "Transaktionsgebühr für {coinName} senden",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "Erhalten Sie die Transaktionsgebühr {coinName}",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Filter",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Status",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Alle",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Erfolgreich",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Fehlgeschlagen",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "Von Datum",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "Bis Datum",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Taker/Maker",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Maker",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "Alle",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Taker",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Coin verkaufen",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Coin erhalten",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Alle Filter löschen",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Unzureichendes Guthaben",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "Nicht genug Guthaben für die gescannte",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "Zahlungsaufforderung.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Es wurde versucht, zu viele Assets zu aktivieren",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "Sie haben",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "Assets aktivert und versuchen",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "weitere zu aktivieren. Das Maximallimit beträgt",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": ". Bitte deaktivieren sie welche, bevor neue aktiviert werden.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Sie haben die maximale Anzahl an Assets ausgewählt",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Zu viele Assets aktiviert",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "Sie haben",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "Assets aktiviert. Max Limit aktivierbarer Assets ist",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ". Bitte deaktivieren Sie welche, bevor Sie neue hinzufügen.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Zahlung angefordert",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Coin:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "Nach Adresse",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "Menge:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "Akzeptieren Sie diese Transaktion?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Bezahlen",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "Abbrechen",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} ist nicht aktiviert. Bitte aktivieren und erneut versuchen.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Falscher Coin",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "Sie versuchen, einen QR-Code für eine Zahlung zu scannen",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "aber Sie sind auf dem",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "Auszahlungs-Bildschirm",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Verkaufen",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Kaufen",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Erhalten",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Senden",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Schließen",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Aktivieren",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "Maximum an aktivierbaren Coins ist {maxCoins}. Bitte deaktivieren Sie welche.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "{coin} kann nicht aktiviert werden",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} ist nicht aktiviert!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Bitte geben Sie die {coin} Menge an, die Sie kaufen möchten",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Bitte geben Sie die {coin} Menge an, die Sie verkaufen möchten",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Weniger anzeigen",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Mehr anzeigen",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "Kein Coin gefunden",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "Es ist eine neue Ära! Wir haben unseren Namen offiziell von „AtomicDEX“ in „Komodo Wallet“ geändert.",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "Offizielle Pressemitteilung",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "Nach vergangenen {coin}-Transaktionen suchen?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "Aktivierung abbrechen",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "Welche {name}-Transaktionen möchten Sie synchronisieren?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "Synchronisieren Sie neue Transaktionen",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Ab dem angegebenen Datum synchronisieren",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Synchronisierung durch Setzlingsaktivierung",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Wählen Sie ein Datum aus",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Startdatum",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "Wir synchronisieren zukünftige Transaktionen, die nach der Aktivierung in Verbindung mit Ihrem öffentlichen Schlüssel durchgeführt werden. Dies ist die schnellste Option und beansprucht am wenigsten Speicherplatz.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "In Ihrem Wallet werden alle vergangenen Transaktionen angezeigt. Dies wird viel Speicherplatz und Zeit in Anspruch nehmen, da alle Blöcke heruntergeladen und gescannt werden.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "In Ihrem Wallet werden Ihre vergangenen Transaktionen angezeigt, die nach dem angegebenen Datum getätigt wurden.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "{coinName} wird aktiviert",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName}-Aktivierung",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} Aktivierung wird ausgeführt",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Aktiv",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Coin aktivieren",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} erfolgreich aktiviert!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Adresse hinzufügen",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Adressbuch",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "Adressbuch ist leer",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Nur Kontakte mit {title} Adressen anzeigen",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Adressbuch",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "Sie können kein Guthaben an die {abbr} Adresse senden, da {abbr} nicht aktiviert ist. Bitte gehen Sie zum Portfolio.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Nichts gefunden",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Coin auswählen",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Empfängeradresse",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Fortgeschritten",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "Alle",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Benutzerdefinierten Seed erlauben",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "In Ihrem Wallet werden alle vergangenen Transaktionen angezeigt. Dies wird viel Speicherplatz und Zeit in Anspruch nehmen, da alle Blöcke heruntergeladen und gescannt werden.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "Ist bereits vorhanden",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Menge",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Zu verkaufende Menge",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "Nein! {appName} hat keine Vormundschaft. Wir speichern niemals sensible Daten, einschließlich Ihrer privaten Schlüssel, Seed-Phrasen oder PINs. Diese Daten werden nur auf dem Gerät des Benutzers gespeichert und verlassen es nie. Sie haben die volle Kontrolle über Ihr Vermögen.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName} ist für Mobilgeräte auf Android und iPhone sowie für Desktops auf <a href=\"https://komodoplatform.com/\">Windows-, Mac- und Linux-Betriebssystemen</a> verfügbar.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Bei anderen DEXs können Sie im Allgemeinen nur Assets handeln, die auf einem einzigen Blockchain-Netzwerk basieren, Proxy-Token verwenden und nur einen einzigen Auftrag mit denselben Geldmitteln aufgeben.\n\n{appName} ermöglicht Ihnen den nativen Handel über zwei verschiedene Blockchain-Netzwerke ohne Proxy-Tokens. Sie können auch mehrere Aufträge mit demselben Guthaben platzieren. Sie können zum Beispiel 0,1 BTC für KMD, QTUM oder VRSC verkaufen - der erste Auftrag, der ausgeführt wird, storniert automatisch alle anderen Aufträge.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Mehrere Faktoren bestimmen die Bearbeitungszeit für einen Swap. Die Blockzeit der gehandelten Assets hängt vom jeweiligen Netzwerk ab (Bitcoin ist normalerweise das langsamste). Außerdem kann der Benutzer die Sicherheitseinstellungen anpassen. Zum Beispiel (können Sie {appName} bitten, eine KMD-Transaktion nach nur 3 Bestätigungen als endgültig zu betrachten, wodurch die Swap-Zeit kürzer wird als beim Warten auf eine <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">Beglaubigung</a>",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Ja. Sie müssen mit dem Internet verbunden bleiben und die App ausführen, um jeden Atomic Swap erfolgreich abzuschließen (sehr kurze Verbindungsunterbrechungen sind normalerweise in Ordnung). Andernfalls besteht das Risiko einer Auftragsstornierung, wenn Sie ein Maker sind, und das Risiko eines Geldverlusts, wenn Sie ein Taker sind.\n\nDas Atomic-Swap-Protokoll erfordert, dass beide Teilnehmer online bleiben und die beteiligten Blockchains überwachen, damit der Prozess atomar bleibt.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "Beim Handel auf {appName} sind zwei Gebührenkategorien zu berücksichtigen.\n\n1. {appName} berechnet ungefähr 0,13 % (1/777 des Handelsvolumens, aber nicht weniger als 0,0001) als Handelsgebühr für Taker-Aufträge, Maker-Aufträge haben keine Gebühren.\n\n2. Sowohl Maker als auch Taker müssen normale Netzwerkgebühren an die beteiligten Blockchains zahlen, wenn sie Atomic-Swap-Transaktionen durchführen.\n\nDie Netzwerkgebühren können je nach ausgewähltem Handelspaar stark variieren.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "Ja! {appName} bietet Support über den <a href=\"{link}\">{appCompanyShort} {name}</a>. Das Team und die Community helfen Euch gerne weiter!\n",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "Nein! {appName} ist vollständig dezentralisiert. Es ist nicht möglich, den Benutzerzugang durch Dritte zu beschränken.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} wird vom {appCompanyShort}-Team entwickelt. {appCompanyShort} ist eines der etabliertesten Blockchain-Projekte, das an innovativen Lösungen wie Atomic Swaps, Delayed Proof of Work und einer interoperablen Multi-Chain-Architektur arbeitet.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "Absolut! Weitere Informationen finden Sie in unserer <a href=\"https://developers.komodoplatform.com/\">Entwicklerdokumentation</a> oder kontaktieren Sie uns mit Ihren Partnerschaftsanfragen. Haben Sie eine spezielle technische Frage? Die {appName}-Entwickler-Community ist immer bereit zu helfen!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Beifall",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "BIST DU SICHER?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "ein Swap ist fehlgeschlagen",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "ein Swap läuft bis zur Fertigstellung",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "authentifizieren",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Sie werden automatisch zur Portfolio-Seite weitergeleitet, wenn der erneute Aktivierungsprozess abgeschlossen ist.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "max vol",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "zurück",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Sicherung",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "basierend auf {coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "Der Akkustand ist kritisch ({batteryLevelCritical}%) um einen Swap sicher auszuführen. Bitte laden Sie ihr Handy auf und versuchen es später noch einmal.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "Ihre Akkuladung ist niedriger als {batteryLevelLow} %. Bitte denken Sie an das Aufladen des Telefons.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "Ihr  Handy ist im Energissparmodus. Bitte deaktivieren Sie diesen Modus oder gehen Sie mit der App NICHT im Hintergrundmodus. Andernfalls könnte die App durch das Betriebssystem beendet werden und der Swap schlägt fehl.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Wechselkurs",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Auf Komodo aufgebaut",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Auf Komodo aufgebaut",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Kaufen",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "In Maker-Auftrag umwandeln, wenn kein match stattgefunden hat",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Swap gestartet, bitte warten!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Auftragsvermittlung läuft, bitte warten Sie {seconde} Sekunden!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "Warnung, Sie möchten Test-Coins ohne tatsächlichen Wert kaufen!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Tarnungs-PIN und Bio-Schutz können nicht gleichzeitig aktiviert werden.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Konflikt zwischen Carmo-PIN und Bio-Schutz.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Tarnungs-PIN ändern",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Tarnungs-PIN erstellen",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Wenn Sie die App mit der Tarnungs-PIN entsperren, wird ein gefälschtes NIEDRIGERES Guthaben angezeigt und die Konfigurationsoption Tarnungs-PIN ist in den Einstellungen NICHT sichtbar.",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "ungültiger Tarnungs-PIN",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Tarnungs-PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Tarnungs-PIN nicht gefunden",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Aus",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "An",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Tarnungs-PIN gespeichert",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Tarnungs-PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Neuen Tarnungs-PIN eingeben",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Tarnungs-PIN Einrichtung",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Tarnungs-PIN Einrichtung",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "stornieren",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Aktivierung abbrechen",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "stornieren",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Auftrag stornieren",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ok",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "ist ein Standard-Coin. Standard-Coins können nicht deaktiviert werden.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Kann nicht deaktiviert werden",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Kann nicht abgespielt werden",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEX-Tauschrate",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEX-Daten",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Die mit diesem Symbol gekennzeichneten Marktdaten (Kurse, Charts usw.) stammen aus Drittquellen (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEX-Kurs",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "PIN-Code ändern",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Nach Updates suchen",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Abmelden",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Seed-Phrase überprüfen",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "WEITER",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "ZURÜCK UND ERNEUT ÜBERPRÜFEN",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "{index} Wort eingeben",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "Ihr Seed ist wichtig - deshalb stellen wir Ihnen drei verschiedene Fragen, um sicherzustellen, dass dieser korrekt ist und Sie Ihr Wallet jederzeit problemlos wiederherstellen können.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "Was ist das {index}.Wort in Ihrer Seed?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "LASSEN SIE UNS IHREN SEED DOPPELT ÜBERPRÜFEN",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Chinesisch",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "Anfordern",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "KMD Prämie anfordern?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Zum Anzeigen klicken",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "In die Zwischenablage kopiert",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "In die Zwischenablage kopieren",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Schließen",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Fehlermeldung schließen",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Vorschau schließen",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Code:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Sie haben die maximale Anzahl an Assets ausgewählt",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName}-Münzen sind aktiviert",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName}-Münzen wurden erfolgreich aktiviert",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "{protocolName}-Münzen sind nicht aktiviert",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Löschen",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "keine aktivierten Coins",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Coin auswählen",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Demnächst...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "TX Details folgen in Kürze!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "Details folgen in Kürze!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "Provision",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "im Vergleich zum Durchschnitt. 24h CEX-Preis",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "im Vergleich zu CEX",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Bitte warten, ihre Wallet wird konfiguriert...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Bestätigen",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Tarnungs-PIN bestätigen",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Wollen Sie die Order wirklich stornieren?",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "Durch Klicken auf die folgenden Schaltflächen bestätigen Sie, dass Sie die \"EULA\" und die \"Allgemeinen Geschäftsbedingungen\" gelesen haben und diese akzeptieren",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Kennwort bestätigen",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "PIN-Code bestätigen",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Seed-Phrase bestätigen",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Verbindung wird hergestellt ...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Abbrechen",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Kontakt löschen",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Löschen",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "Möchten Sie den Kontakt {name} wirklich löschen?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Verwerfen",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Bearbeiten",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Beenden",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Änderungen verwerfen?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "Keine Kontakte gefunden",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Sichern",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Kontaktdetails",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Name",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Vertrag",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Umwandeln",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "URL konnte nicht gestartet werden",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "Konnte nicht importiert werden:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "Handeln",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "Wallet erstellen",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Kontakt erstellen",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "PIN erstellen",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Währung",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Währung",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Aktueller Wert:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Individuelle Gebühr",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "Individuelle Gebühr nur nutzen, wenn Sie wissen was darunter zu verstehen ist!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Benutzerdefinierte Seed-Phrasen sind möglicherweise weniger sicher und leichter zu knacken als eine generierte BIP39-konforme Seed-Phrase oder ein privater Schlüssel (WIF). Um zu bestätigen, dass Sie das Risiko verstehen und wissen was Sie tun, geben Sie \"{iUnderstand}\" im Kasten unten an.\n",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Datum",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Wallet entschlüsseln",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Löschen",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Deaktivierung bestätigen",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "Möchten Sie",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "von ihrem Portfolio entfernen? Alle offenen Aufträge werden storniert.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " wird ebenfalls deaktiviert",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Wallet löschen",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Wallet wird gelöscht...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "Erhalten Sie die Transaktionsgebühr {coinName}",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "Transaktionsgebühr für {coinName} senden",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "Handelsgebühr senden Transaktionsgebühr",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "Handelsgebühr",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "Details",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Deutsch",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Entwickler/in",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX ist für diesen Coin nicht verfügbar",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Deaktivieren Sie Screenshots/Vorschau",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Haftungsausschluss & AGB",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Erledigt",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Schließen Sie die App nicht. Für weitere Informationen tippen ...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Nicht mehr nachfragen",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "Ich möchte kein Kennwort",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW Sicherheit",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Dauer",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Kontakt bearbeiten",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Geben Sie die {abbr}  Adresse ein",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "Verschlüsselungskennwort darf nicht leer sein",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "Kennwort darf nicht leer sein",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Kontakt-Name darf nicht leer sein",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "Wallet-Name darf nicht leer sein",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Sie können {remains} weiterhin aktivieren, Ausgewählt: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Bitte aktivieren Sie Benachrichtigungen, um Updates zum Aktivierungsfortschritt zu erhalten.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Test-Coins aktivieren",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "Sie haben",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "Assets aktivert und versuchen",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "weitere zu aktivieren. Das Maximallimit beträgt",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ". Bitte deaktivieren sie welche, bevor neue aktiviert werden.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Es wurde versucht, zu viele Assets zu aktivieren",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Wallet verschlüsseln",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "Englisch",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Geben Sie ihren neuen PIN ein",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Geben Sie ihren alten PIN ein",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Bitte Kennwort eingeben um fortzufahren.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Geben Sie Ihren PIN-Code ein",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Geben Sie Ihre Seed-Phrase ein",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Sie müssen zuerst die Verkaufsmenge eingeben",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Guthaben unzureichend",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Ungültige Adresse",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Segwit-Adressen werden (noch) nicht unterstützt",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Nicht genug Gas - verwenden Sie mindestens {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Fehler, bitte versuchen Sie es erneut",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Fehler, bitte versuchen Sie es später",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "Wert ist zu hoch oder zu niedrig",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Bitte Daten eintippen",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Geschätzter Gesamtwert",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "Um abgeschlossen zu werden, {appCompanyLong}muss jede virtuelle Währungstransaktion, die mit dem erstellt wurde, bestätigt und im Ledger für virtuelle Währungen aufgezeichnet werden, das dem jeweiligen virtuellen Währungsnetzwerk zugeordnet ist. {appCompanyLong}Bei solchen Netzwerken handelt es sich um dezentrale Peer-to-Peer-Netzwerke, die von unabhängigen Dritten unterstützt werden, die sich nicht im Besitz, unter der Kontrolle oder unter der Kontrolle von ihnen befinden.\n{appCompanyLong}hat keine Kontrolle über virtuelle Währungsnetzwerke und kann und wird daher nicht sicherstellen, dass alle Transaktionsdetails, die Sie über unsere Dienste einreichen, im jeweiligen Netzwerk für virtuelle Währungen bestätigt werden. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionsdetails, die Sie über unsere Dienste übermitteln, durch das zur Bearbeitung der Transaktion verwendete virtuelle Währungsnetzwerk möglicherweise nicht abgeschlossen oder erheblich verzögert werden können. Wir garantieren nicht, dass das Wallet das Eigentum oder die Rechte an einer virtuellen Währung übertragen kann, und geben auch keine Garantie in Bezug auf den Titel.\nSobald Transaktionsdetails an ein virtuelles Währungsnetzwerk übermittelt wurden, können wir Ihnen nicht helfen, Ihre Transaktion oder Transaktionsdetails zu stornieren oder anderweitig zu ändern. {appCompanyLong}hat keine Kontrolle über ein Netzwerk für virtuelle Währungen und ist nicht in der Lage, Stornierungs- oder Änderungsanfragen zu bearbeiten.\nIm Falle eines Forks {appCompanyLong}kann es sein, dass wir Aktivitäten im Zusammenhang mit Ihrer virtuellen Währung nicht unterstützen können. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionen im Falle einer Fork möglicherweise nicht, teilweise, falsch abgeschlossen oder erheblich verzögert werden. {appCompanyLong}ist nicht verantwortlich für Verluste, die Ihnen ganz oder teilweise, direkt oder indirekt, durch einen Fork entstehen.\nIn keinem Fall {appCompanyLong}haften ihre verbundenen Unternehmen und Dienstleister oder ihre jeweiligen leitenden Angestellten, Direktoren, Agenten, Mitarbeiter oder Vertreter für entgangene Gewinne oder besondere, zufällige, indirekte, immaterielle oder Folgeschäden, unabhängig davon, ob sie auf Vertrag, unerlaubter Handlung, Fahrlässigkeit, verschuldensunabhängiger Haftung oder auf andere Weise beruhen, die sich aus oder in Verbindung mit der autorisierten oder unbefugten Nutzung der Dienste oder dieser Vereinbarung ergeben, auch wenn ein bevollmächtigter Vertreter {appCompanyLong}von darauf hingewiesen wurde, hat davon gewusst oder hätte von der Möglichkeit solcher Schäden bekannt. \nBeispielsweise (und ohne den Umfang des vorstehenden Satzes einzuschränken) dürfen Sie sich nicht für entgangene Gewinne, entgangene Geschäftschancen oder andere Arten von besonderen, zufälligen, indirekten, immateriellen oder Folgeschäden zurückfordern. In einigen Rechtsordnungen ist der Ausschluss oder die Beschränkung von Neben- oder Folgeschäden nicht zulässig, sodass die obige Beschränkung möglicherweise nicht für Sie gilt. \nWir sind Ihnen gegenüber nicht verantwortlich oder haftbar für Verluste und übernehmen keine Verantwortung für Schäden oder Ansprüche, die sich ganz oder teilweise, direkt oder indirekt ergeben aus: \n(a) Benutzerfehler wie vergessene Passwörter, falsch erstellte Transaktionen oder falsch eingegebene Adressen für virtuelle Währungen; \n(b) Serverausfall oder Datenverlust; \n(c) beschädigte oder anderweitig nicht funktionierende Wallets oder Wallet-Dateien; \n(d) unbefugter Zugriff auf Anwendungen; \n(e) alle nicht autorisierten Aktivitäten, einschließlich, aber nicht beschränkt auf den Einsatz von Hacking, Viren, Phishing, Brute-Forcing oder anderen Angriffsmethoden gegen die Dienste.\n\n",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Beispiel: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Sinnvoll",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Teuer",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Identisch mit CEX",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Wechselkurs:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "TAUSCHEN",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Exportieren",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Kontakte",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Bitte wählen Sie die Elemente aus, die in eine verschlüsselte Datei exportiert werden sollen.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Exportieren",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Hinweise",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Die Elemente wurden erfolgreich exportiert:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Swaps",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Exportieren",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Fehlgeschlagen",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Gefälschter Guthaben:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Häufig gestellte Fragen",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Fehler",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Anfrage an {coin} faucet senden...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "FAUCET",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Erfolg",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "Zeitüberschreitung der Anfrage",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Protokolldatei teilen",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Neuigkeiten",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Hier gibt es nichts",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} Neuigkeiten",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Mehr lesen...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Feed",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Newsfeed",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Aktualisierung der Nachrichten kann nicht fortgesetzt werden",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Nachrichten können nicht aktualisiert werden",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Newsfeed aktualisiert",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Bereits auf dem neuesten Stand",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Die Gebühren müssen bis zu {value} betragen.",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Alle",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Filter",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Alle Filter löschen",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Fehlgeschlagen",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "Von Datum",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Maker",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Coin erhalten",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Coin verkaufen",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Status",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Erfolgreich",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Taker",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "Bis Datum",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Taker/Maker",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Fingerabdruck",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Bitte warten Sie, bis der Vorgang abgeschlossen ist",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "QR-Code gefunden",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Französisch",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "Von",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "Wir synchronisieren zukünftige Transaktionen, die nach der Aktivierung in Verbindung mit Ihrem öffentlichen Schlüssel durchgeführt werden. Dies ist die schnellste Option und beansprucht am wenigsten Speicherplatz.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin}-Gebühr",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "Gas-Limit",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Bitte aktivieren Sie {coin}.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "Gas-Preis",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "Der allgemeine PIN-Schutz ist nicht aktiv.\nDer Tarnungsmodus ist nicht verfügbar.\nBitte aktivieren Sie den PIN-Schutz.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Wichtig: Sichern Sie Ihren Seed bevor Sie fortfahren!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "Die Transaktion wird ausgeführt. Bitte warten Sie",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Zum Portfolio gehen",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei muss bis zu {value} sein",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Hilfe",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Hilfe und Support",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Guthaben ausblenden",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Kennwort bestätigen",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Kennwort erstellen",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Aktuelles Kennwort",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Geben Sie Ihr Kennwort ein",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Geben Sie Ihren Seed ein",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Benennen Sie Ihr Wallet",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Kennwort",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "Verlauf",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "h",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Ungarisch",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Importieren",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Ungültiges Kennwort oder beschädigte Daten",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "Zu importierende Gegenstände:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Datei nicht gefunden",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Ungültige Swap-Daten. Bitte geben Sie eine gültige Swap-Status JSON-Datei an.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Importieren",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Bitte wählen Sie eine verschlüsselte Datei zum Importieren aus.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Öffnung...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Bitte wählen Sie eine einfache Textauslagerungsdatei zum Importieren aus.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Abbrechen",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ok",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Kennwort",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Einzigen Swap importieren",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Swaps importieren",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Einige Elemente wurden übersprungen",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Die Elemente wurden erfolgreich importiert:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Import von Swaps fehlgeschlagen",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Fehler beim Dekodieren der json-Datei",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Importieren",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Eingehende {coinName}-TXS-Schutzeinstellungen",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Verwenden Sie ein sicheres Kennwort und speichern Sie es nicht auf demselben Gerät",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "Der Swap kann nicht rückgängig gemacht werden und ist ein endgültiges Ereignis!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "Der Swap kann bis zu 60 Minuten dauern. Schließen Sie diese Anwendung NICHT!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Aus Sicherheitsgründen müssen Sie ein Kennwort für die Verschlüsselung ihres Wallets angeben.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} Guthaben reicht nicht aus, um die Handelsgebühr zu bezahlen",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "Die Mindestmenge, die für diesen Auftrag erforderlich ist, beträgt",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Unzureichendes Volumen",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Aktualisieren",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Internetverbindung wiederhergestellt",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Ungültige {coin}-Adresse",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "Swap kann nicht durchgeführt werden",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Details",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} ist nicht verfügbar :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "Ich habe verstanden",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Japanisch",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Koreanisch",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Sprache",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Letzte Transaktionen",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Rechtliches",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Weniger",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Vorsicht! Der Markt für {coinName} hat ein 24-Stunden-Handelsvolumen von weniger als 10.000 US-Dollar!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "Das Limit muss bis zu {value} betragen",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Wird geladen...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Auftragsbuch wird geladen...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "Bildschirm ist gesperrt",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "Bitte authentifizieren!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "Anmeldung",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Ausloggen",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Beim Beenden abmelden",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Abmelde-Einstellungen",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "Sind Sie sicher, dass Sie sich jetzt abmelden möchten?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "Minuten",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "Einen Auftrag erstellen",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Maker",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Auftrag stornieren",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Erstellt am",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Erhalten",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "Auftrags-ID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Durch diesen Auftrag wurden keine Swaps gestartet",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Preis",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Verkauf",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Durch diesen Auftrag gestartete Swaps",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Details des Maker-Auftrag",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Maker-Auftrag",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Marktplatz",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Chart",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Tiefe",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "Keine Anfragen gefunden",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "Keine Angebote gefunden",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "AUFTRAGSBUCH",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Details zum Auftrag",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "PREIS",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Bitte Coins auswählen",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Märkte",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "MÄRKTE",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Kennwörter müssen übereinstimmen",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Ändern",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Ihre allgemeine PIN und die Tarnungs-PIN sind identisch.\nDer Tarnmodus wird nicht verfügbar sein.\nBitte ändern Sie die Tarnungs-PIN.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "Ungültige PIN",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAX",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Max Auftragsvolumen:",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Neuigkeiten",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "DURCHBLÄTTERN",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "FEED DURCHBLÄTTERN",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "Von",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "SIE HABEN KEINE GESPEICHERTEN ARTIKEL",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "GESPEICHERT",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Memo",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Zusammenfassen",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Zusammengefasster Wert:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "ms",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "MIN",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Warnung: Durch das Minimieren der App auf iOS wird der Aktivierungsprozess abgebrochen.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "Min Auftragsvolumen:",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "m",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "Die Mindestmenge für den Kauf ist {number} {coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "Die Mindestmenge des Auftrags ist {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "Die Mindestmenge für den Verkauf ist {number} {coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "Muss größer sein als {minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Muss niedriger als die Verkaufsmenge sein",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Erforderliches Mindestvolumen",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Benutzerdefiniertes Mindestvolumen verwenden",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Bitte beachten Sie, dass Sie jetzt Mobilfunkdaten verwenden und die Teilnahme am P2P-Netzwerk von {appName} Internetverkehr verbraucht. Es ist besser, ein WiFi-Netzwerk zu verwenden, wenn Ihr mobiler Datentarif kostspielig ist.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Mehr Info",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "Mehr",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Aktivieren Sie {coin} und laden Sie zuerst Ihr Guthaben auf",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Menge",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Coin",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Verkaufen",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Abbrechen",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Bestätigen",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "{number} Auftrag/Aufträge erstellen:",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Erstellen",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Auftrag",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Aufträge",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "Gebühr",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Abbrechen",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Bitte geben Sie den gewünschten Fiat-Betrag ein:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Automatisch ausfüllen",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Bitte beheben Sie alle Fehler, bevor Sie fortfahren",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Ungültige Menge",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Ungültige Verkaufsmenge",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "Nicht genug {coin} vorhanden, um die Gebühren zu zahlen. MIN Guthaben beträgt {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} Guthaben ist zu niedrig",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "Max Verkaufsmenge beträgt",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "Der Mindestbetrag, den Sie erhalten, beträgt",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "Min Verkaufsmenge beträgt",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Erhalten:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Verkaufen:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Mehrfach",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Menge erhalten",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Preis/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Netzwerkgebühr",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "neues Konto",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Neues Konto",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Newsfeed",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Neuer Wert:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "Weiter",
-  "@next": {
-    "type": "text"
-  },
-  "no": "Nein",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "Keine Neuigkeiten - bitte versuchen Sie es später erneut!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "Kein Coin gefunden",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Kein Guthaben",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "Kein Guthaben vorhanden - bitte zuerst einzahlen.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "Keine Internetverbindung",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "Keine Elemente ausgewählt",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "Keine Elemente ausgewählt",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "Keine übereinstimmenden Aufträge gefunden",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Keiner",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "Der Wert muss numerisch sein",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Bitte geben Sie die {coinName} Menge ein.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Klicken Sie hier, um einen Auftrag zu erstellen",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "Keine Aufträge, bitte gehen Sie zum Handel.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "Keine anforderungsfähigen Belohnungen",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "Keine Belohnung verfügbar. Bitte versuchen Sie es in 1 Stunde erneut.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "Diese Münze gibt es nicht",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "Kein Verlauf vorhanden",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "Nicht genug {coin} für die Transaktion!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "Nicht genügend Guthaben für Gebühren - handeln Sie einen kleinere Menge",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Hinweis: Übereinstimmende Aufträge können nicht mehr storniert werden.",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Notiz hinzufügen",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Notiz",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Nichts gefunden",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "{sell}/{buy} swap wurde erfolgreich abgeschlossen",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Swap abgeschlossen",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} swap fehlgeschlagen",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Swap fehlgeschlagen",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} swap gestartet",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Neuer swap gestartet",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Swap-Status geändert",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} swap ist abgelaufen(Zeitüberschreitung)",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Swap ist abgelaufen(Zeitüberschreitung)",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "Du hast eine {coin} Transaktion erhalten!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Eingehende Transaktion",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "Keine Transaktionen vorhanden",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} Assets",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Offizielle Pressemitteilung",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ok",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Löschen",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Alte Protokolle",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Genutzter Speicher",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Fehlermeldung öffnen",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Optional",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Weniger",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "Mehr",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Alle {coin} Aufträge werden storniert.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Auftrag erstellt",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Auftrag erfolgreich erstellt",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Adresse",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Abbrechen",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Sinnvoll: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Teuer: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "für",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Identisch mit CEX",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "min.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Preis",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Erhalten",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Auswählen",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Verkäufe",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Durch einmaliges antippen öffnen Sie die Details, durch langes antippen wählen Sie einen Auftrag",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Ausgegeben",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Details",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% ausgefüllt",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Auftrag gematched!",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Auftrag wird gematched",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "Aufträge",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Aktiv",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "Verlauf",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "({coin}) Menge",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "({coin}) Preis",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "({coin}) Gesamt",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Auftrag",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Unbekannter Auftragstyp",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Überschreiben",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "Dies ist Ihr eigener Auftrag!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Bezahlt aus dem Guthaben:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Bezahlt aus dem eingegangenen Volumen:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Bezahlt mit",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "Das Kennwort muss mindestens 12 Zeichen enthalten, davon ein Kleinbuchstabe, ein Großbuchstabe und ein Sonderzeichen.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "In Ihrem Wallet werden Ihre vergangenen Transaktionen angezeigt, die nach dem angegebenen Datum getätigt wurden.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Bezahlen",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Akzeptieren Sie diese Transaktion?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "Nach Adresse",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Menge:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Coin:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Abbrechen",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Zahlung angefordert",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} ist nicht aktiviert. Bitte aktivieren und erneut versuchen.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Auftrag platzieren",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "In voller Lautstärke abspielen",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Bitte fügen Sie einen Coin hinzu",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Bitte starten Sie die App neu, um es erneut zu versuchen, oder drücken Sie die Schaltfläche unten.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Portfolio",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Unterstützt von Komodo",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "Preis",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Privater Schlüssel",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Private Schlüssel",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Bestätigungen",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Individuelle Schutzeinstellungen verwenden",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "AUS",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "AN",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Achtung, dieser Atomic Swap ist nicht durch dPoW geschützt.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Öffentlicher Schlüssel (Pubkey)",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "QR-Code-Scanner",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Speichern Sie meine privaten Schlüssel?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "Auf welchen Geräten kann ich {appName} verwenden?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "Wie unterscheidet sich der Handel auf {appName} vom Handel auf anderen DEXs?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "Wie lange dauert ein Atomic Swap?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "Muss ich für die Dauer des Swaps online sein?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "Wie werden die Gebühren für {appName} berechnet?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Bieten Sie einen Support für die Nutzer an?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Gibt es länderspezifische Einschränkungen?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Wer steckt hinter {appName}?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "Ist es möglich, meine eigene White-Label-Börse auf {appName} zu entwickeln?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "Es ist eine neue Ära! Wir haben unseren Namen offiziell von „AtomicDEX“ in „Komodo Wallet“ geändert.",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "ERHALTEN",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Erhalten",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Wir empfehlen die Offline-Sicherung.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Deaktivieren",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Angeforderter Handel",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "LÖSCHEN",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Formular zurücksetzen",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "WIEDERHERSTELLEN",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Erneuter Versuch, alle Münzen zu aktivieren...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Erneuter Versuch, alle zu aktivieren",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Belohnungen beantragen",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Stornieren",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "Transaktion ist in Bearbeitung",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "in Bearbeitung",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO-Menge ist geringer als 10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Eine Stunde ist noch nicht vergangen",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 Stunde",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Ok",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Belohnungsstatus:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "Lesen Sie mehr über KMD-Belohnungen für aktive Nutzer",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Empfangen",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Erfolgreich! {amount} KMD erhalten",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Fiat",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Belohnungen,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Status",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Verbleibende Zeit",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Informationen zu den Belohnungen:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO Menge,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} Tag(e)",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}h {minutes}m",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}min",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Informationen zu den Belohnungen",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Russisch",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Zusammenfassung speichern",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Scrollen Sie nach unten, um fortzufahren...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Coin suchen",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Alle Avax tokens auswählen",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Alle BEP tokens auswählen",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Wählen Sie alle Cosmos Network aus",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Alle ERC tokens auswählen",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Alle ETC tokens auswählen",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Alle Fantom tokens auswählen",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Alle HecoChain tokens auswählen",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Alle Harmony tokens auswählen",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Wählen Sie alle Iris-Netzwerke aus",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Alle Kucoin tokens auswählen",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Alle Moonriver tokens auswählen",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Alle Polygon tokens auswählen",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Alle QRC tokens auswählen",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Alle SmartBCH tokens auswählen",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Wählen Sie alle SLP-Tokens aus",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Alle SmartChains auswählen",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Alle Test Assets auswählen",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Alle Ubiq coins auswählen",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Alle UTXO coins auswählen",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Wählen Sie alle ZHTLC-Münzen aus",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Ticker suchen",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Sicherheit",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Seed-Phrase",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Ihr neuer Seed",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "Klicken Sie hier, um {amount} Aufträge zu sehen",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "Transaktionsverlauf anzeigen",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Coin auswählen",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Wählen Sie die Coins aus, die Sie Ihrem Portfolio hinzufügen möchten.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Coins aktivieren:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Wählen Sie den zu kaufenden Coin aus",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Wählen Sie den zu verkaufenden Coin",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Wählen Sie ein Datum aus",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Ausgewählter Auftrag:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Datei auswählen",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Sprache wählen",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Wählen Sie eine Bezahlart",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Verkaufen",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Achtung, Sie sind bereit, Testmünzen OHNE realen Wert zu verkaufen!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "SENDEN",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Sind Sie sicher, dass Sie die",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "Wallet löschen möchten?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Wenn ja, stellen Sie sicher, dass Sie",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "Ihren Seed sichern,",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "um Ihre Wallet in Zukunft wiederherzustellen.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Sprachen",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Einstellungen",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "KENNWORT EINRICHTEN",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Teilen",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "Meine {coinName} Adresse:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "Nach vergangenen {coin}-Transaktionen suchen?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Adresse anzeigen",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Details anzeigen",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "Es werden {count} von {maxCount} Bestellungen angezeigt.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "MEINE AUFTRÄGE ANZEIGEN",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Mit Kennwort anmelden",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Kennwort vergessen? Wallet mit der Seed wiederherstellen",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Einfach",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Aktivieren",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Bitte geben Sie die {coin} Menge an, die Sie kaufen möchten",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Kaufen",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Schließen",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "Maximum an aktivierbaren Coins ist {maxCoins}. Bitte deaktivieren Sie welche.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} ist nicht aktiviert!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Erhalten",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Bitte geben Sie die {coin} Menge an, die Sie verkaufen möchten",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Verkaufen",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Senden",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Weniger anzeigen",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Mehr anzeigen",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "{coin} kann nicht aktiviert werden",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Überspringen",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Ablehnen",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Sound",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Wählen Sie bitte eine mp3- oder wav-Datei aus. Wir spielen es, wenn {description}.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "Abgespielt, wenn {description}",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Sounds",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Verstanden, nicht mehr zeigen",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Sound",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Sound-Einstellungen",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "Während des Swap-Prozesses und wenn ein aktiver Maker-Auftrag erteilt wird, hören Sie akustische Benachrichtigungen.\nDas Atomic-Swap-Protokoll erfordert, dass die Teilnehmer für einen erfolgreichen Handel online sind, und akustische Benachrichtigungen helfen dabei.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Beachten Sie, dass Sie Ihre eigenen Sounds in den Anwendungseinstellungen festlegen können.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Spanisch",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Startdatum",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Starten Sie den Tausch",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Schritt",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Erfolgreich!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Support",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Wenn Sie Fragen haben oder glauben, dass Sie ein technisches Problem mit der {appName} App gefunden haben, können Sie dies melden und Unterstützung von unserem Team erhalten.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "swap",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Aktuell",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "TAUSCH-DETAILS BESTÄTIGEN",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Schätzung",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Swap fehlgeschlagen",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Bitte aktivieren Sie zuerst {coin} und laden Sie Ihr Guthaben auf",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "Das {coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen. {coin} {amount} sind erforderlich.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Swap läuft",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "Fortschrittdetails",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "Gestartet",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Swap erfolgreich",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Gesamt",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "Swap UUID",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Thema ändern",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Ab dem angegebenen Datum synchronisieren",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Synchronisierung durch Setzlingsaktivierung",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Synchronisieren Sie neue Transaktionen",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "Welche {name}-Transaktionen möchten Sie synchronisieren?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Taker",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Taker-Auftrag",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Zeitüberschreitung",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "PASSWORT ERSTELLEN",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Auftrag ausgewählt",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "An",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "An Adresse:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "Sie haben",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "Assets aktiviert. Max Limit aktivierbarer Assets ist",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". Bitte deaktivieren Sie welche, bevor Sie neue hinzufügen.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Zu viele Assets aktiviert",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Gesamtgebühren:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "HANDEL",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "SWAP ABGESCHLOSSEN!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "HANDELSDETAILS",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Handelsgebühren konnten nicht berechnet werden",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "Handelsgebühr:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Handelsart:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Transaktionsadresse",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Transaktion ausgeblendet",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Diese Transaktion wurde aufgrund eines möglichen Phishing-Versuchs ausgeblendet.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "Wenn auch dann noch einige Coins nicht aktiviert sind, versuchen Sie, die App neu zu starten.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Türkisch",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Block",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Bestätigungen",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "BESTÄTIGT",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Gebühr",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "Transaktionsgebühr:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "Transaktions ID",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Verbleibende Transaktionen: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Zu viele Anfragen.\nDas Limit für Anfragen zur Transaktionshistorie wurde überschritten.\nBitte versuchen Sie es später noch einmal.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "UNBESTÄTIGT",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Ukrainisch",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "Freischalten",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Geldmittel freischalten",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "{amnt} Geldmittel wurden erfolgreich freigeschaltet - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "Nicht verwendbar",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Neue Version verfügbar",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Nach Updates suchen...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "Sie nutzen Version {version}",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Neue Version verfügbar. Bitte updaten.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Version {version} verfügbar. Bitte updaten.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Update verfügbar",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Vorerst überspringen",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "{appName} Update",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Update",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Bereits auf dem neuesten Stand",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Nicht genug Guthaben für die gescannte",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "Zahlungsaufforderung.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Unzureichendes Guthaben",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Wert:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "Version",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Explorer",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Seed & Private Schlüssel",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Volumen",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "Wallet-Name existiert bereits",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "Wallet-Name darf maximal 40 Zeichen lang sein",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Nur Wallet",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "Achtung!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ok",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Achtung - in besonderen Fällen enthalten diese Protokolldaten sensible Informationen, die dazu verwendet werden können, Coins aus fehlgeschlagenen Swaps auszugeben!",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "Wir konnten {coinAbbr} nicht aktivieren",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "Wir konnten {coinAbbr} nicht aktivieren.\nBitte starten Sie die App neu, um es erneut zu versuchen.",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} ist eine Multi-Coin-Wallet der nächsten Generation mit nativer DEX-Funktionalität der dritten Generation und mehr.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "AUF GEHT'S!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "WILLKOMMEN",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "Wallet",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "Nach Fertigstellung werden Sie zur Portfolio-Seite weitergeleitet.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Dies dauert eine Weile und die App muss im Vordergrund bleiben.\nDas Beenden der App während der Aktivierung kann zu Problemen führen.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Auszahlung",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "Sie haben {appName} zuvor den Zugriff auf die Kamera verweigert.\nBitte ändern Sie die Kamerazugriffsrechte manuell in den Telefoneinstellungen, um mit dem QR-Code-Scan fortzufahren.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Zugriff verweigert",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Auszahlung bestätigen",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "{amount} {coinName} ABHEBEN",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "Sie versuchen, einen QR-Code für eine Zahlung zu scannen",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "aber Sie sind auf dem",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "Auszahlungs-Bildschirm",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Falscher Coin",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "Die Kennwörter stimmen nicht überein. Bitte versuche es erneut.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Ja",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Sie senden:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "Sie haben einen neuen Auftrag, der  einem bestehenden Auftrag zugeordnet werden soll",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "Sie haben einen aktiven Swap in Arbeit",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "Sie haben einen Auftrag, dem neue Aufträge zugeordnet werden können",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "Ihr Wallet",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "Sie erhalten {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Sie erhalten:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,3726 +1,5478 @@
 {
-  "@@locale": "es",
-  "accepteula": "Aceptar EULA",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Aceptar TERMINOS y CONDICIONES",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Activar protección biométrica",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "Activar la protección con PIN",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "¿Activar monedas {protocolName}?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de {appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Acceso Denegado",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "Previamente le has negado a {appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "BIENVENIDO",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "wallet",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "¡VAMOS A PREPARARNOS!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "{appName} actualizar",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "Estás usando la versión {version}",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Comprobando actualizaciones...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Ya está actualizado",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Nueva versión disponible",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Actualizar",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Saltar por ahora",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Actualización disponible",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Nueva versión disponible. Por favor actualice.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "Versión {version} disponible. Por favor actualice.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Ayuda",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Ayuda y apoyo",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Preguntas frecuentes",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Apoyo",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación {appName}, puede informar y obtener asistencia de nuestro equipo.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "¿Guardás mis llaves privadas?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "¡No! {appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "¿En qué se diferencia el comercio en {appName} del comercio en otros DEX?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n{appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "¿Cuánto tiempo toma cada intercambio atómico?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a {appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "¿Necesito estar en línea durante la duración del intercambio?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "¿Cómo se calculan las tarifas de {appName}?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "Hay dos categorías de tarifas a tener en cuenta al intercambiar en {appName}.\n\n1. {appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "¿Ofrecen soporte al usuario?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "¡Sí! {appName} ofrece soporte a través de <a href=\"{link}\">{appCompanyShort} {name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "¿Tiene restricciones de país?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "¡No! {appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "¿Quién está detrás de {appName}?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} está desarrollado por el equipo de {appCompanyShort}. {appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "¿Es posible desarrollar mi propio intercambio con {appName}?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de {appName} siempre está lista para ayudar!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "¿En qué dispositivos puedo usar {appName}?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Informacion",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Noticias",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Leer más...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Nada aquí",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Fuente de noticias actualizada",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Descartar",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Noticias",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Duración",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "No se puede obtener la actualización de noticias",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "No se puede continuar con la actualización de noticias",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Ya está actualizado",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Fecha",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} noticias",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "Crear numero PIN",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "Ingresa tu numero PIN",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "acceso",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "nueva cuenta",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Nueva Cuenta",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "¡Activado {name} con éxito!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Conectando...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Activar moneda",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} activos",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Ingrese su Semilla de 12 palabras",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Ejemplo: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "Confirmar",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "La carga de su batería es crítica ({batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "La carga de la batería es inferior al {batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Comprar",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Vender",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "Mi {coinName} dirección:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Retirar",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "El valor es demasiado alto o bajo",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Cantidad",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Dirección de los destinatarios",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "RETIRAR {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Confirmar Retiro",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Algo salió mal. Vuelva a intentarlo más tarde.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Cerrar",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "Confirmar frase semilla",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Tu nueva frase semilla",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Recomendamos almacenarlo fuera de línea.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "próximo",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "Confirmar código PIN",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Configuración de PIN de camuflaje",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Confirmar PIN de camuflaje",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Error, inténtalo de nuevo",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Ajustes",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Seguridad",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "Activar la protección con PIN",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Desactivar capturas de pantalla/vista previa",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "La pantalla está bloqueada",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "Cambiar código PIN",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Cerrar sesión",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "MAXIMO",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "Min",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Tarifas totales:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Pagado del saldo:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Modo de comercio:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Omitir",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Unir",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Sobrescribir",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Valor actual:",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Nuevo valor:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Valor combinado:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Guardar combinado",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "Ya existe",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Sencillo",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Avanzado",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Pagado del volumen recibido:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Cantidad a Vender",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Usted recibirá:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "Seleccione la moneda que desea VENDER",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "Seleccione la moneda que desea COMPRAR",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "intercambio",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Intercambio emitido, por favor espere!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "Ordermatch en curso, ¡espere {seconde} segundos!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Tarifa de red",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "cuota de comisión",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Portfolio",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Verificar",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Valor total estimado",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Selecciona tu forma de pago",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Volumenes",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Haga su pedido",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "Próximamente...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Mercado",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Usted está enviando:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Código:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Valor:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Pagado con",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "Por favor ingrese datos",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "No hay suficiente equilibrio",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feesError": "Las tarifas deben ser de hasta {value}",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "No es una dirección válida",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Las direcciones de Segwit no son compatibles (todavía)",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "Hacia:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "RECIBIR",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "ENVIAR",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Llave Publica",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "back",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "Cancelar",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "detalles",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Sí",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "No",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Nota: el pedido emparejado no se puede cancelar de nuevo",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "No vuelvas a preguntar",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Cancelar orden",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "¿Está seguro de que desea cancelar el pedido?",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "ingastable",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "Detalles de TX próximamente!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "historia",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "intercambiar",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "¡Detalles muy pronto!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Triangulación de órdenes",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Orden Triangulada",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Intercambio en curso",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Intercambio exitoso",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Se acabó el tiempo",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Convertir",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "Intercambio fallido",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Error, intente más tarde",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Últimas transacciones",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "Obteniendo transacción, por favor espere",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Terminando, por favor espera.",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Compartir archivo de registro",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Cargando libro de ordenes...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "afirmar",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "¿Reclamar su recompensa KMD?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "¡Éxito!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Cargando...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Transacciones restantes: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": " El saldo de {abbr} no es suficiente para pagar la tarifa de negociación",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Noticias",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Noticias",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "Copiado al portapapeles",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "Desde",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "Para",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "CONFIRMADO",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "INCONFIRMADO",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Bloque",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Confirmaciones",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Tarifa",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "ID de transacción",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Memorándum",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "No historia.",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "INTERCAMBIO",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "RESETEAR",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Restablecer formulario",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "¡CAMBIO COMPLETADO!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Paso",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "DETALLES INTERCAMBIO",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Comercio solicitado",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "Intercambiar UUID",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "NAVEGAR",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "GUARDADO",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaNotSavedDescription": "NO TIENES ARTÍCULOS GUARDADOS",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "NAVEGAR RSS",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "By",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "¡Por favor, autentícate!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "Sin transacciones",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Hecho",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Activar monedas:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Seleccione las monedas que desea agregar a su cartera.",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "No hay noticias. Vuelva a consultar más tarde.",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "¡La solicitud de intercambio no se puede deshacer y es un evento final!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "CONFIRMAR DETALLES DE CAMBIO",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Volumen mínimo requerido",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "Usar volumen mínimo personalizado",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "El valor debe ser numérico.",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Debe ser menor que el monto de venta",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "Debe ser mayor que {minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "Comprobar la frase inicial",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "¿Cuál es la palabra {index} en su frase inicial?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "Introduzca la palabra {index} ",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "SEGUIR",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "VOLVER Y VERIFICAR DE NUEVO",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Explorador",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Activar protección biométrica",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Permitir semilla personalizada",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "¡Advertencia!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "Entiendo",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"{iUnderstand}\" en el cuadro a continuación.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Ingresa tu contraseña",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "Su billetera",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "¿Olvidó la contraseña? Restaurar billetera desde semilla",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Iniciar sesión con contraseña",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Ingrese su frase inicial",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "Las contraseñas no coinciden. Inténtalo de nuevo.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Nombra tu billetera",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Confirmar contraseña",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "no quiero una contraseña",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "ESTAS SEGURO?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Utilice una contraseña segura y no la almacene en el mismo dispositivo",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "CONFIGURAR UNA CONTRASEÑA",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "CREAR UNA CARTERA",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "RESTAURAR",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Clave",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Crear contraseña",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Confirmar contraseña",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Contraseña actual",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Configuración de cierre de sesión",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Cerrar sesión al salir",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Eliminar Billetera",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Borrar",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Estás seguro de que quieres eliminar",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "billetera?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Si es así, asegúrese de",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "guardar su frase inicial.",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "Para restaurar su billetera en el futuro.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Respaldo",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "version",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Semilla y Claves Privadas",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "Frase Semilla",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Llaves Privadas",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Llave Privada",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Por favor ingrese su contraseña para continuar.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "Copiar al portapapeles",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "desbloquear",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "Desbloqueó con éxito {amnt} fondos - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Desbloquear fondos",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "No hay pedidos, por favor vaya al comercio.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Ingrese la cantidad de {coinName}.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "Tipo de cambio",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Recibir",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "hacer un pedido",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "INTERCAMBIO",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "ordenes",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Seleccionar moneda",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗¡Precaución! ¡El mercado de {coinName} tiene un volumen de negociación de menos de $ 10k las 24 horas!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Seleccione el idioma",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Sin Fondos",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "No hay fondos disponibles, por favor deposite.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Ir al portafolio",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Haga clic para crear un pedido",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Volumen insuficiente",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "El volumen mínimo requerido por este pedido es",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Pedido creado",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Pedido creado con éxito",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "Mostrar mis pedidos",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "La cantidad mínima para vender es {number} {coinName}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "CREA UNA CONTRASEÑA",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "La cantidad mínima para comprar es {number}{coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "La cantidad mínima para vender es {number}{coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "El monto mínimo del pedido es {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Primero debe ingresar el monto de la venta",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Billetera cifrada",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Billetera de descifrado",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "No hay suficiente saldo para las tarifas: opere con una cantidad menor",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "Sin conexión a Internet",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Construido en Komodo",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Por favor agregue una moneda",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "Conexión a Internet restaurada",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Actualizar",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Legal",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Descargo de responsabilidad y condiciones de servicio",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "Aceptar EULA",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "Aceptar TERMINOS y CONDICIONES",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "Al hacer clic en los botones a continuación, confirma haber leído el 'EULA' y los 'Términos y condiciones' y acepta estos",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": " tarifa{coin} ",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "¡No hay suficiente {coin} para la transacción!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Activa {coin}.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "Recibirás {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "Haga clic para ver {amount} pedidos",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Clic para ver",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "price",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "volumen máximo",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "Configurando su billetera, por favor espere...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Pedido seleccionado",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "tarifa de transacción:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "tarifa de negociación:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "El saldo de {coin} no es suficiente para pagar las tarifas de transacción.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": " El saldo de{coin} no es suficiente para pagar las tarifas de transacción. {coin} {amount} obligatorio.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "No se puede continuar con el intercambio",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Mostrar detalles",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Tipo de cambio:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Orden seleccionado:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "Volumen mínimo de pedido:",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Volumen máximo de pedidos:",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Detalles",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Activa {coin} y recarga el saldo primero",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Error al calcular las tarifas comerciales",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Desactivar",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Solo billetera",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "El nombre de la billetera no debe estar vacío",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "El nombre de la billetera debe tener un máximo de 40 caracteres",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "El nombre de la billetera ya está en uso",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX no está disponible para esta moneda",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Buscar una moneda",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Seleccione todos los SmartChains",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Seleccionar todos los activos de prueba",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Seleccionar todos los tokens ERC",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Seleccionar todos los tokens SLP",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Seleccionar todo Cosmos Network",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Seleccionar todo Iris Network",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Seleccionar todos los tokens de Kucoin",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Seleccionar todas las fichas de armonía",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Seleccionar todos los tokens ETC",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Seleccione todos los tokens SmartBCH",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Seleccionar todos los tokens de Avax",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Seleccionar todas las monedas Ubiq",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Seleccionar todos los tokens BEP",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Seleccione todas las fichas de polígono",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Seleccionar todos los tokens QRC",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Seleccionar todos los tokens de HecoChain",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Seleccione todas las monedas ZHTLC",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Seleccionar todas las fichas de Fantom",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Seleccione todas las fichas de Moonriver",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Costo de Transacción Personalizado",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "Limite de Gas",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "Precio de Gas",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "¡Solo use tarifas personalizadas si sabe lo que está haciendo!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Seleccione todas las monedas UTXO",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Construido en Komodo",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Desarrollado por Komodo",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "No hay suficiente gas: usa al menos {gas} Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Todos los pedidos de {coin} serán cancelados.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Confirmar desactivación",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "¿Quieres eliminar",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "de tu cartera? Todos los pedidos no emparejados serán cancelados.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " también se desactivará",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "No se puede deshabilitar",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ok",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "Compartir",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos.",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Ingrese su antiguo PIN",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Ingrese su nuevo PIN",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "autenticar",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Idiomas",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "Inglés",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Francés",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Alemán",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Chino",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Ruso",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Japonés",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Turco",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Húngaro",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "Español",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Coreano",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Ucranio",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "GRIFO",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Éxito",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Error",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "Tiempo de espera agotado",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "Enviando solicitud a la llave {coin}...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "Opcional",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Sonido",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "Juega a todo volumen",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Comprador",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "tiene un pedido nuevo que está tratando de coincidir con un pedido existente",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Vendedor",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "tiene un pedido con el que pueden coincidir nuevos pedidos",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Activo",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "tienes un intercambio activo en curso",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Fallido",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "un intercambio falla",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Aplausos",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "un intercambio se ejecuta hasta su finalización",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "no puedo escuchar eso",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando {description}.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "Jugado cuando {description}",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Sonidos",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Entendido, no lo muestres más.",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Ajustes de sonido",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Sonido",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Mercados",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "MERCADOS",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "PRECIO",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "LIBRO DE ORDENES",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "Gráfico",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Profundidad",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Precio",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Ventas",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "for",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "min.",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Direccion",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "Expediente: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "Caro: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "Idéntico a CEX",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Recibir",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Gastar",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "Esta es tu propia orden!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Por favor seleccione monedas",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Seleccionar moneda",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "No hay monedas activas",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Remover",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "Precio ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "Cantidad ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "Total ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "No se encontraron ofertas",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "No se encontraron solicitudes",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Detalles del Pedido",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Algo salió mal. Vuelve a intentarlo más tarde.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Información de recompensas",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "Obtenga más información sobre las recompensas para usuarios activos de KMD",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Cancelar",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Recibir",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "No hay recompensas reclamables",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Información de recompensas:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO\ncantidad,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "Recompensas,\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "Fiat",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Tiempo\nrestante",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Estado",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Estado de recompensas:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "Ok",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} dias(s)",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}h {minutes}m",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}min",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "¡Éxito! {amount} KMD recibido.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "Cantidad de UTXO inferior a 10 KMD",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "procesando",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "La transacción está en curso",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 hora",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Aún no ha pasado una hora",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Reclama tus recompensas",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "Ver historial de transacciones",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Volviendo a intentar activar todas las monedas...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "Se le redirigirá a la página del portafolio al finalizar.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "No pudimos activar {coinAbbr}",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Reinicie la aplicación para volver a intentarlo o presione el botón a continuación.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Vuelva a intentar activar todo",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "No pudimos activar {coinAbbr}.\nReinicie la aplicación para volver a intentarlo.",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} no está disponible :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Multi",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Corrija todos los errores antes de continuar",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Crear",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Orden",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Ordenes",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Moneda",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Vender:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Vender",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Cantidad",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Recibir:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "Precio/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Recibir Cntd.",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Ingrese la cantidad de dinero para recibir:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "Cancelar",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Autollenarl",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "costo",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "No hay suficientes {coin} para pagar las tarifas. El saldo MÍN es {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "Crear {number} pedido(s):",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "Cancelar",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Confirmar",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Cantidad de venta no válido",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "La cantidad máxima de venta es",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "La cantidad mínima de venta es",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Monto invalido",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiActivateGas": "Active {coin} y añada saldo primero",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": " El saldo de{coin} es demasiado bajo",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "La cantidad mínima recibida es",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Directorio",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Directorio",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Detalles de contacto",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "La libreta de direcciones está vacía",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Solo mostrar contactos con direcciones {title}",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Crear Contacto",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "Nombre",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Editar contacto",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "Cancelar",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Guardar",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Descartar",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Salir",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Descartar tus cambios?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Añadir Direccion",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Seleccionar Moneda",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Buscar teletipo",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Borrar Contacto",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "¿Está seguro de que desea eliminar el contacto {name}?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "Borrar",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "No se encontraron contactos",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Editar",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Nada Encontrado",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "No hay tal moneda",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "No puede enviar fondos a la dirección {abbr} porque {abbr} no está activado. Por favor, vaya a la cartera.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Ok",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "El nombre del contacto no puede estar vacío",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "Introduzca la dirección {abbr} ",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Camuflajear el PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Camuflajear PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "Activado",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Desactivado",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "PIN Invalido",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Cambiar",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Conflicto entre PIN de camuflaje y bioprotección.",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Cantidad de saldo falso:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "PIN de camuflaje no encontrado",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Crear PIN de camuflaje",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "PIN de camuflaje guardado",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "PIN de camuflaje no válido",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Cambiar PIN de camuflaje",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Configuración de PIN de camuflaje",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Ingrese el nuevo PIN de camuflaje",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "ACTIVADO",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "DESACTIVADO",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Confirmaciones",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Seguridad de Komodo dPoW",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Usar configuraciones de protección personalizadas",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Advertencia, este intercambio atómico no está protegido por dPoW.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "Convertir a Vendedor si no coincide",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "Tasa de Cambio CEX",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Expediente",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Caro",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "Identico a CEX",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "comparable a CEX",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "en comparación con el promedio Precio CEX 24h",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Activo",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "Historial",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Detalles",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Abra detalles con un solo toque y seleccione Ordenar con un toque largo",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "Cancelar",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Seleccione",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "No se encontraron pedidos coincidentes",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Orden de Vendedor",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Orden de Comprador",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Actual",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "Estimado",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "Iniciado",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Total",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "Detalles del Progreso",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Cerrar mensaje de error",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Abrir mensaje de error",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Transaccion entrante",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "¡Ha recibido una transacción de {coin}!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "Intercambio completado",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": " El intercambio de{sell}/{buy} se completó con éxito",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "Intercambio fallido",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} intercambio fallido",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Se agotó el tiempo de intercambio",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} intercambio se agotó",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Cambio de estado cambiado",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Nuevo intercambio iniciado",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} intercambio iniciado",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Idioma",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Moneda",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Ocultar saldos",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Cambiar Tema",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "data de CEX",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Buscar actualizaciones",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "¿Estás seguro de que quieres cerrar sesión ahora?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Moneda",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "ms",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "m",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "Minutos",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "h",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "Mas",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "menos",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Registros antiguos",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Borrar",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Eliminando billetera...",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Espacio usado",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Ok",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Cerrar prevista",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "Cancelar",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "Desplácese hacia abajo para continuar...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Desarrollador",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Habilitar monedas de prueba",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Detalles del pedido del fabricante",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Vender",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Recibir",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Precio",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Cancelar orden",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "ID de Orden",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "Createdo en",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Este pedido no inició intercambios",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "Intercambios iniciados por este pedido",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% llenado",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Nota",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Añadir Nota",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "Importar",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Importar un Intercambio",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Exportar",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "Importar",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Importar Intercambio",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Exportar",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Seleccione elementos para exportar a un archivo cifrado.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Seleccione el archivo cifrado para importar.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Seleccione el archivo de intercambio de texto sin formato para importar.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Abriendo...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "Elementos a importar:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Notas",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Contactos",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Intercambios",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Nada Encontrado",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Exportar",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "Importar",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "La contraseña de cifrado no puede estar vacía",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "La contraseña no puede estar vacía",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "Las contraseñas deben coincidir",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "No hay artículos seleccionados",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "No hay artículos seleccionados",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Seleccione Archivo",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Archivo no encontrado",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Huella dactilar",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Clave",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "Cancelar",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Ok",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "Los elementos se han exportado correctamente:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "Los elementos se han importado correctamente:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Contraseña no válida o datos dañados",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Error al decodificar el archivo json",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Orden",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Orden desconocida",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "No se pudo importar:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Se han saltado algunos elementos",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "No se pudo importar el intercambio",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "Activando {coinName}",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "No cierres la aplicación. Toca para obtener más información...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "Activación de {coinName}",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "Las monedas {protocolName} están activadas",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "Las monedas {protocolName} no están activadas",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName} monedas activadas con éxito",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} Activación en curso",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "¿Activar monedas {protocolName}?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Más información",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Mostrar dirección",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Esta transacción fue ocultada debido a un posible intento de phishing.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "Dirección de transacción",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "Transacción oculta",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "No se pudo iniciar la URL",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "Escáner de código QR",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "Código QR encontrado",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Contrato",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Iniciar intercambio",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Ninguno",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "Tasa CEX",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Configuración de protección de txs entrantes de {coinName}",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "Mostrando {count} de {maxCount} pedidos.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "Menos",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "Más",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "basado en {coinName1}/{coinName2}",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "enviar tarifa comercial tarifa de transacción",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "tarifa comercial",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "enviar tarifa de transacción de {coinName}",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "recibir tarifa de transacción de {coinName}",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Filtro",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Estado",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Todo",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Exitoso",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Fallido",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "Partir de la fecha",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "Hasta la fecha",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Comprador/Vendedor",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Vendedor",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "TODOS",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Comprador",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Vender moneda",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Recibir moneda",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Borrar todos los filtros",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Saldo insuficiente",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "No hay suficiente saldo para escaneado",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "solicitud de pago.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Intentando habilitar demasiados activos",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "Tu tienes",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "activos habilitados y tratando de habilitar",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "más. El límite máximo de activos habilitados es",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": ". Desactive algunos antes de agregar otros nuevos.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Ha seleccionado el número máximo de activos",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Demasiados recursos habilitados",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "Tu tienes",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "activos habilitados. El límite máximo de activos habilitados es",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ". Desactive algunos antes de agregar otros nuevos.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Pago solicitado",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Moneda:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "A Direccion",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "Monto:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "¿Acepta esta transacción?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Pagar",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "Cancelar",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} no está activo. Activa e inténtalo de nuevo..",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Moneda equivocada",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "Está intentando escanear un código QR de pago para",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "pero tu estas en la",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "pantalla de retirar",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Vender",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Comprar",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Recibir",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Enviar",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Cerrar",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Activar",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "El número máximo de monedas activas es {maxCoins}. Por favor, desactive algunos.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "No se puede activar {coin}",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} no está activo!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Ingrese la cantidad de {coin} para comprar",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Ingrese la cantidad de {coin} para vender",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Muestra menos",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Mostrar mas",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "No se encontró ninguna moneda",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de 'AtomicDEX' a 'Komodo Wallet'",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "comunicado de prensa oficial",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivation": "Cancelar activación",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "¿Estás seguro de que deseas cancelar la activación?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "¿Estás seguro de que deseas cancelar la activación?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncNewTransactions": "Sincronizar nuevas transacciones",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Sincronización desde la fecha especificada",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Sincronización desde la activación del retoño",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Seleccione una fecha",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Fecha de inicio",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "Sincronizaremos las transacciones futuras realizadas después de la activación asociada con su clave pública. Esta es la opción más rápida y ocupa la menor cantidad de almacenamiento.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "Su billetera mostrará cualquier transacción pasada. Esto requerirá mucho almacenamiento y tiempo, ya que todos los bloques se descargarán y escanearán.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "Su billetera mostrará sus transacciones pasadas realizadas después de la fecha especificada.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "Activando {coinName}",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "Activación de {coinName}",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} Activación en curso",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Activo",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Activar moneda",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "¡Activado {name} con éxito!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Añadir Direccion",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Directorio",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "La libreta de direcciones está vacía",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Solo mostrar contactos con direcciones {title}",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Directorio",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "No puede enviar fondos a la dirección {abbr} porque {abbr} no está activado. Por favor, vaya a la cartera.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Nada Encontrado",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Seleccionar Moneda",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Dirección de los destinatarios",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Avanzado",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "TODOS",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Permitir semilla personalizada",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "Su billetera mostrará cualquier transacción pasada. Esto requerirá mucho almacenamiento y tiempo, ya que todos los bloques se descargarán y escanearán.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "Ya existe",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Cantidad",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Cantidad a Vender",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "¡No! {appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n{appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a {appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "Hay dos categorías de tarifas a tener en cuenta al intercambiar en {appName}.\n\n1. {appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "¡Sí! {appName} ofrece soporte a través de <a href=\"{link}\">{appCompanyShort} {name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "¡No! {appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} está desarrollado por el equipo de {appCompanyShort}. {appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de {appName} siempre está lista para ayudar!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Aplausos",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "ESTAS SEGURO?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "un intercambio falla",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "un intercambio se ejecuta hasta su finalización",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "autenticar",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "volumen máximo",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "back",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Respaldo",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "basado en {coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "La carga de su batería es crítica ({batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "La carga de la batería es inferior al {batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Tipo de cambio",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Construido en Komodo",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Construido en Komodo",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Comprar",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Convertir a Vendedor si no coincide",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Intercambio emitido, por favor espere!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Ordermatch en curso, ¡espere {seconde} segundos!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Conflicto entre PIN de camuflaje y bioprotección.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Cambiar PIN de camuflaje",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Crear PIN de camuflaje",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "PIN de camuflaje no válido",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Camuflajear PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "PIN de camuflaje no encontrado",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Desactivado",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "Activado",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "PIN de camuflaje guardado",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Camuflajear el PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Ingrese el nuevo PIN de camuflaje",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Configuración de PIN de camuflaje",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Configuración de PIN de camuflaje",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "Cancelar",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Cancelar activación",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "¿Estás seguro de que deseas cancelar la activación?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "Cancelar",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Cancelar orden",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Algo salió mal. Vuelve a intentarlo más tarde.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ok",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "No se puede deshabilitar",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "no puedo escuchar eso",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "Tasa de Cambio CEX",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "data de CEX",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "Tasa CEX",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "Cambiar código PIN",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Buscar actualizaciones",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Verificar",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Comprobar la frase inicial",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "SEGUIR",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "VOLVER Y VERIFICAR DE NUEVO",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "Introduzca la palabra {index} ",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "¿Cuál es la palabra {index} en su frase inicial?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Chino",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "afirmar",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "¿Reclamar su recompensa KMD?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Clic para ver",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Copiado al portapapeles",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Copiar al portapapeles",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Cerrar",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Cerrar mensaje de error",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Cerrar prevista",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Código:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "¿Estás seguro de que deseas cancelar la activación?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Ha seleccionado el número máximo de activos",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "Las monedas {protocolName} están activadas",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName} monedas activadas con éxito",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "Las monedas {protocolName} no están activadas",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Remover",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "No hay monedas activas",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Seleccionar moneda",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Próximamente...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "Detalles de TX próximamente!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "¡Detalles muy pronto!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "cuota de comisión",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "en comparación con el promedio Precio CEX 24h",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "comparable a CEX",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Configurando su billetera, por favor espere...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Confirmar",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Confirmar PIN de camuflaje",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "¿Está seguro de que desea cancelar el pedido?",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "Al hacer clic en los botones a continuación, confirma haber leído el 'EULA' y los 'Términos y condiciones' y acepta estos",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Confirmar contraseña",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "Confirmar código PIN",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Confirmar frase semilla",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Conectando...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Cancelar",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Borrar Contacto",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Borrar",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "¿Está seguro de que desea eliminar el contacto {name}?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Descartar",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Editar",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Salir",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Descartar tus cambios?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "No se encontraron contactos",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Guardar",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Detalles de contacto",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Nombre",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Contrato",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Convertir",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "No se pudo iniciar la URL",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "No se pudo importar:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "intercambiar",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "CREAR UNA CARTERA",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Crear Contacto",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "Crear numero PIN",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Moneda",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Moneda",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Valor actual:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Costo de Transacción Personalizado",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "¡Solo use tarifas personalizadas si sabe lo que está haciendo!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"{iUnderstand}\" en el cuadro a continuación.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Fecha",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Billetera de descifrado",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Borrar",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Confirmar desactivación",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "¿Quieres eliminar",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "de tu cartera? Todos los pedidos no emparejados serán cancelados.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " también se desactivará",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Eliminar Billetera",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Eliminando billetera...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "recibir tarifa de transacción de {coinName}",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "enviar tarifa de transacción de {coinName}",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "enviar tarifa comercial tarifa de transacción",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "tarifa comercial",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "detalles",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Alemán",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Desarrollador",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX no está disponible para esta moneda",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Desactivar capturas de pantalla/vista previa",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Descargo de responsabilidad y condiciones de servicio",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Hecho",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "No cierres la aplicación. Toca para obtener más información...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "No vuelvas a preguntar",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "no quiero una contraseña",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Seguridad de Komodo dPoW",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Duración",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Editar contacto",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Introduzca la dirección {abbr} ",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "La contraseña de cifrado no puede estar vacía",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "La contraseña no puede estar vacía",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "El nombre del contacto no puede estar vacío",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "El nombre de la billetera no debe estar vacío",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Todavía puede habilitar {restos}, Seleccionado: {seleccionado}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Habilitar monedas de prueba",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "Tu tienes",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "activos habilitados y tratando de habilitar",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "más. El límite máximo de activos habilitados es",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ". Desactive algunos antes de agregar otros nuevos.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Intentando habilitar demasiados activos",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Billetera cifrada",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "Inglés",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Ingrese su nuevo PIN",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Ingrese su antiguo PIN",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Por favor ingrese su contraseña para continuar.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Ingresa tu numero PIN",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Ingrese su Semilla de 12 palabras",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Primero debe ingresar el monto de la venta",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "No hay suficiente equilibrio",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "No es una dirección válida",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Las direcciones de Segwit no son compatibles (todavía)",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "No hay suficiente gas: usa al menos {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Error, inténtalo de nuevo",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Error, intente más tarde",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "El valor es demasiado alto o bajo",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Por favor ingrese datos",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Valor total estimado",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Ejemplo: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Expediente",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Caro",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Identico a CEX",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Tipo de cambio:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "INTERCAMBIO",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Exportar",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Contactos",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Seleccione elementos para exportar a un archivo cifrado.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Exportar",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Notas",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Los elementos se han exportado correctamente:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Intercambios",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Exportar",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Fallido",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Cantidad de saldo falso:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Preguntas frecuentes",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Error",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Enviando solicitud a la llave {coin}...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "GRIFO",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Éxito",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "Tiempo de espera agotado",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Compartir archivo de registro",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Noticias",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Nada aquí",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} noticias",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Leer más...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Informacion",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Noticias",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "No se puede continuar con la actualización de noticias",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "No se puede obtener la actualización de noticias",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Fuente de noticias actualizada",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Ya está actualizado",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Las tarifas deben ser de hasta {value}",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Todo",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Filtro",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Borrar todos los filtros",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Fallido",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "Partir de la fecha",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Vendedor",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Recibir moneda",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Vender moneda",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Estado",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Exitoso",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Comprador",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "Hasta la fecha",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Comprador/Vendedor",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Huella dactilar",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Terminando, por favor espera.",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "Código QR encontrado",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Francés",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "Desde",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "Sincronizaremos las transacciones futuras realizadas después de la activación asociada con su clave pública. Esta es la opción más rápida y ocupa la menor cantidad de almacenamiento.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": " tarifa{coin} ",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "Limite de Gas",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Activa {coin}.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "Precio de Gas",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "Obteniendo transacción, por favor espere",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Ir al portafolio",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei debe ser de hasta {valor}",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Ayuda",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Ayuda y apoyo",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Ocultar saldos",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Confirmar contraseña",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Crear contraseña",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Contraseña actual",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Ingresa tu contraseña",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Ingrese su frase inicial",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Nombra tu billetera",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Clave",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "historia",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "h",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Húngaro",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Importar",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Contraseña no válida o datos dañados",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "Elementos a importar:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Archivo no encontrado",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Importar",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Seleccione el archivo cifrado para importar.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Abriendo...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Seleccione el archivo de intercambio de texto sin formato para importar.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Cancelar",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ok",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Clave",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Importar un Intercambio",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Importar Intercambio",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Se han saltado algunos elementos",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Los elementos se han importado correctamente:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "No se pudo importar el intercambio",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Error al decodificar el archivo json",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Importar",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Configuración de protección de txs entrantes de {coinName}",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Utilice una contraseña segura y no la almacene en el mismo dispositivo",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "¡La solicitud de intercambio no se puede deshacer y es un evento final!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": " El saldo de {abbr} no es suficiente para pagar la tarifa de negociación",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "El volumen mínimo requerido por este pedido es",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Volumen insuficiente",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Actualizar",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Conexión a Internet restaurada",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Dirección de {moneda} no válida",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "No se puede continuar con el intercambio",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Detalles",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} no está disponible :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "Entiendo",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Japonés",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Coreano",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Idioma",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Últimas transacciones",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Legal",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "menos",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗¡Precaución! ¡El mercado de {coinName} tiene un volumen de negociación de menos de $ 10k las 24 horas!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "El límite debe ser de hasta {valor}",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Cargando...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Cargando libro de ordenes...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "La pantalla está bloqueada",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "¡Por favor, autentícate!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "acceso",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Cerrar sesión",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Cerrar sesión al salir",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Configuración de cierre de sesión",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "¿Estás seguro de que quieres cerrar sesión ahora?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "Minutos",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "hacer un pedido",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Vendedor",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Cancelar orden",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Createdo en",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Recibir",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "ID de Orden",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Este pedido no inició intercambios",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Precio",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Vender",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Intercambios iniciados por este pedido",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Detalles del pedido del fabricante",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Orden de Vendedor",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Mercado",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Gráfico",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Profundidad",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "No se encontraron solicitudes",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "No se encontraron ofertas",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "LIBRO DE ORDENES",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Detalles del Pedido",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "PRECIO",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Por favor seleccione monedas",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Mercados",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "MERCADOS",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Las contraseñas deben coincidir",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Cambiar",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "PIN Invalido",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAXIMO",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Volumen máximo de pedidos:",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Noticias",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "NAVEGAR",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "NAVEGAR RSS",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "By",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "NO TIENES ARTÍCULOS GUARDADOS",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "GUARDADO",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Memorándum",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Unir",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Valor combinado:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "ms",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "Min",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "Volumen mínimo de pedido:",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "m",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "La cantidad mínima para vender es {number} {coinName}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "La cantidad mínima para comprar es {number}{coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "El monto mínimo del pedido es {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "La cantidad mínima para vender es {number}{coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "Debe ser mayor que {minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Debe ser menor que el monto de venta",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Volumen mínimo requerido",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Usar volumen mínimo personalizado",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de {appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Más información",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "Mas",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Active {coin} y añada saldo primero",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Cantidad",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Moneda",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Vender",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Cancelar",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Confirmar",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "Crear {number} pedido(s):",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Crear",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Orden",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Ordenes",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "costo",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Cancelar",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Ingrese la cantidad de dinero para recibir:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Autollenarl",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Corrija todos los errores antes de continuar",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Monto invalido",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Cantidad de venta no válido",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "No hay suficientes {coin} para pagar las tarifas. El saldo MÍN es {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": " El saldo de{coin} es demasiado bajo",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "La cantidad máxima de venta es",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "La cantidad mínima recibida es",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "La cantidad mínima de venta es",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Recibir:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Vender:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Multi",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Recibir Cntd.",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Precio/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Tarifa de red",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "nueva cuenta",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Nueva Cuenta",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Noticias",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Nuevo valor:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "próximo",
-  "@next": {
-    "type": "text"
-  },
-  "no": "No",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "No hay noticias. Vuelva a consultar más tarde.",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "No se encontró ninguna moneda",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Sin Fondos",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "No hay fondos disponibles, por favor deposite.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "Sin conexión a Internet",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "No hay artículos seleccionados",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "No hay artículos seleccionados",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "No se encontraron pedidos coincidentes",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Ninguno",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "El valor debe ser numérico.",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Ingrese la cantidad de {coinName}.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Haga clic para crear un pedido",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "No hay pedidos, por favor vaya al comercio.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "No hay recompensas reclamables",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "No hay tal moneda",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "No historia.",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "¡No hay suficiente {coin} para la transacción!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "No hay suficiente saldo para las tarifas: opere con una cantidad menor",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Nota: el pedido emparejado no se puede cancelar de nuevo",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Añadir Nota",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Nota",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Nada Encontrado",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": " El intercambio de{sell}/{buy} se completó con éxito",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Intercambio completado",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} intercambio fallido",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Intercambio fallido",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} intercambio iniciado",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Nuevo intercambio iniciado",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Cambio de estado cambiado",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} intercambio se agotó",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Se agotó el tiempo de intercambio",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "¡Ha recibido una transacción de {coin}!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Transaccion entrante",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "Sin transacciones",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} activos",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "comunicado de prensa oficial",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ok",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Borrar",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Registros antiguos",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Espacio usado",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Abrir mensaje de error",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Opcional",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Menos",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "Más",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Todos los pedidos de {coin} serán cancelados.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Pedido creado",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Pedido creado con éxito",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Direccion",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Cancelar",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Expediente: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Caro: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "for",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Idéntico a CEX",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "min.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Precio",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Recibir",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Seleccione",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Ventas",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Abra detalles con un solo toque y seleccione Ordenar con un toque largo",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Gastar",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Detalles",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% llenado",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Orden Triangulada",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Triangulación de órdenes",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "ordenes",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Activo",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "Historial",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Cantidad ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "Precio ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Total ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Orden",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Orden desconocida",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Sobrescribir",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "Esta es tu propia orden!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Pagado del saldo:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Pagado del volumen recibido:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Pagado con",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "Su billetera mostrará sus transacciones pasadas realizadas después de la fecha especificada.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Pagar",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "¿Acepta esta transacción?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "A Direccion",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Monto:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Moneda:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Cancelar",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Pago solicitado",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} no está activo. Activa e inténtalo de nuevo..",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Haga su pedido",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "Juega a todo volumen",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Por favor agregue una moneda",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Reinicie la aplicación para volver a intentarlo o presione el botón a continuación.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Portfolio",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Desarrollado por Komodo",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "price",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Llave Privada",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Llaves Privadas",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Confirmaciones",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Usar configuraciones de protección personalizadas",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "DESACTIVADO",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "ACTIVADO",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Advertencia, este intercambio atómico no está protegido por dPoW.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Llave Publica",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "Escáner de código QR",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "¿Guardás mis llaves privadas?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "¿En qué dispositivos puedo usar {appName}?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "¿En qué se diferencia el comercio en {appName} del comercio en otros DEX?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "¿Cuánto tiempo toma cada intercambio atómico?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "¿Necesito estar en línea durante la duración del intercambio?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "¿Cómo se calculan las tarifas de {appName}?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "¿Ofrecen soporte al usuario?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "¿Tiene restricciones de país?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "¿Quién está detrás de {appName}?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "¿Es posible desarrollar mi propio intercambio con {appName}?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de 'AtomicDEX' a 'Komodo Wallet'",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "RECIBIR",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Recibir",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Recomendamos almacenarlo fuera de línea.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Desactivar",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Comercio solicitado",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "RESETEAR",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Restablecer formulario",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "RESTAURAR",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Volviendo a intentar activar todas las monedas...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Vuelva a intentar activar todo",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Reclama tus recompensas",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Cancelar",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "La transacción está en curso",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "procesando",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "Cantidad de UTXO inferior a 10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Aún no ha pasado una hora",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 hora",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Ok",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Estado de recompensas:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "Obtenga más información sobre las recompensas para usuarios activos de KMD",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Recibir",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "¡Éxito! {amount} KMD recibido.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Fiat",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Recompensas,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Estado",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Tiempo\nrestante",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Información de recompensas:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO\ncantidad,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} dias(s)",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}h {minutes}m",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}min",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Información de recompensas",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Ruso",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Guardar combinado",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Desplácese hacia abajo para continuar...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Buscar una moneda",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Seleccionar todos los tokens de Avax",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Seleccionar todos los tokens BEP",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Seleccionar todo Cosmos Network",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Seleccionar todos los tokens ERC",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Seleccionar todos los tokens ETC",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Seleccionar todas las fichas de Fantom",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Seleccionar todos los tokens de HecoChain",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Seleccionar todas las fichas de armonía",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Seleccionar todo Iris Network",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Seleccionar todos los tokens de Kucoin",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Seleccione todas las fichas de Moonriver",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Seleccione todas las fichas de polígono",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Seleccionar todos los tokens QRC",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Seleccione todos los tokens SmartBCH",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Seleccionar todos los tokens SLP",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Seleccione todos los SmartChains",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Seleccionar todos los activos de prueba",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Seleccionar todas las monedas Ubiq",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Seleccione todas las monedas UTXO",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Seleccione todas las monedas ZHTLC",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Buscar teletipo",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Seguridad",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Frase Semilla",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Tu nueva frase semilla",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "Haga clic para ver {amount} pedidos",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "Ver historial de transacciones",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Seleccionar moneda",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Seleccione las monedas que desea agregar a su cartera.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Activar monedas:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Seleccione la moneda que desea COMPRAR",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Seleccione la moneda que desea VENDER",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Seleccione una fecha",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Orden seleccionado:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Seleccione Archivo",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Seleccione el idioma",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Selecciona tu forma de pago",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Vender",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "ENVIAR",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Estás seguro de que quieres eliminar",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "billetera?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Si es así, asegúrese de",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "guardar su frase inicial.",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "Para restaurar su billetera en el futuro.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Idiomas",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Ajustes",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "CONFIGURAR UNA CONTRASEÑA",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Compartir",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "Mi {coinName} dirección:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "¿Buscar transacciones pasadas de {monedas}?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Mostrar dirección",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Mostrar detalles",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "Mostrando {count} de {maxCount} pedidos.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "Mostrar mis pedidos",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Iniciar sesión con contraseña",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "¿Olvidó la contraseña? Restaurar billetera desde semilla",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Sencillo",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Activar",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Ingrese la cantidad de {coin} para comprar",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Comprar",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Cerrar",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "El número máximo de monedas activas es {maxCoins}. Por favor, desactive algunos.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} no está activo!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Recibir",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Ingrese la cantidad de {coin} para vender",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Vender",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Enviar",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Muestra menos",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Mostrar mas",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "No se puede activar {coin}",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Omitir",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Descartar",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Sonido",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando {description}.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "Jugado cuando {description}",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Sonidos",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Entendido, no lo muestres más.",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Sonido",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Ajustes de sonido",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Español",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Fecha de inicio",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Iniciar intercambio",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Paso",
-  "@step": {
-    "type": "text"
-  },
-  "success": "¡Éxito!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Apoyo",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación {appName}, puede informar y obtener asistencia de nuestro equipo.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "intercambio",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Actual",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "CONFIRMAR DETALLES DE CAMBIO",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Estimado",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Intercambio fallido",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Activa {coin} y recarga el saldo primero",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "El saldo de {coin} no es suficiente para pagar las tarifas de transacción.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": " El saldo de{coin} no es suficiente para pagar las tarifas de transacción. {coin} {amount} obligatorio.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Intercambio en curso",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "Detalles del Progreso",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "Iniciado",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Intercambio exitoso",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Total",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "Intercambiar UUID",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Cambiar Tema",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Sincronización desde la fecha especificada",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Sincronización desde la activación del retoño",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Sincronizar nuevas transacciones",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "¿Qué transacciones de {nombre} te gustaría sincronizar?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Comprador",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Orden de Comprador",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Se acabó el tiempo",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "CREA UNA CONTRASEÑA",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Pedido seleccionado",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "Para",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "Hacia:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "Tu tienes",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "activos habilitados. El límite máximo de activos habilitados es",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". Desactive algunos antes de agregar otros nuevos.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Demasiados recursos habilitados",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Tarifas totales:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "INTERCAMBIO",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "¡CAMBIO COMPLETADO!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "DETALLES INTERCAMBIO",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Error al calcular las tarifas comerciales",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "tarifa de negociación:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Modo de comercio:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Dirección de transacción",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Transacción oculta",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Esta transacción fue ocultada debido a un posible intento de phishing.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Turco",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Bloque",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Confirmaciones",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "CONFIRMADO",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Tarifa",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "tarifa de transacción:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "ID de transacción",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Transacciones restantes: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "INCONFIRMADO",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Ucranio",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "desbloquear",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Desbloquear fondos",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "Desbloqueó con éxito {amnt} fondos - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "ingastable",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Nueva versión disponible",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Comprobando actualizaciones...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "Estás usando la versión {version}",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Nueva versión disponible. Por favor actualice.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Versión {version} disponible. Por favor actualice.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Actualización disponible",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Saltar por ahora",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "{appName} actualizar",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Actualizar",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Ya está actualizado",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "No hay suficiente saldo para escaneado",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "solicitud de pago.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Saldo insuficiente",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Valor:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "version",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Explorador",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Semilla y Claves Privadas",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Volumenes",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "El nombre de la billetera ya está en uso",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "El nombre de la billetera debe tener un máximo de 40 caracteres",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Solo billetera",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "¡Advertencia!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ok",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos.",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "No pudimos activar {coinAbbr}",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "No pudimos activar {coinAbbr}.\nReinicie la aplicación para volver a intentarlo.",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "¡VAMOS A PREPARARNOS!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "BIENVENIDO",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "wallet",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "Se le redirigirá a la página del portafolio al finalizar.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Retirar",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "Previamente le has negado a {appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Acceso Denegado",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Confirmar Retiro",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Algo salió mal. Vuelva a intentarlo más tarde.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "RETIRAR {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "Está intentando escanear un código QR de pago para",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "pero tu estas en la",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "pantalla de retirar",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Moneda equivocada",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "Las contraseñas no coinciden. Inténtalo de nuevo.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Sí",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Usted está enviando:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "tiene un pedido nuevo que está tratando de coincidir con un pedido existente",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "tienes un intercambio activo en curso",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "tiene un pedido con el que pueden coincidir nuevos pedidos",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "Su billetera",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "Recibirás {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Usted recibirá:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,3638 +1,3726 @@
 {
-    "accepteula": "Aceptar EULA",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "Aceptar TERMINOS y CONDICIONES",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Activar protección biométrica",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "Activar la protección con PIN",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "¿Activar monedas {protocolName}?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "Activando {coinName}",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "Activación de {coinName}",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} Activación en curso",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Activo",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Activar moneda",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "¡Activado {name} con éxito!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Añadir Direccion",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Directorio",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "La libreta de direcciones está vacía",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Solo mostrar contactos con direcciones {title}",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Directorio",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "No puede enviar fondos a la dirección {abbr} porque {abbr} no está activado. Por favor, vaya a la cartera.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Nada Encontrado",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Seleccionar Moneda",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Dirección de los destinatarios",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Avanzado",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "TODOS",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Permitir semilla personalizada",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "Ya existe",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Cantidad",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Cantidad a Vender",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "¡No! {appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n{appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a {appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "Hay dos categorías de tarifas a tener en cuenta al intercambiar en {appName}.\n\n1. {appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "¡Sí! {appName} ofrece soporte a través de <a href=\"{link}\">{appCompanyShort} {name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "¡No! {appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} está desarrollado por el equipo de {appCompanyShort}. {appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de {appName} siempre está lista para ayudar!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Aplausos",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "ESTAS SEGURO?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "un intercambio falla",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "un intercambio se ejecuta hasta su finalización",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "autenticar",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "volumen máximo",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "back",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Respaldo",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "basado en {coinName1}/{coinName2}",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "La carga de su batería es crítica ({batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "La carga de la batería es inferior al {batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "Tipo de cambio",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Construido en Komodo",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Construido en Komodo",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Comprar",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "Convertir a Vendedor si no coincide",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Intercambio emitido, por favor espere!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "Ordermatch en curso, ¡espere {seconde} segundos!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Conflicto entre PIN de camuflaje y bioprotección.",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Cambiar PIN de camuflaje",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Crear PIN de camuflaje",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "PIN de camuflaje no válido",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Camuflajear PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "PIN de camuflaje no encontrado",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Desactivado",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "Activado",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "PIN de camuflaje guardado",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Camuflajear el PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Ingrese el nuevo PIN de camuflaje",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Configuración de PIN de camuflaje",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Configuración de PIN de camuflaje",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "Cancelar",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "Cancelar",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Cancelar orden",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Algo salió mal. Vuelve a intentarlo más tarde.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ok",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "No se puede deshabilitar",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "no puedo escuchar eso",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "Tasa de Cambio CEX",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "data de CEX",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "Tasa CEX",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "Cambiar código PIN",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Buscar actualizaciones",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Verificar",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "Comprobar la frase inicial",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "SEGUIR",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "VOLVER Y VERIFICAR DE NUEVO",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "Introduzca la palabra {index} ",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "¿Cuál es la palabra {index} en su frase inicial?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Chino",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "afirmar",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "¿Reclamar su recompensa KMD?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Clic para ver",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "Copiado al portapapeles",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "Copiar al portapapeles",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Cerrar",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Cerrar mensaje de error",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Cerrar prevista",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Código:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Ha seleccionado el número máximo de activos",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "Las monedas {protocolName} están activadas",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName} monedas activadas con éxito",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "Las monedas {protocolName} no están activadas",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Remover",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "No hay monedas activas",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Seleccionar moneda",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "Próximamente...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "Detalles de TX próximamente!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "¡Detalles muy pronto!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "cuota de comisión",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "en comparación con el promedio Precio CEX 24h",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "comparable a CEX",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "Configurando su billetera, por favor espere...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "Confirmar",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Confirmar PIN de camuflaje",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "¿Está seguro de que desea cancelar el pedido?",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "Al hacer clic en los botones a continuación, confirma haber leído el 'EULA' y los 'Términos y condiciones' y acepta estos",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Confirmar contraseña",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "Confirmar código PIN",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "Confirmar frase semilla",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Conectando...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "Cancelar",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Borrar Contacto",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "Borrar",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "¿Está seguro de que desea eliminar el contacto {name}?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Descartar",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Editar",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Salir",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Descartar tus cambios?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "No se encontraron contactos",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Guardar",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Detalles de contacto",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "Nombre",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Contrato",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Convertir",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "No se pudo iniciar la URL",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "No se pudo importar:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "intercambiar",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "CREAR UNA CARTERA",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Crear Contacto",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "Crear numero PIN",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Moneda",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Moneda",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Valor actual:",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Costo de Transacción Personalizado",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "¡Solo use tarifas personalizadas si sabe lo que está haciendo!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"{iUnderstand}\" en el cuadro a continuación.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Fecha",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Billetera de descifrado",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Borrar",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Confirmar desactivación",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "¿Quieres eliminar",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "de tu cartera? Todos los pedidos no emparejados serán cancelados.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " también se desactivará",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Eliminar Billetera",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Eliminando billetera...",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "recibir tarifa de transacción de {coinName}",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "enviar tarifa de transacción de {coinName}",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "enviar tarifa comercial tarifa de transacción",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "tarifa comercial",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "detalles",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Alemán",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Desarrollador",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX no está disponible para esta moneda",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Desactivar capturas de pantalla/vista previa",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Descargo de responsabilidad y condiciones de servicio",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Hecho",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "No cierres la aplicación. Toca para obtener más información...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "No vuelvas a preguntar",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "no quiero una contraseña",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Seguridad de Komodo dPoW",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Duración",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Editar contacto",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "Introduzca la dirección {abbr} ",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "La contraseña de cifrado no puede estar vacía",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "La contraseña no puede estar vacía",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "El nombre del contacto no puede estar vacío",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "El nombre de la billetera no debe estar vacío",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enableNotificationsForActivationProgress": "Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Habilitar monedas de prueba",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "Tu tienes",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "activos habilitados y tratando de habilitar",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "más. El límite máximo de activos habilitados es",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": ". Desactive algunos antes de agregar otros nuevos.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Intentando habilitar demasiados activos",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Billetera cifrada",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "Inglés",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Ingrese su nuevo PIN",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Ingrese su antiguo PIN",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Por favor ingrese su contraseña para continuar.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "Ingresa tu numero PIN",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Ingrese su Semilla de 12 palabras",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Primero debe ingresar el monto de la venta",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "No hay suficiente equilibrio",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "No es una dirección válida",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Las direcciones de Segwit no son compatibles (todavía)",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "No hay suficiente gas: usa al menos {gas} Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Error, inténtalo de nuevo",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Error, intente más tarde",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "El valor es demasiado alto o bajo",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "Por favor ingrese datos",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Valor total estimado",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Ejemplo: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Expediente",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Caro",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "Identico a CEX",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Tipo de cambio:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "INTERCAMBIO",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Exportar",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Contactos",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Seleccione elementos para exportar a un archivo cifrado.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Exportar",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Notas",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "Los elementos se han exportado correctamente:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Intercambios",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Exportar",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Fallido",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Cantidad de saldo falso:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Preguntas frecuentes",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Error",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "Enviando solicitud a la llave {coin}...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "GRIFO",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Éxito",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "Tiempo de espera agotado",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Compartir archivo de registro",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Noticias",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Nada aquí",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} noticias",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Leer más...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Informacion",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Noticias",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "No se puede continuar con la actualización de noticias",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "No se puede obtener la actualización de noticias",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Fuente de noticias actualizada",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Ya está actualizado",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "Las tarifas deben ser de hasta {value}",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Todo",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Filtro",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Borrar todos los filtros",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Fallido",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "Partir de la fecha",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Vendedor",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Recibir moneda",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Vender moneda",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Estado",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Exitoso",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Comprador",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "Hasta la fecha",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Comprador/Vendedor",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Huella dactilar",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Terminando, por favor espera.",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "Código QR encontrado",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Francés",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "Desde",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": " tarifa{coin} ",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "Limite de Gas",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Activa {coin}.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "Precio de Gas",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "Obteniendo transacción, por favor espere",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Ir al portafolio",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "helpLink": "Ayuda",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Ayuda y apoyo",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Ocultar saldos",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Confirmar contraseña",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Crear contraseña",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Contraseña actual",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Ingresa tu contraseña",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Ingrese su frase inicial",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Nombra tu billetera",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Clave",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "historia",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "h",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Húngaro",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "Importar",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Contraseña no válida o datos dañados",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "Elementos a importar:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Archivo no encontrado",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "Importar",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Seleccione el archivo cifrado para importar.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Abriendo...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Seleccione el archivo de intercambio de texto sin formato para importar.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "Cancelar",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Ok",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Clave",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Importar un Intercambio",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Importar Intercambio",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Se han saltado algunos elementos",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "Los elementos se han importado correctamente:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "No se pudo importar el intercambio",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Error al decodificar el archivo json",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "Importar",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Configuración de protección de txs entrantes de {coinName}",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Utilice una contraseña segura y no la almacene en el mismo dispositivo",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "¡La solicitud de intercambio no se puede deshacer y es un evento final!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": " El saldo de {abbr} no es suficiente para pagar la tarifa de negociación",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "El volumen mínimo requerido por este pedido es",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Volumen insuficiente",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Actualizar",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "Conexión a Internet restaurada",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "No se puede continuar con el intercambio",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Detalles",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} no está disponible :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "Entiendo",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Japonés",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Coreano",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Idioma",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Últimas transacciones",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Legal",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "menos",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗¡Precaución! ¡El mercado de {coinName} tiene un volumen de negociación de menos de $ 10k las 24 horas!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "loading": "Cargando...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Cargando libro de ordenes...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "La pantalla está bloqueada",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "¡Por favor, autentícate!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "acceso",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Cerrar sesión",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Cerrar sesión al salir",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Configuración de cierre de sesión",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "¿Estás seguro de que quieres cerrar sesión ahora?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "Minutos",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "hacer un pedido",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Vendedor",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Cancelar orden",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "Createdo en",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Recibir",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "ID de Orden",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Este pedido no inició intercambios",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Precio",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Vender",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "Intercambios iniciados por este pedido",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Detalles del pedido del fabricante",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Orden de Vendedor",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Mercado",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "Gráfico",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Profundidad",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "No se encontraron solicitudes",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "No se encontraron ofertas",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "LIBRO DE ORDENES",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Detalles del Pedido",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "PRECIO",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Por favor seleccione monedas",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Mercados",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "MERCADOS",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "Las contraseñas deben coincidir",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Cambiar",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "PIN Invalido",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "MAXIMO",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Volumen máximo de pedidos:",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Noticias",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "NAVEGAR",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "NAVEGAR RSS",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "By",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "NO TIENES ARTÍCULOS GUARDADOS",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "GUARDADO",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Memorándum",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Unir",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Valor combinado:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "ms",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "Min",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "Volumen mínimo de pedido:",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "m",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "La cantidad mínima para vender es {number} {coinName}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "La cantidad mínima para comprar es {number}{coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "El monto mínimo del pedido es {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "La cantidad mínima para vender es {number}{coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "Debe ser mayor que {minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Debe ser menor que el monto de venta",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Volumen mínimo requerido",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "Usar volumen mínimo personalizado",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de {appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Más información",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "Mas",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Active {coin} y añada saldo primero",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Cantidad",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Moneda",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Vender",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "Cancelar",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Confirmar",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "Crear {number} pedido(s):",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Crear",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Orden",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Ordenes",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "costo",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "Cancelar",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Ingrese la cantidad de dinero para recibir:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Autollenarl",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Corrija todos los errores antes de continuar",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Monto invalido",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Cantidad de venta no válido",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "No hay suficientes {coin} para pagar las tarifas. El saldo MÍN es {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": " El saldo de{coin} es demasiado bajo",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "La cantidad máxima de venta es",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "La cantidad mínima recibida es",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "La cantidad mínima de venta es",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Recibir:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Vender:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Multi",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Recibir Cntd.",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "Precio/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Tarifa de red",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "nueva cuenta",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Nueva Cuenta",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Noticias",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Nuevo valor:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "próximo",
-    "@next": {
-        "type": "text"
-    },
-    "no": "No",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "No hay noticias. Vuelva a consultar más tarde.",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "No se encontró ninguna moneda",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Sin Fondos",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "No hay fondos disponibles, por favor deposite.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "Sin conexión a Internet",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "No hay artículos seleccionados",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "No hay artículos seleccionados",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "No se encontraron pedidos coincidentes",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Ninguno",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "El valor debe ser numérico.",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Ingrese la cantidad de {coinName}.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Haga clic para crear un pedido",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "No hay pedidos, por favor vaya al comercio.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "No hay recompensas reclamables",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "No hay tal moneda",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "No historia.",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "¡No hay suficiente {coin} para la transacción!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "No hay suficiente saldo para las tarifas: opere con una cantidad menor",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Nota: el pedido emparejado no se puede cancelar de nuevo",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Añadir Nota",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Nota",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Nada Encontrado",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": " El intercambio de{sell}/{buy} se completó con éxito",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "Intercambio completado",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} intercambio fallido",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "Intercambio fallido",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} intercambio iniciado",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Nuevo intercambio iniciado",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Cambio de estado cambiado",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} intercambio se agotó",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Se agotó el tiempo de intercambio",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "¡Ha recibido una transacción de {coin}!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Transaccion entrante",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "Sin transacciones",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} activos",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "comunicado de prensa oficial",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Ok",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Borrar",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Registros antiguos",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Espacio usado",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Abrir mensaje de error",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "Opcional",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "Menos",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "Más",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Todos los pedidos de {coin} serán cancelados.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Pedido creado",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Pedido creado con éxito",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Direccion",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "Cancelar",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "Expediente: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "Caro: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "for",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "Idéntico a CEX",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "min.",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Precio",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Recibir",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Seleccione",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Ventas",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Abra detalles con un solo toque y seleccione Ordenar con un toque largo",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Gastar",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Detalles",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% llenado",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Orden Triangulada",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Triangulación de órdenes",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "ordenes",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Activo",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "Historial",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "Cantidad ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "Precio ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "Total ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Orden",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Orden desconocida",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Sobrescribir",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "Esta es tu propia orden!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Pagado del saldo:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Pagado del volumen recibido:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Pagado con",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Pagar",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "¿Acepta esta transacción?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "A Direccion",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "Monto:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Moneda:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "Cancelar",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Pago solicitado",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} no está activo. Activa e inténtalo de nuevo..",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Haga su pedido",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "Juega a todo volumen",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Por favor agregue una moneda",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Reinicie la aplicación para volver a intentarlo o presione el botón a continuación.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Portfolio",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Desarrollado por Komodo",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "price",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Llave Privada",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Llaves Privadas",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Confirmaciones",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Usar configuraciones de protección personalizadas",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "DESACTIVADO",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "ACTIVADO",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Advertencia, este intercambio atómico no está protegido por dPoW.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Llave Publica",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "Escáner de código QR",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "¿Guardás mis llaves privadas?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "¿En qué dispositivos puedo usar {appName}?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "¿En qué se diferencia el comercio en {appName} del comercio en otros DEX?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "¿Cuánto tiempo toma cada intercambio atómico?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "¿Necesito estar en línea durante la duración del intercambio?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "¿Cómo se calculan las tarifas de {appName}?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "¿Ofrecen soporte al usuario?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "¿Tiene restricciones de país?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "¿Quién está detrás de {appName}?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "¿Es posible desarrollar mi propio intercambio con {appName}?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de 'AtomicDEX' a 'Komodo Wallet'",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "RECIBIR",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Recibir",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Recomendamos almacenarlo fuera de línea.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Desactivar",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Comercio solicitado",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "RESETEAR",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Restablecer formulario",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "RESTAURAR",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Volviendo a intentar activar todas las monedas...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Vuelva a intentar activar todo",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Reclama tus recompensas",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Cancelar",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "La transacción está en curso",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "procesando",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "Cantidad de UTXO inferior a 10 KMD",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Aún no ha pasado una hora",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 hora",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "Ok",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Estado de recompensas:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "Obtenga más información sobre las recompensas para usuarios activos de KMD",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Recibir",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "¡Éxito! {amount} KMD recibido.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "Fiat",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "Recompensas,\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Estado",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Tiempo\nrestante",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Información de recompensas:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO\ncantidad,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} dias(s)",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}h {minutes}m",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}min",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "Información de recompensas",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Ruso",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Guardar combinado",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "Desplácese hacia abajo para continuar...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Buscar una moneda",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Seleccionar todos los tokens de Avax",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Seleccionar todos los tokens BEP",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Seleccionar todo Cosmos Network",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Seleccionar todos los tokens ERC",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Seleccionar todos los tokens ETC",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Seleccionar todas las fichas de Fantom",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Seleccionar todos los tokens de HecoChain",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Seleccionar todas las fichas de armonía",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Seleccionar todo Iris Network",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Seleccionar todos los tokens de Kucoin",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Seleccione todas las fichas de Moonriver",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Seleccione todas las fichas de polígono",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Seleccionar todos los tokens QRC",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Seleccione todos los tokens SmartBCH",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Seleccionar todos los tokens SLP",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Seleccione todos los SmartChains",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Seleccionar todos los activos de prueba",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Seleccionar todas las monedas Ubiq",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Seleccione todas las monedas UTXO",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Seleccione todas las monedas ZHTLC",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Buscar teletipo",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Seguridad",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "Frase Semilla",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Tu nueva frase semilla",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "Haga clic para ver {amount} pedidos",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "Ver historial de transacciones",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Seleccionar moneda",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Seleccione las monedas que desea agregar a su cartera.",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Activar monedas:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "Seleccione la moneda que desea COMPRAR",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "Seleccione la moneda que desea VENDER",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Orden seleccionado:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Seleccione Archivo",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Seleccione el idioma",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Selecciona tu forma de pago",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Vender",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "ENVIAR",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Estás seguro de que quieres eliminar",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "billetera?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Si es así, asegúrese de",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "guardar su frase inicial.",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "Para restaurar su billetera en el futuro.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Idiomas",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Ajustes",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "CONFIGURAR UNA CONTRASEÑA",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "Compartir",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "Mi {coinName} dirección:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Mostrar dirección",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Mostrar detalles",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "Mostrando {count} de {maxCount} pedidos.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "Mostrar mis pedidos",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Iniciar sesión con contraseña",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "¿Olvidó la contraseña? Restaurar billetera desde semilla",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Sencillo",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Activar",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Ingrese la cantidad de {coin} para comprar",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Comprar",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Cerrar",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "El número máximo de monedas activas es {maxCoins}. Por favor, desactive algunos.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} no está activo!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Recibir",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Ingrese la cantidad de {coin} para vender",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Vender",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Enviar",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Muestra menos",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Mostrar mas",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "No se puede activar {coin}",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Omitir",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Descartar",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Sonido",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando {description}.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "Jugado cuando {description}",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Sonidos",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Entendido, no lo muestres más.",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Sonido",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Ajustes de sonido",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "Español",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Iniciar intercambio",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Paso",
-    "@step": {
-        "type": "text"
-    },
-    "success": "¡Éxito!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Apoyo",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación {appName}, puede informar y obtener asistencia de nuestro equipo.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "intercambio",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Actual",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "CONFIRMAR DETALLES DE CAMBIO",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "Estimado",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "Intercambio fallido",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Activa {coin} y recarga el saldo primero",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "El saldo de {coin} no es suficiente para pagar las tarifas de transacción.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": " El saldo de{coin} no es suficiente para pagar las tarifas de transacción. {coin} {amount} obligatorio.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Intercambio en curso",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "Detalles del Progreso",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "Iniciado",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Intercambio exitoso",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Total",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "Intercambiar UUID",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Cambiar Tema",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Comprador",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Orden de Comprador",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Se acabó el tiempo",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "CREA UNA CONTRASEÑA",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Pedido seleccionado",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "Para",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "Hacia:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "Tu tienes",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "activos habilitados. El límite máximo de activos habilitados es",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ". Desactive algunos antes de agregar otros nuevos.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Demasiados recursos habilitados",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Tarifas totales:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "INTERCAMBIO",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "¡CAMBIO COMPLETADO!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "DETALLES INTERCAMBIO",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Error al calcular las tarifas comerciales",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "tarifa de negociación:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Modo de comercio:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "Dirección de transacción",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "Transacción oculta",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Esta transacción fue ocultada debido a un posible intento de phishing.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Turco",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Bloque",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Confirmaciones",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "CONFIRMADO",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Tarifa",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "tarifa de transacción:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "ID de transacción",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Transacciones restantes: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "INCONFIRMADO",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Ucranio",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "desbloquear",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Desbloquear fondos",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "Desbloqueó con éxito {amnt} fondos - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "ingastable",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Nueva versión disponible",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Comprobando actualizaciones...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "Estás usando la versión {version}",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Nueva versión disponible. Por favor actualice.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "Versión {version} disponible. Por favor actualice.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Actualización disponible",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Saltar por ahora",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "{appName} actualizar",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Actualizar",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Ya está actualizado",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "No hay suficiente saldo para escaneado",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "solicitud de pago.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Saldo insuficiente",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Valor:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "version",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Explorador",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Semilla y Claves Privadas",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Volumenes",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "El nombre de la billetera ya está en uso",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "El nombre de la billetera debe tener un máximo de 40 caracteres",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Solo billetera",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "¡Advertencia!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Ok",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos.",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "No pudimos activar {coinAbbr}",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "No pudimos activar {coinAbbr}.\nReinicie la aplicación para volver a intentarlo.",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "¡VAMOS A PREPARARNOS!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "BIENVENIDO",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "wallet",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "Se le redirigirá a la página del portafolio al finalizar.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Retirar",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "Previamente le has negado a {appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Acceso Denegado",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Confirmar Retiro",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Algo salió mal. Vuelva a intentarlo más tarde.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "RETIRAR {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "Está intentando escanear un código QR de pago para",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "pero tu estas en la",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "pantalla de retirar",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Moneda equivocada",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "Las contraseñas no coinciden. Inténtalo de nuevo.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Sí",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Usted está enviando:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "tiene un pedido nuevo que está tratando de coincidir con un pedido existente",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "tienes un intercambio activo en curso",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "tiene un pedido con el que pueden coincidir nuevos pedidos",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "Su billetera",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "Recibirás {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Usted recibirá:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "es",
+  "accepteula": "Aceptar EULA",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "Aceptar TERMINOS y CONDICIONES",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Activar protección biométrica",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "Activar la protección con PIN",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "¿Activar monedas {protocolName}?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "Activando {coinName}",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "Activación de {coinName}",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} Activación en curso",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Activo",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Activar moneda",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "¡Activado {name} con éxito!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Añadir Direccion",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Directorio",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "La libreta de direcciones está vacía",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Solo mostrar contactos con direcciones {title}",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Directorio",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "No puede enviar fondos a la dirección {abbr} porque {abbr} no está activado. Por favor, vaya a la cartera.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Nada Encontrado",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Seleccionar Moneda",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Dirección de los destinatarios",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Avanzado",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "TODOS",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Permitir semilla personalizada",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "Su billetera mostrará cualquier transacción pasada. Esto requerirá mucho almacenamiento y tiempo, ya que todos los bloques se descargarán y escanearán.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "Ya existe",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Cantidad",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Cantidad a Vender",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "¡No! {appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n{appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a {appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "Hay dos categorías de tarifas a tener en cuenta al intercambiar en {appName}.\n\n1. {appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "¡Sí! {appName} ofrece soporte a través de <a href=\"{link}\">{appCompanyShort} {name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "¡No! {appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} está desarrollado por el equipo de {appCompanyShort}. {appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de {appName} siempre está lista para ayudar!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Aplausos",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "ESTAS SEGURO?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "un intercambio falla",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "un intercambio se ejecuta hasta su finalización",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "autenticar",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "volumen máximo",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "back",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Respaldo",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "basado en {coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "La carga de su batería es crítica ({batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "La carga de la batería es inferior al {batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "Tipo de cambio",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Construido en Komodo",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Construido en Komodo",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Comprar",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "Convertir a Vendedor si no coincide",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Intercambio emitido, por favor espere!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "Ordermatch en curso, ¡espere {seconde} segundos!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Conflicto entre PIN de camuflaje y bioprotección.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Cambiar PIN de camuflaje",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Crear PIN de camuflaje",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "PIN de camuflaje no válido",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Camuflajear PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "PIN de camuflaje no encontrado",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Desactivado",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "Activado",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "PIN de camuflaje guardado",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Camuflajear el PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Ingrese el nuevo PIN de camuflaje",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Configuración de PIN de camuflaje",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Configuración de PIN de camuflaje",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "Cancelar",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Cancelar activación",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "¿Estás seguro de que deseas cancelar la activación?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "Cancelar",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Cancelar orden",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Algo salió mal. Vuelve a intentarlo más tarde.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ok",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "No se puede deshabilitar",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "no puedo escuchar eso",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "Tasa de Cambio CEX",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "data de CEX",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "Tasa CEX",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "Cambiar código PIN",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Buscar actualizaciones",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Verificar",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "Comprobar la frase inicial",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "SEGUIR",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "VOLVER Y VERIFICAR DE NUEVO",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "Introduzca la palabra {index} ",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "¿Cuál es la palabra {index} en su frase inicial?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Chino",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "afirmar",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "¿Reclamar su recompensa KMD?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Clic para ver",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "Copiado al portapapeles",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "Copiar al portapapeles",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Cerrar",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Cerrar mensaje de error",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Cerrar prevista",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Código:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "¿Estás seguro de que deseas cancelar la activación?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Ha seleccionado el número máximo de activos",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "Las monedas {protocolName} están activadas",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} monedas activadas con éxito",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "Las monedas {protocolName} no están activadas",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Remover",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "No hay monedas activas",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Seleccionar moneda",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "Próximamente...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "Detalles de TX próximamente!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "¡Detalles muy pronto!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "cuota de comisión",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "en comparación con el promedio Precio CEX 24h",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "comparable a CEX",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "Configurando su billetera, por favor espere...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "Confirmar",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Confirmar PIN de camuflaje",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "¿Está seguro de que desea cancelar el pedido?",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "Al hacer clic en los botones a continuación, confirma haber leído el 'EULA' y los 'Términos y condiciones' y acepta estos",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Confirmar contraseña",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "Confirmar código PIN",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "Confirmar frase semilla",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Conectando...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "Cancelar",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Borrar Contacto",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "Borrar",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "¿Está seguro de que desea eliminar el contacto {name}?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Descartar",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Editar",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Salir",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Descartar tus cambios?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "No se encontraron contactos",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Guardar",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Detalles de contacto",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "Nombre",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Contrato",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Convertir",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "No se pudo iniciar la URL",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "No se pudo importar:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "intercambiar",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "CREAR UNA CARTERA",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Crear Contacto",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "Crear numero PIN",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Moneda",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Moneda",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Valor actual:",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Costo de Transacción Personalizado",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "¡Solo use tarifas personalizadas si sabe lo que está haciendo!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"{iUnderstand}\" en el cuadro a continuación.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Fecha",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Billetera de descifrado",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Borrar",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Confirmar desactivación",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "¿Quieres eliminar",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "de tu cartera? Todos los pedidos no emparejados serán cancelados.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " también se desactivará",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Eliminar Billetera",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Eliminando billetera...",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "recibir tarifa de transacción de {coinName}",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "enviar tarifa de transacción de {coinName}",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "enviar tarifa comercial tarifa de transacción",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "tarifa comercial",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "detalles",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Alemán",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Desarrollador",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX no está disponible para esta moneda",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Desactivar capturas de pantalla/vista previa",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Descargo de responsabilidad y condiciones de servicio",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Hecho",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "No cierres la aplicación. Toca para obtener más información...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "No vuelvas a preguntar",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "no quiero una contraseña",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Seguridad de Komodo dPoW",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Duración",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Editar contacto",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "Introduzca la dirección {abbr} ",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "La contraseña de cifrado no puede estar vacía",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "La contraseña no puede estar vacía",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "El nombre del contacto no puede estar vacío",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "El nombre de la billetera no debe estar vacío",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Todavía puede habilitar {restos}, Seleccionado: {seleccionado}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Habilitar monedas de prueba",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "Tu tienes",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "activos habilitados y tratando de habilitar",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "más. El límite máximo de activos habilitados es",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": ". Desactive algunos antes de agregar otros nuevos.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Intentando habilitar demasiados activos",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Billetera cifrada",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "Inglés",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Ingrese su nuevo PIN",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Ingrese su antiguo PIN",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Por favor ingrese su contraseña para continuar.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "Ingresa tu numero PIN",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Ingrese su Semilla de 12 palabras",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Primero debe ingresar el monto de la venta",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "No hay suficiente equilibrio",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "No es una dirección válida",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Las direcciones de Segwit no son compatibles (todavía)",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "No hay suficiente gas: usa al menos {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Error, inténtalo de nuevo",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Error, intente más tarde",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "El valor es demasiado alto o bajo",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "Por favor ingrese datos",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Valor total estimado",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Ejemplo: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Expediente",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Caro",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "Identico a CEX",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Tipo de cambio:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "INTERCAMBIO",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Exportar",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Contactos",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Seleccione elementos para exportar a un archivo cifrado.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Exportar",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Notas",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "Los elementos se han exportado correctamente:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Intercambios",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Exportar",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Fallido",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Cantidad de saldo falso:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Preguntas frecuentes",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Error",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "Enviando solicitud a la llave {coin}...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "GRIFO",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Éxito",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "Tiempo de espera agotado",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Compartir archivo de registro",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Noticias",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Nada aquí",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} noticias",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Leer más...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Informacion",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Noticias",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "No se puede continuar con la actualización de noticias",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "No se puede obtener la actualización de noticias",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Fuente de noticias actualizada",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Ya está actualizado",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "Las tarifas deben ser de hasta {value}",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Todo",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Filtro",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Borrar todos los filtros",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Fallido",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "Partir de la fecha",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Vendedor",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Recibir moneda",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Vender moneda",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Estado",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Exitoso",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Comprador",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "Hasta la fecha",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Comprador/Vendedor",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Huella dactilar",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Terminando, por favor espera.",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "Código QR encontrado",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Francés",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "Desde",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "Sincronizaremos las transacciones futuras realizadas después de la activación asociada con su clave pública. Esta es la opción más rápida y ocupa la menor cantidad de almacenamiento.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": " tarifa{coin} ",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "Limite de Gas",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Activa {coin}.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "Precio de Gas",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "Obteniendo transacción, por favor espere",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Ir al portafolio",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei debe ser de hasta {valor}",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Ayuda",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Ayuda y apoyo",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Ocultar saldos",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Confirmar contraseña",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Crear contraseña",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Contraseña actual",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Ingresa tu contraseña",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Ingrese su frase inicial",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Nombra tu billetera",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Clave",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "historia",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "h",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Húngaro",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "Importar",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Contraseña no válida o datos dañados",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "Elementos a importar:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Archivo no encontrado",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "Importar",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Seleccione el archivo cifrado para importar.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Abriendo...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Seleccione el archivo de intercambio de texto sin formato para importar.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "Cancelar",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Ok",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Clave",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Importar un Intercambio",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Importar Intercambio",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Se han saltado algunos elementos",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "Los elementos se han importado correctamente:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "No se pudo importar el intercambio",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Error al decodificar el archivo json",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "Importar",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Configuración de protección de txs entrantes de {coinName}",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Utilice una contraseña segura y no la almacene en el mismo dispositivo",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "¡La solicitud de intercambio no se puede deshacer y es un evento final!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": " El saldo de {abbr} no es suficiente para pagar la tarifa de negociación",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "El volumen mínimo requerido por este pedido es",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Volumen insuficiente",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Actualizar",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "Conexión a Internet restaurada",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Dirección de {moneda} no válida",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "No se puede continuar con el intercambio",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Detalles",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} no está disponible :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "Entiendo",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Japonés",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Coreano",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Idioma",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Últimas transacciones",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Legal",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "menos",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗¡Precaución! ¡El mercado de {coinName} tiene un volumen de negociación de menos de $ 10k las 24 horas!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "El límite debe ser de hasta {valor}",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Cargando...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Cargando libro de ordenes...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "La pantalla está bloqueada",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "¡Por favor, autentícate!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "acceso",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Cerrar sesión",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Cerrar sesión al salir",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Configuración de cierre de sesión",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "¿Estás seguro de que quieres cerrar sesión ahora?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "Minutos",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "hacer un pedido",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Vendedor",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Cancelar orden",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "Createdo en",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Recibir",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "ID de Orden",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Este pedido no inició intercambios",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Precio",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Vender",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "Intercambios iniciados por este pedido",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Detalles del pedido del fabricante",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Orden de Vendedor",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Mercado",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "Gráfico",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Profundidad",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "No se encontraron solicitudes",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "No se encontraron ofertas",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "LIBRO DE ORDENES",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Detalles del Pedido",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "PRECIO",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Por favor seleccione monedas",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Mercados",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "MERCADOS",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "Las contraseñas deben coincidir",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Cambiar",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "PIN Invalido",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "MAXIMO",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Volumen máximo de pedidos:",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Noticias",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "NAVEGAR",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "NAVEGAR RSS",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "By",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "NO TIENES ARTÍCULOS GUARDADOS",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "GUARDADO",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Memorándum",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Unir",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Valor combinado:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "ms",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "Min",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "Volumen mínimo de pedido:",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "m",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "La cantidad mínima para vender es {number} {coinName}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "La cantidad mínima para comprar es {number}{coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "El monto mínimo del pedido es {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "La cantidad mínima para vender es {number}{coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "Debe ser mayor que {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Debe ser menor que el monto de venta",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Volumen mínimo requerido",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "Usar volumen mínimo personalizado",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de {appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Más información",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "Mas",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Active {coin} y añada saldo primero",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Cantidad",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Moneda",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Vender",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "Cancelar",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Confirmar",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "Crear {number} pedido(s):",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Crear",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Orden",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Ordenes",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "costo",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "Cancelar",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Ingrese la cantidad de dinero para recibir:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Autollenarl",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Corrija todos los errores antes de continuar",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Monto invalido",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Cantidad de venta no válido",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "No hay suficientes {coin} para pagar las tarifas. El saldo MÍN es {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": " El saldo de{coin} es demasiado bajo",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "La cantidad máxima de venta es",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "La cantidad mínima recibida es",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "La cantidad mínima de venta es",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Recibir:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Vender:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Multi",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Recibir Cntd.",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "Precio/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Tarifa de red",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "nueva cuenta",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Nueva Cuenta",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Noticias",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Nuevo valor:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "próximo",
+  "@next": {
+    "type": "text"
+  },
+  "no": "No",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "No hay noticias. Vuelva a consultar más tarde.",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "No se encontró ninguna moneda",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Sin Fondos",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "No hay fondos disponibles, por favor deposite.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "Sin conexión a Internet",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "No hay artículos seleccionados",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "No hay artículos seleccionados",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "No se encontraron pedidos coincidentes",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Ninguno",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "El valor debe ser numérico.",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Ingrese la cantidad de {coinName}.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Haga clic para crear un pedido",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "No hay pedidos, por favor vaya al comercio.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "No hay recompensas reclamables",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "No hay tal moneda",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "No historia.",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "¡No hay suficiente {coin} para la transacción!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "No hay suficiente saldo para las tarifas: opere con una cantidad menor",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Nota: el pedido emparejado no se puede cancelar de nuevo",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Añadir Nota",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Nota",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Nada Encontrado",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": " El intercambio de{sell}/{buy} se completó con éxito",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Intercambio completado",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} intercambio fallido",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Intercambio fallido",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} intercambio iniciado",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Nuevo intercambio iniciado",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Cambio de estado cambiado",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} intercambio se agotó",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Se agotó el tiempo de intercambio",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "¡Ha recibido una transacción de {coin}!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Transaccion entrante",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "Sin transacciones",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} activos",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "comunicado de prensa oficial",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Ok",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Borrar",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Registros antiguos",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Espacio usado",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Abrir mensaje de error",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "Opcional",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "Menos",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "Más",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Todos los pedidos de {coin} serán cancelados.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Pedido creado",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Pedido creado con éxito",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Direccion",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "Cancelar",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "Expediente: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "Caro: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "for",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "Idéntico a CEX",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "min.",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Precio",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Recibir",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Seleccione",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Ventas",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Abra detalles con un solo toque y seleccione Ordenar con un toque largo",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Gastar",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Detalles",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% llenado",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Orden Triangulada",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Triangulación de órdenes",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "ordenes",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Activo",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "Historial",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "Cantidad ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "Precio ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "Total ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Orden",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Orden desconocida",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Sobrescribir",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "Esta es tu propia orden!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Pagado del saldo:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Pagado del volumen recibido:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Pagado con",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "Su billetera mostrará sus transacciones pasadas realizadas después de la fecha especificada.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Pagar",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "¿Acepta esta transacción?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "A Direccion",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "Monto:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Moneda:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "Cancelar",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Pago solicitado",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} no está activo. Activa e inténtalo de nuevo..",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Haga su pedido",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "Juega a todo volumen",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Por favor agregue una moneda",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Reinicie la aplicación para volver a intentarlo o presione el botón a continuación.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Portfolio",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Desarrollado por Komodo",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "price",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Llave Privada",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Llaves Privadas",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Confirmaciones",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Usar configuraciones de protección personalizadas",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "DESACTIVADO",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "ACTIVADO",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Advertencia, este intercambio atómico no está protegido por dPoW.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Llave Publica",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "Escáner de código QR",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "¿Guardás mis llaves privadas?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "¿En qué dispositivos puedo usar {appName}?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "¿En qué se diferencia el comercio en {appName} del comercio en otros DEX?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "¿Cuánto tiempo toma cada intercambio atómico?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "¿Necesito estar en línea durante la duración del intercambio?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "¿Cómo se calculan las tarifas de {appName}?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "¿Ofrecen soporte al usuario?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "¿Tiene restricciones de país?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "¿Quién está detrás de {appName}?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "¿Es posible desarrollar mi propio intercambio con {appName}?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de 'AtomicDEX' a 'Komodo Wallet'",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "RECIBIR",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Recibir",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Recomendamos almacenarlo fuera de línea.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Desactivar",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Comercio solicitado",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "RESETEAR",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Restablecer formulario",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "RESTAURAR",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Volviendo a intentar activar todas las monedas...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Vuelva a intentar activar todo",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Reclama tus recompensas",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Cancelar",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Algo salió mal. Por favor, inténtelo de nuevo más tarde.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "La transacción está en curso",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "procesando",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "Cantidad de UTXO inferior a 10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Aún no ha pasado una hora",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 hora",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "Ok",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Estado de recompensas:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "Obtenga más información sobre las recompensas para usuarios activos de KMD",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Recibir",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "¡Éxito! {amount} KMD recibido.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "Fiat",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "Recompensas,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Estado",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Tiempo\nrestante",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Información de recompensas:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO\ncantidad,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} dias(s)",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}h {minutes}m",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}min",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Información de recompensas",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Ruso",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Guardar combinado",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "Desplácese hacia abajo para continuar...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Buscar una moneda",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Seleccionar todos los tokens de Avax",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Seleccionar todos los tokens BEP",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Seleccionar todo Cosmos Network",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Seleccionar todos los tokens ERC",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Seleccionar todos los tokens ETC",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Seleccionar todas las fichas de Fantom",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Seleccionar todos los tokens de HecoChain",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Seleccionar todas las fichas de armonía",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Seleccionar todo Iris Network",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Seleccionar todos los tokens de Kucoin",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Seleccione todas las fichas de Moonriver",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Seleccione todas las fichas de polígono",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Seleccionar todos los tokens QRC",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Seleccione todos los tokens SmartBCH",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Seleccionar todos los tokens SLP",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Seleccione todos los SmartChains",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Seleccionar todos los activos de prueba",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Seleccionar todas las monedas Ubiq",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Seleccione todas las monedas UTXO",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Seleccione todas las monedas ZHTLC",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Buscar teletipo",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Seguridad",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "Frase Semilla",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Tu nueva frase semilla",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "Haga clic para ver {amount} pedidos",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "Ver historial de transacciones",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Seleccionar moneda",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Seleccione las monedas que desea agregar a su cartera.",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Activar monedas:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "Seleccione la moneda que desea COMPRAR",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "Seleccione la moneda que desea VENDER",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Seleccione una fecha",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Orden seleccionado:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Seleccione Archivo",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Seleccione el idioma",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Selecciona tu forma de pago",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Vender",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "ENVIAR",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Estás seguro de que quieres eliminar",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "billetera?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Si es así, asegúrese de",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "guardar su frase inicial.",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "Para restaurar su billetera en el futuro.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Idiomas",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Ajustes",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "CONFIGURAR UNA CONTRASEÑA",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "Compartir",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "Mi {coinName} dirección:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "¿Buscar transacciones pasadas de {monedas}?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Mostrar dirección",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Mostrar detalles",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "Mostrando {count} de {maxCount} pedidos.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "Mostrar mis pedidos",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Iniciar sesión con contraseña",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "¿Olvidó la contraseña? Restaurar billetera desde semilla",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Sencillo",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Activar",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Ingrese la cantidad de {coin} para comprar",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Comprar",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Cerrar",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "El número máximo de monedas activas es {maxCoins}. Por favor, desactive algunos.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} no está activo!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Recibir",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Ingrese la cantidad de {coin} para vender",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Vender",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Enviar",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Muestra menos",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Mostrar mas",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "No se puede activar {coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Omitir",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Descartar",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Sonido",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando {description}.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "Jugado cuando {description}",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Sonidos",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Entendido, no lo muestres más.",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Sonido",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Ajustes de sonido",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "Español",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Fecha de inicio",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Iniciar intercambio",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Paso",
+  "@step": {
+    "type": "text"
+  },
+  "success": "¡Éxito!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Apoyo",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación {appName}, puede informar y obtener asistencia de nuestro equipo.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "intercambio",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Actual",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "CONFIRMAR DETALLES DE CAMBIO",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "Estimado",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "Intercambio fallido",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Activa {coin} y recarga el saldo primero",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "El saldo de {coin} no es suficiente para pagar las tarifas de transacción.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": " El saldo de{coin} no es suficiente para pagar las tarifas de transacción. {coin} {amount} obligatorio.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Intercambio en curso",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "Detalles del Progreso",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "Iniciado",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Intercambio exitoso",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Total",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "Intercambiar UUID",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Cambiar Tema",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Sincronización desde la fecha especificada",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Sincronización desde la activación del retoño",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Sincronizar nuevas transacciones",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "¿Qué transacciones de {nombre} te gustaría sincronizar?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Comprador",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Orden de Comprador",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Se acabó el tiempo",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "CREA UNA CONTRASEÑA",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Pedido seleccionado",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "Para",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "Hacia:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "Tu tienes",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "activos habilitados. El límite máximo de activos habilitados es",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ". Desactive algunos antes de agregar otros nuevos.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Demasiados recursos habilitados",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Tarifas totales:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "INTERCAMBIO",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "¡CAMBIO COMPLETADO!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "DETALLES INTERCAMBIO",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Error al calcular las tarifas comerciales",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "tarifa de negociación:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Modo de comercio:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "Dirección de transacción",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "Transacción oculta",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Esta transacción fue ocultada debido a un posible intento de phishing.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Turco",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Bloque",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Confirmaciones",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "CONFIRMADO",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Tarifa",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "tarifa de transacción:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "ID de transacción",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Transacciones restantes: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "INCONFIRMADO",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Ucranio",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "desbloquear",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Desbloquear fondos",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "Desbloqueó con éxito {amnt} fondos - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "ingastable",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Nueva versión disponible",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Comprobando actualizaciones...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "Estás usando la versión {version}",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Nueva versión disponible. Por favor actualice.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "Versión {version} disponible. Por favor actualice.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Actualización disponible",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Saltar por ahora",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "{appName} actualizar",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Actualizar",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Ya está actualizado",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "No hay suficiente saldo para escaneado",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "solicitud de pago.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Saldo insuficiente",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Valor:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "version",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Explorador",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Semilla y Claves Privadas",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Volumenes",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "El nombre de la billetera ya está en uso",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "El nombre de la billetera debe tener un máximo de 40 caracteres",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Solo billetera",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "¡Advertencia!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Ok",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos.",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "No pudimos activar {coinAbbr}",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "No pudimos activar {coinAbbr}.\nReinicie la aplicación para volver a intentarlo.",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "¡VAMOS A PREPARARNOS!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "BIENVENIDO",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "wallet",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "Se le redirigirá a la página del portafolio al finalizar.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Retirar",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "Previamente le has negado a {appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Acceso Denegado",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Confirmar Retiro",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Algo salió mal. Vuelva a intentarlo más tarde.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "RETIRAR {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "Está intentando escanear un código QR de pago para",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "pero tu estas en la",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "pantalla de retirar",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Moneda equivocada",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "Las contraseñas no coinciden. Inténtalo de nuevo.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Sí",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Usted está enviando:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "tiene un pedido nuevo que está tratando de coincidir con un pedido existente",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "tienes un intercambio activo en curso",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "tiene un pedido con el que pueden coincidir nuevos pedidos",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "Su billetera",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "Recibirás {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Usted recibirá:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -3589,6 +3589,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "No se pudo cancelar la activación de {coinAbbr}",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} no está disponible :(",
     "@isUnavailable": {
         "type": "text",
@@ -5405,6 +5415,28 @@
     },
     "officialPressRelease": "comunicado de prensa oficial",
     "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activationCancelled": "Activación de monedas cancelada",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationCancelled": "activación de {coin} cancelada",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Acepte todas las solicitudes especiales de activación de monedas o anule la selección de las monedas.",
+    "@pleaseAcceptAllCoinActivationRequests": {
         "type": "text",
         "placeholders_order": [],
         "placeholders": {}

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,3660 +1,3726 @@
 {
-    "accepteula": "Accepter les conditions générales de ventes",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "Accepter les conditions générales d'utilisations",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Activer la protection Biométrique",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "Activer la protection PIN",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "Activer les pièces {protocolName} ?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "Activation de {coinName}",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "Activation de {coinName}",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} Activation en cours",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Active",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Activer la crypto-monnaie",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} activé avec succès !",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Ajouter Adresse",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Répertoire",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "Répertoire vide",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Seules les adresses {title} sont affichées",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Répertoire",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "Impossible d'envoyer les fonds sur l'adresse {abbr} car elle n'est pas activée. Veuillez ouvrir le portfolio.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Pas de résultats",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Choisir Crypto-monnaie",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Adresse du destinataire",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Avancé",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "Tout",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Autoriser les passphrases personnalisées",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "Doublon existant",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Montant",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Montant à vendre",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "Non ! {appName} est non-custodial. Aucune donnée sensible n'est sauvegardé, ni votre clé privé, ni votre passphrases, ni votre PIN. Toutes ces données sont stockées sur votre appareil et ne sont jamais transmises.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName} est disponible pour mobile sur Android et iPhone, et pour ordinateur sur <a href=\"https://komodoplatform.com/\">systèmes d'exploitation Windows, Mac et Linux</a>.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Les autres DEX ne vous permettent généralement que d'échanger des actifs basés sur un seul réseau de blockchain, d'utiliser des jetons proxy et de ne permettre de passer qu'une seule commande avec les mêmes fonds.\n\n{appName} vous permet d'échanger nativement sur deux réseaux blockchain différents sans jetons proxy. Vous pouvez également passer plusieurs commandes avec les mêmes fonds. Par exemple, vous pouvez vendre 0,1 BTC pour KMD, QTUM ou VRSC — la première commande exécutée annule automatiquement toutes les autres commandes.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Plusieurs facteurs déterminent le temps de traitement de chaque échange. Le temps de blocage des actifs échangés dépend de chaque réseau (Bitcoin étant généralement le plus lent). De plus, l'utilisateur peut personnaliser les préférences de sécurité. Par exemple, vous pouvez demander à {appName} de considérer une transaction KMD comme finale après seulement 3 confirmations, ce qui raccourcit le temps d'échange par rapport à l'attente d'une <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarisation</a>.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Oui. Vous devez rester connecté à Internet et exécuter votre application pour réussir chaque échange atomique (de très courtes pauses de connectivité sont généralement acceptables). Sinon, il y a un risque d'annulation de transaction si vous êtes un fabricant et un risque de perte de fonds si vous êtes un preneur. Le protocole d'échange atomique exige que les deux participants restent en ligne et surveillent les chaînes de blocs impliquées pour que le processus reste atomique.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "Il existe deux catégories de frais à prendre en compte lors de la négociation sur {appName}.\n\n1. {appName} facture environ 0,13 % (1/777 du volume de négociation mais pas moins de 0,0001) comme frais de négociation pour les ordres preneurs, et les ordres fabricant n'ont aucun frais.\n\n2. Les fabricants et les preneurs devront payer des frais de réseau normaux aux chaînes de blocs impliquées lors des transactions d'échange atomique.\n\nLes frais de réseau peuvent varier considérablement en fonction de la paire de négociation que vous avez sélectionnée.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "Oui! {appName} propose une assistance via le <a href=\"{link}\">{appCompanyShort} {name}</a>. L'équipe et la communauté sont toujours ravies de vous aider !",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "Non! {appName} est entièrement décentralisé. Il n'est pas possible de limiter l'accès des utilisateurs par un tiers.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} est développé par l'équipe {appCompanyShort} . {appCompanyShort} est l'un des projets de blockchain les plus établis travaillant sur des solutions innovantes telles que les swaps atomiques, la preuve de travail différée et une architecture multichaîne interopérable.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "Absolument! Vous pouvez lire notre <a href=\"https://developers.komodoplatform.com/\">documentation pour les développeurs</a> pour plus de détails ou nous contacter pour vos demandes de partenariat. Vous avez une question technique spécifique ? La communauté de développeurs {appName} est toujours prête à vous aider !",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Applause",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "ÊTES-VOUS SÛR?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "un échange a échoué",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "un échange est en cours",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "authentification",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Vous serez automatiquement redirigé vers la page du portfolio une fois le processus de réactivation terminé.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "vol max",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "retour",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Sauvegarde",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "basé sur {coinName1}/{coinName2}",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "La charge de votre batterie est essentielle ({batteryLevelCritical} %) pour effectuer un échange en toute sécurité. Veuillez le mettre en charge et réessayer.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "La charge de votre batterie est inférieure à {batteryLevelLow} %. Veuillez considérer la recharge du téléphone.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "Votre téléphone est en mode d'économie de batterie. Veuillez désactiver ce mode ou ne PAS mettre l'application en arrière-plan, sinon l'application pourrait être tuée par le système d'exploitation et l'échange échouerait.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "Meilleur tarif disponible",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Conçu sur Komodo",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Conçu sur Komodo",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Acheter",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "Convertir en Maker s'il n'y a pas de correspondance",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Échange émis, veuillez patienter!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "Ordre en cours, veuillez patienter {seconde} secondes!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "Attention, vous êtes prêt à acheter des pièces test SANS valeur réelle !",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "Le code PIN de camouflage et la protection bio ne peuvent pas être activés en même temps.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Camo PIN et conflit de protection Bio.",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Changer Masque PIN",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Créer Masque PIN",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Si vous déverrouillez l'application avec le code PIN de camouflage, un faux solde FAIBLE sera affiché et l'option de configuration du code PIN de camouflage ne sera PAS visible dans les paramètres.",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "Masque PIN incorrect",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Masque PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "Masque PIN introuvable",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Off",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "On",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "Masque PIN sauvegardé",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Masque PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Entrer un nouveau Masque PIN",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Configuration Masque PIN",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Configuration Masque PIN",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "Annuler",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "Annuler",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Annuler l'ordre",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Un problème est survenu. Réessayez plus tard.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ok",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": " est une pièce par défaut. Les pièces par défaut ne peuvent pas être désactivées.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "Désactivation impossible",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "Lecture impossible",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "Taux de change CEX",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "Données CEX",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Les données de marché (prix, graphiques, etc.) marquées de cette icône proviennent de sources tierces (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "Taux CEX",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "Changer code PIN",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Vérifier les mises à jours",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Check-out",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "Vérifier la passphrase",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "CONTINUER",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "RETOURNEZ ET VÉRIFIEZ À NOUVEAU",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "Entrez le {index} mot",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "Votre passphrase est importante - c'est pourquoi nous voulons nous assurer qu'elle est correcte. Nous vous poserons trois questions différentes sur votre passphrase pour vous assurer que vous pourrez facilement restaurer votre portefeuille à tout moment.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "Quel est le {index} mot dans votre passphrase?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "VERIFIONS UNE NOUVELLE FOIS VOTRE PASSPHRASE",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Chinois",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "réclamer",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "Réclamer votre récompense KMD?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Cliquez pour voir",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "Copié dans le presse-papiers",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "Copier dans le presse-papiers",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Fermer",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Fermer Message d'Erreur",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Fermer aperçu",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Code:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Vous avez sélectionné le nombre maximum d'éléments",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "Les pièces {protocolName} sont activées",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName} pièces activées avec succès",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "Les pièces {protocolName} ne sont pas activées",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Effacer",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "Aucune crypto-monnaie active",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Choisir crypto-monnaie",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "A venir...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "TX détails à venir!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "Détails à venir!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "frais de commission",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "par rapport à la moyenne Prix CEX 24h",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "comparé au CEX",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "Portefeuille en cours de configuration, veuillez patienter...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "Confirmer",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Confirmer Masque PIN",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "Êtes-vous sûr d'annuler l'odre",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "En cliquant sur le bouton ci-dessous vous confrimez avec lu et accepté les CGV et CGU",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Confirmez le mot de passe",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "Confirmer le code PIN",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "Confirmer la passphrase",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Connexion…",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "Annuler",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Supprimer Contact",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "Supprimer",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "Voulez-vous supprimer le contact {name}?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Annuler",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Editer",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Fermer",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Annuler vos modifications ?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "Aucun contact trouvé",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Enregistrer",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Détail Contact",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "Nom",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Contracter",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Convertir",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "Impossible de lancer l'URL",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "Import impossible:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "Échange",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "CRÉER UN PORTEFEUILLE",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Créer contact",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "Créer PIN",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Monnaie",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Monnaie",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Prix actuel:",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Frais personnalisés",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "N'utiliser les frais personnalisés que si vous savez ce que vous faite!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Les phrases de départ personnalisées peuvent être moins sécurisées et plus faciles à déchiffrer qu'une phrase de départ ou une clé privée (WIF) conforme à BIP39. Pour confirmer que vous comprenez le risque et savez ce que vous faites, saisissez \" {iUnderstand}\" dans la case ci-dessous.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Date",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Décryptage du portefeuille...",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Supprimer",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Confirmer désactivation",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "Voulez-vous supprimer",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": " de votre portefeuille ? Toutes les commandes sans correspondance seront annulées.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " sera également désactivé",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Supprimer le portefeuille",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Supression portefeuille…",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "recevez des frais de transaction {coinName}",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "envoyer des frais de transaction à {coinName}",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "envoyer des frais de négociation frais de transaction",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "frais de négociation",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "détails",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Allemand",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Développeur",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "Cette crypto-monnaie n'est pas supporté par DEX",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Désactiver les captures d'écran/aperçu",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Avertissement et Conditions d'utilisation",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Terminé",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "Ne fermez pas l'application. Appuyez pour plus d'informations...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "Ne plus demander",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "Je ne veux pas de mot de passe",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo sécurité dPoW",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Durée",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Editer contact",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "Entrez l'adresse {abbr} ",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "Le mot de passe chiffré ne peut être nul",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "Le mot de passe ne peut être nul",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "Le nom du contact ne peut être nul",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "Le nom du portefeuille ne peut être nul",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "Vous pouvez toujours activer {remains}, Selected : {selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "Veuillez activer les notifications pour obtenir des mises à jour sur la progression de l'activation.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Activer les crypto-monnaies de Test",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "Vous avez",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": " actifs activés et tentative d'activation",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": " Suite. La limite maximale des éléments activés est",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Tentative d'activation d'un trop grand nombre d'éléments",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Chiffrement du portefeuille...",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "Anglais",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Enter votre nouveau PIN",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Entrer votre ancien PIN",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Veuillez entrer votre mot de passe pour continuer.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "Entrez votre code PIN",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Entrez votre passphrase",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Vous devez d'abord entrer le prix de vente",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "Solde insuffisant",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "Adresse non valide",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Adresses Segwit non supportées (pour le moment)",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "Pas assez de gas - veuillez utiliser au moins {gas} Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Erreur, veuillez réessayer",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Erreur, merci d'essayer plus tard",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "La valeur est trop élevée ou trop basse",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "S'il vous plaît entrer des données",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Valeur totale estimée",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Exemple: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Opportun",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Coûteux",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "Identique au CEX",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Taux de change:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "ÉCHANGE",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Exporter",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Contacts",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Veuillez selectionner les objets à exporter dans le fichier chiffré.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Exporter",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Notes",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "Les objets ont été exportés avec succès:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Échange",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Exporter",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Erreur",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Montant du faux solde :",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Foire aux questions",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Erreur",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "Envoi de la demande au robinet {coin} ...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "FAUCET",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Succès",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "La demande a expiré",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Envoyer des commentaires",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Actualités",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Rien ici",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} actualités",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Lire plus...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Fil",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Fil d'Actualités",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "Impossible de mettre à jour le fil d'actu",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "Impossible de recevoir les mises à jour du fil d'actu",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Fil d'actualité mis à jour",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Déjà à jour",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "Les frais doivent être jusqu'à {value}",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Tout",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Filtrer",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Effacer tous les filtres",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Échoué",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "du",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Maker",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Recevoir crypto-monnaie",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Vendre crypto-monnaie",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Statut",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Réussi",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Taker",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "au",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Taker/Maker",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Empreinte digitale",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Je termine, veuillez patienter",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "Code QR trouvé",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Français",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "De",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} commission",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "limite Gas",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Veuillez activer {coin}.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "prix Gas",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "Protection PIN pas activé.\nCamouflage PIN non disponible.\nVeuillez activer la protection PIN.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Important: sauvegardez votre passphrase avant de continuer!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "En cours de transaction, veuillez patienter",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Ouvrir portfolio",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Gwei doit atteindre {value}",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "Aide",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Aide et Assistance",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Masquer balances",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Confirmez le Mot de passe",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Créer Mot de passe",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Mot de passe actuel",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Tapez votre Mot de passe",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Entrez votre passphrase",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Nommez votre portefeuille",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Mot de passe",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "historique",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "h",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Hongrois",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "Importer",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Données corrompues ou Mot de passe incorrect",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "données à importer:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Fichier non trouvé",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Données d'échange non valides. Veuillez fournir un fichier JSON d'état d'échange valide.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "Importer",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Veuillez selectionner le chiffré à importer.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Ouverture...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Veuillez selectionner le fichier texte d'échange à importer.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "Retour",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Ok",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Mot de passe",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Importer Échange Simple",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Importer Échange",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Des données ont été ignorées",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "Données importé avec succès:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "Impossible d'importer l'échange",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Erreur décodage fichier json",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "Importer",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Paramètres de protection des transmissions entrantes {coinName}",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Si vous n'entrez pas de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "La demande d'échange ne peut pas être annulée et constitue un événement final!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "Cette transaction peut prendre jusqu'à 10 minutes. NE FERMEZ PAS cette application!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Vous pouvez choisir de chiffrer votre portefeuille avec un mot de passe. Si vous choisissez de ne pas utiliser de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} balance insuffisante pour payer les frais de courtage",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "Le volume minimum requis pour cet ordre est",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Volume insuffisant",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Rafraichir",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "Connexion Internet Restauré",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "Échange impossible",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Détails",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} est indisponible :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "Je comprends",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Japonais",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Coréen",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Langue",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Dernières Transactions",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Légal",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "Moins",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗Attention ! Le marché pour {coinName} a un volume de transactions inférieur à 10 000 $ sur 24 heures !",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "La limite doit aller jusqu'à {value}",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "Chargement...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Chargement des ordres ...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "L'écran est verrouillé",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "S'il vous plaît authentifiez vous!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "se connecter",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Se Déconnecter",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Déconnexion à la sortie",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Paramètres de déconnexion",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "Êtes-vous sur de vouloir quitter?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "minutes",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "creer un ordre",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Maker",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Annuler ordre",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "Créer à",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Reçu",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "ID Ordre",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Aucun échange démarré par cet ordre",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Prix",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Vendre",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "Échange démarré par cet ordre",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Détails ordre des Maker",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Ordre des Maker",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Marché",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "Graphique",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Profondeur",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "aucune demande trouvée",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "Aucune offre trouvée",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "CARNET d'ORDRES",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Détail Ordre",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "PRIX",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Veuillez selectionner crypto-monnaies",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Marchés",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "MARCHÉS",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "Les mots de passes doivent être identiques",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Change",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Votre PIN et masque PIN sont identiques.\nLe mode Masquage ne sera pas activé.\nVeuillez changer le Masque PIN.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "PIN Incorrect",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "MAX",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Volume d'odre Max:",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Média",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "FEUILLETER",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "PARCOURIR",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "Par",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "VOUS N'AVEZ PAS D'ARTICLES ENREGISTRÉS",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "ENREGISTRÉ",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Note",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Fusionner",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Valeur fusionnée :",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "ms",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "MIN",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Avertissement : la réduction de l'application sur iOS mettra fin au processus d'activation.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "Volume d'odre Min:",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "m",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "Le montant minimum à vendre est {number} {coinName}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "Le montant minimum à acheter est {number} {coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "Le montant minimum de la commande est de {buyAmount}{buyCoin}({sellAmount}{sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "Le montant minimum à vendre est de {number}{coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "Doit être supérieur à {minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Doit être inférieur au montant de la vente",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Volume Min requis",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "Utiliser le volume minimal personnalisé",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Veuillez noter que vous utilisez maintenant des données cellulaires et que votre participation au réseau {appName} P2P consomme du trafic Internet. Il est préférable d'utiliser un réseau WiFi si votre forfait de données cellulaires est coûteux.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Plus d'informations",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "Plus",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Activez {coin} et rechargez d'abord le solde",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Montant",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Crypto-monnaie",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Vendre",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "Annuler",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Confirmer",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "Créer {number} Ordre(s):",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Créer",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Ordre",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Ordres",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "frais",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "Annuler",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Veuillez entrer le montant fiat à recevoir:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Replissage auto",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Veuillez corriger toutes les erreurs avant de continuer",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Montant invalide",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Montant de vente invalide",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "Pas assez de {coin} pour payer les frais. Balance MIN necessaire {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "La balance {coin} est trop faible",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "Montant de vente Max est",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "Montant de reception Min est",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "Montant de vente Min est",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Recevoir:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Vendre:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Multi",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Montant reçu",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "Prix/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Frais de réseau",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "nouveau compte",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Nouveau compte",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Fil d'actualité",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Nouvel valeur:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "suivant",
-    "@next": {
-        "type": "text"
-    },
-    "no": "Non",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "Pas d'articles - s'il vous plaît revenez plus tard!",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "Pas de crypto-monnaie trouvé",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Pas de fonds",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "Pas de fonds disponibles - faire un dépot s'il vous plaît.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "Pas de connexion Internet",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "Pas d'articles sélectionnés",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "Pas d'articles sélectionnés",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "Pas d'ordres compatibles trouvés",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Aucun",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "Entrer une valeur numérique",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Aucun ordre {coinName} disponible - réessayez ultérieurement ou créez un ordre.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Cliquez pour créer un ordre",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "Pas d'ordres, veuillez ouvrir menu échange.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "Pas de bonus disponible",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "Aucune récompense ne peut être demandée - veuillez réessayer dans 1h.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "Pas une telle pièce",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "Pas d'historique.",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "Pas assez de {coin} pour la transaction!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "Pas assez de solde pour les frais - échangez un montant inférieur",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Remarque : La commande correspondante ne peut plus être annulée",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Ajouter une Note",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Note",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Pas de résultat",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": " L'échange{sell} / {buy} s'est terminé avec succès",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "Échange terminé",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} échange échoué",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "Échange échoué",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} échange démarré",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Nouvel échange démarré",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Statut de l'échange modifié",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} délais d'échange dépassé",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Délais d'échange dépassé",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "Vous avez reçu {coin}  transaction !",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Transaction entrante",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "Aucune transactions",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} Actifs",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "Communiqué de presse officiel",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Ok",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Supprimer",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Anciens logs",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Espace utilisé",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Ouvrir Message d'Erreur",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "Facultatif",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "Moins",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "Plus",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Tous les ordres {coin} seront annulés.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Ordre créée",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Ordre créée avec succès",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Adresses",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "Annuler",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "Expédient : CEX +{delta} %",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "Cher : CEX {delta} %",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "pour",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "Identique au CEX",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "min.",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Prix",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Recevoir",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Selectionner",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Ventes",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Ouvrez les détails en un seul clic et sélectionnez Commander en appuyant longuement",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Dépenser",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Détails",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% rempli",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Ordre trouvé",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Recherche d'ordre",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "ordres",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Actif",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "Historique",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "Mnt. ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "Prix ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "Total ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Ordre",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Type d'odre inconnu",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Écraser",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": " Ceci est votre propre commande!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Payé à partir du solde :",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Payé à partir du volume reçu :",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Payé avec",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "Le mot de passe doit contenir au moins 12 caractères, avec une minuscule, une majuscule et un symbole spécial.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Payer",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "Acceptez-vous cette transaction?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "Adresser",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "Montant:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Crypto-monnaie:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "Annuler",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Paiement demandé",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} n'est pas actif. Veuillez activer et réessayer.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Passer votre ordre",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "\n\nÉcouter au volume max",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Veuillez ajouter une Crypto-monnaie",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Veuillez redémarrer l'application pour réessayer, ou appuyer sur le bouton ci-dessous.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Portfolio",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Propulsé par Komodo",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "prix",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Clé privée",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Clés privées",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Confirmations",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Utiliser les paramètres de protection personnalisés",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "OFF",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "ON",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Attention, cet \"atomic swap\" n'est pas protégé par dPoW.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Pubkey",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "Scanner de codes QR",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "Stockez-vous ma clé privé?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "Quels sont les appareils compatibles avec {appName}?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "En quoi le trading sur {appName} est-il différent du trading sur d'autres DEX ?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "Combien de temps dure chaque échange atomique ?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "Dois-je être en ligne pendant toute la durée de l'échange ?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "Comment sont calculés les frais sur {appName}  ?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "Offrez-vous une assistance aux utilisateurs ?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "Avez-vous des restrictions par pays ?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "Qui est derrière {appName}?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "Est-il possible de développer mon propre échange en marque blanche sur {appName} ?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "C'est une nouvelle ère ! Nous avons officiellement changé notre nom de 'AtomicDEX' en 'Komodo Wallet'",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "RECEVOIR",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Recevoir",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Nous vous recommandons de la stocker hors ligne.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Désactivé",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Commerce demandé",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "EFFACER",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Réinitialiser le formulaire",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "RESTAURER",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Nouvelle tentative d'activation de toutes les pièces...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Réessayez d'activer tout",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Réclamer votre récompense",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Annuler",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Quelque chose s'est mal passé. Veuillez réessayer plus tard.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "La transaction est en cours",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "En traitement",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "Montant UTXO inférieur à 10 KMD",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Une heure pas encore passée",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 hour",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "Ok",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Statut récompense:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "En savoir plus sur les récompenses des utilisateurs actifs KMD",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Recevoir",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "Succès! {amount} KMD reçu.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "Fiat",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "Récompense,\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Statut",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Temps restant",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Information récompense:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "mnt UTXO,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} jour(s)",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}h {minutes}m",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}min",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "Information récompense",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Russe",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Enregistrer fusionné",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "Faites défiler vers le bas pour continuer...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Rechercher une crypto-monnaie",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Sélectionner tous les tokens Avax",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Sélectionner tous les tokens BEP",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Tout sélectionner Cosmos Network",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Sélectionner tous les tokens ERC",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Sélectionner tous les tokens ETC",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Sélectionner tous les tokens Fantom",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Sélectionner tous les tokens HecoChain",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Sélectionner tous les tokens Harmony",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Tout sélectionner Réseau Iris",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Sélectionner tous les tokens Kucoin",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Sélectionner tous les tokens Moonriver",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Sélectionner tous les tokens Polygon",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Sélectionner tous les tokens QRC",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Sélectionner tous les tokens SmartBCH",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Sélectionner tous les jetons SLP",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Sélectionner tous les tokens SmartChains",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Sélectionner tous les tokens Test Assets",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Sélectionner tous les tokens Ubiq",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Sélectionner tous les tokens UTXO",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Sélectionnez toutes les pièces ZHTLC",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Rechercher un téléscripteur",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Sécurité",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "Passphrases",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Votre nouvelle passphrase",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "Cliquez pour voir {amount} orders",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "Voir l'historique de transaction",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Choisir crypto-monnaie",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Sélectionnez les crypto-monnaie que vous souhaitez ajouter à votre portefeuille.",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Activer les crypto-monnaie:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "Sélectionnez la crypto-monnaie que vous souhaitez acheter",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "Sélectionnez la crypto-monnaie que vous souhaitez vendre",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Selectionner ordre:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Selectionner fichier",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Selectionner langue",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Sélectionnez votre méthode de paiement",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Vendre",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "Attention, vous êtes prêt à vendre des pièces de test SANS valeur réelle !",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "ENVOYER",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Etes-vous sûr que vous voulez supprimer",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "portefeuille?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Si oui, assurez-vous de",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "enregistrez votre passphrase.",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "Afin de restaurer votre portefeuille à l'avenir.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Langues",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Réglages",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "CONFIGURER UN MOT DE PASSE",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "Partager",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "Mon adresse {coinName}:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Afficher l'adresse",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Afficher Détails",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "Affichage de {count} commandes sur {maxCount}.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "MONTRER MES COMMANDES",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Se connecter avec mot de passe",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "Connectez-vous avec la passphrase",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Facile",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Activer",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Veuillez entrer le montant de {coin} à acheter",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Acheter",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Fermer",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "Le nombre maximum de pièces actives est de {maxCoins}. Veuillez en désactiver certains.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} pas activé!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Recevoir",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Veuillez entrer le montant de {coin} à vendre",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Vendre",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Envoyer",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Afficher moins",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Afficher plus",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "Impossible d'activer {coin}",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Passer",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Rejeter",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Son",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Choisissez un fichier mp3 ou wav s'il vous plaît. Nous y jouerons quand {description}.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "Joué quand {description}",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Sons",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Compris, ne plus afficher",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Son",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Paramètres son",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "Vous entendrez des notifications sonores pendant le processus d'échange et lorsqu'une commande de fabricant active sera passée.\nLe protocole d'échange atomique exige que les participants soient en ligne pour un échange réussi, et des notifications sonores aident à y parvenir.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Notez que vous pouvez définir vos sons personnalisés dans les paramètres de l'application.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "Espagnol",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Commencer l'échange",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Étape",
-    "@step": {
-        "type": "text"
-    },
-    "success": "Succès!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Support",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Si vous avez des questions ou si vous pensez avoir rencontré un problème technique avec l'application {appName} , vous pouvez le signaler et obtenir de l'aide de notre équipe.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "échanger",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Actuel",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "CONFIRMEZ LES DÉTAILS DE L’ÉCHANGE",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "Estimation",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "L'échange a échoué",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Veuillez d'abord activer {coin} et recharger le solde",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "{coin}  solde insuffisant pour payer les frais de transaction.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "{coin}  solde insuffisant pour payer les frais de transaction. {coin} {amount} requis.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Echange en cours",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "Détails de la progression",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "commencé",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Échange réussi",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Total",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "UUID échange",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Changer de thème",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Taker",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Ordre Taker",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Temps écoulé",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "CRÉER UN MOT DE PASSE",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Ordre sélectionnés",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "À",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "Adresse de destination:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "Vous avez",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": " actifs activés. La limite maximale des éléments activés est",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Trop d'éléments activés",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Frais totaux:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "COMMERCE",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "ECHANGE TERMINÉ!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "DÉTAILS DE L'ÉCHANGE",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Échec du calcul des frais commerciaux",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "frais de négociation :",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Trading Mode:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "Adresse de transaction",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "Transaction masquée",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Cette transaction a été masquée en raison d'une éventuelle tentative de phishing.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "Si même alors certaines pièces ne sont toujours pas activées, essayez de redémarrer l'application.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Turque",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Bloc",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Confirmations",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "CONFIRMÉ",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Frais",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "frais transactions:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "Identifiant de transaction",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Transactions restantes : {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Trop de demandes.\nLimite de demandes d'historique des transactions dépassée.\nVeuillez réessayer plus tard.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "NON CONFIRMÉ",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Ukrainien",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "ouvrir",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Débloquer Fonds",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": " {amnt}  fonds ont été débloqués avec succès - TX : {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "indépensable",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Nouvelle version disponible",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Recherche de mise à jour...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "Version {version} en cours d'utilisation",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Nouvelle version disponible. Veuillez mettre à jour.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "Version {version} disponible. Veuillez mettre à jour.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Mise à jour disponible",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Ignorer pour l'instant",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "Mise à jour {appName}",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Update",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Déjà à jour",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "Pas assez de solde pour numériser",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "demander paiement.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Balance insuffisante",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Valeur:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "version",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Explorer",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Passphrases et Clés Privées",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Les volumes",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "Le nom du Portefeuille existe déjà",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "Le nom du Portefeuille ne doit pas dépasser 40 charactères",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Portefeuille uniquement",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "Attention!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Ok",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Attention - dans des cas particuliers, ces données de journal contiennent des informations sensibles qui peuvent être utilisées pour dépenser des pièces à partir d'échanges échoués !",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "Activation {coinAbbr} échoué",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "Activation {coinAbbr} échoué.\nVeuillez redémarrer l'application et réessayer.",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "Komodo Wallet est un portefeuille multi crypto-monnaies de nouvelle génération doté de la fonctionnalité DEX native de troisième génération et encore bien plus.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "CONFIGURONS!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "BIENVENUE",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "portefeuille",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "Vous serez redirigé vers la page du portfolio à la fin.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Cela prendra un certain temps et l'application doit rester au premier plan.\nLa fermeture de l'application pendant l'activation est en cours peut entraîner des problèmes.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Envoyer",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "Vous avez précédemment refusé à {appName} l'accès à la caméra.\nVeuillez modifier manuellement l'autorisation de l'appareil photo dans les paramètres de votre téléphone pour procéder à l'analyse du code QR.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Accès refusé",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Confirmer le retrait",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Un problème est survenu. Réessayez plus tard.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "ENVOYER {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "Vous essayez de scanner un code QR de paiement pour",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": " mais tu es sur",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": " retirer l'écran",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Mauvaise crypto-monnaie",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "Le mot de passe ne correspond pas. Veuillez réessayer.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Oui",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Vous envoyez:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "vous avez une nouvelle commande qui essaie de correspondre à une commande existante",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "vous avez un échange actif en cours",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "vous avez une commande avec laquelle de nouvelles commandes peuvent correspondre",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "votre portefeuille",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "Vous recevrez {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Vous allez recevoir:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "fr",
+  "accepteula": "Accepter les conditions générales de ventes",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "Accepter les conditions générales d'utilisations",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Activer la protection Biométrique",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "Activer la protection PIN",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "Activer les pièces {protocolName} ?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "Activation de {coinName}",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "Activation de {coinName}",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} Activation en cours",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Active",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Activer la crypto-monnaie",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} activé avec succès !",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Ajouter Adresse",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Répertoire",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "Répertoire vide",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Seules les adresses {title} sont affichées",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Répertoire",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "Impossible d'envoyer les fonds sur l'adresse {abbr} car elle n'est pas activée. Veuillez ouvrir le portfolio.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Pas de résultats",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Choisir Crypto-monnaie",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Adresse du destinataire",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Avancé",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "Tout",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Autoriser les passphrases personnalisées",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "Votre portefeuille affichera toutes les transactions passées. Cela prendra beaucoup de temps et de stockage car tous les blocs seront téléchargés et analysés.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "Doublon existant",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Montant",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Montant à vendre",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "Non ! {appName} est non-custodial. Aucune donnée sensible n'est sauvegardé, ni votre clé privé, ni votre passphrases, ni votre PIN. Toutes ces données sont stockées sur votre appareil et ne sont jamais transmises.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} est disponible pour mobile sur Android et iPhone, et pour ordinateur sur <a href=\"https://komodoplatform.com/\">systèmes d'exploitation Windows, Mac et Linux</a>.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Les autres DEX ne vous permettent généralement que d'échanger des actifs basés sur un seul réseau de blockchain, d'utiliser des jetons proxy et de ne permettre de passer qu'une seule commande avec les mêmes fonds.\n\n{appName} vous permet d'échanger nativement sur deux réseaux blockchain différents sans jetons proxy. Vous pouvez également passer plusieurs commandes avec les mêmes fonds. Par exemple, vous pouvez vendre 0,1 BTC pour KMD, QTUM ou VRSC — la première commande exécutée annule automatiquement toutes les autres commandes.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Plusieurs facteurs déterminent le temps de traitement de chaque échange. Le temps de blocage des actifs échangés dépend de chaque réseau (Bitcoin étant généralement le plus lent). De plus, l'utilisateur peut personnaliser les préférences de sécurité. Par exemple, vous pouvez demander à {appName} de considérer une transaction KMD comme finale après seulement 3 confirmations, ce qui raccourcit le temps d'échange par rapport à l'attente d'une <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarisation</a>.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Oui. Vous devez rester connecté à Internet et exécuter votre application pour réussir chaque échange atomique (de très courtes pauses de connectivité sont généralement acceptables). Sinon, il y a un risque d'annulation de transaction si vous êtes un fabricant et un risque de perte de fonds si vous êtes un preneur. Le protocole d'échange atomique exige que les deux participants restent en ligne et surveillent les chaînes de blocs impliquées pour que le processus reste atomique.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "Il existe deux catégories de frais à prendre en compte lors de la négociation sur {appName}.\n\n1. {appName} facture environ 0,13 % (1/777 du volume de négociation mais pas moins de 0,0001) comme frais de négociation pour les ordres preneurs, et les ordres fabricant n'ont aucun frais.\n\n2. Les fabricants et les preneurs devront payer des frais de réseau normaux aux chaînes de blocs impliquées lors des transactions d'échange atomique.\n\nLes frais de réseau peuvent varier considérablement en fonction de la paire de négociation que vous avez sélectionnée.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "Oui! {appName} propose une assistance via le <a href=\"{link}\">{appCompanyShort} {name}</a>. L'équipe et la communauté sont toujours ravies de vous aider !",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "Non! {appName} est entièrement décentralisé. Il n'est pas possible de limiter l'accès des utilisateurs par un tiers.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} est développé par l'équipe {appCompanyShort} . {appCompanyShort} est l'un des projets de blockchain les plus établis travaillant sur des solutions innovantes telles que les swaps atomiques, la preuve de travail différée et une architecture multichaîne interopérable.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "Absolument! Vous pouvez lire notre <a href=\"https://developers.komodoplatform.com/\">documentation pour les développeurs</a> pour plus de détails ou nous contacter pour vos demandes de partenariat. Vous avez une question technique spécifique ? La communauté de développeurs {appName} est toujours prête à vous aider !",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Applause",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "ÊTES-VOUS SÛR?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "un échange a échoué",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "un échange est en cours",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "authentification",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Vous serez automatiquement redirigé vers la page du portfolio une fois le processus de réactivation terminé.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "vol max",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "retour",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Sauvegarde",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "basé sur {coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "La charge de votre batterie est essentielle ({batteryLevelCritical} %) pour effectuer un échange en toute sécurité. Veuillez le mettre en charge et réessayer.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "La charge de votre batterie est inférieure à {batteryLevelLow} %. Veuillez considérer la recharge du téléphone.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Votre téléphone est en mode d'économie de batterie. Veuillez désactiver ce mode ou ne PAS mettre l'application en arrière-plan, sinon l'application pourrait être tuée par le système d'exploitation et l'échange échouerait.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "Meilleur tarif disponible",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Conçu sur Komodo",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Conçu sur Komodo",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Acheter",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "Convertir en Maker s'il n'y a pas de correspondance",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Échange émis, veuillez patienter!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "Ordre en cours, veuillez patienter {seconde} secondes!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "Attention, vous êtes prêt à acheter des pièces test SANS valeur réelle !",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "Le code PIN de camouflage et la protection bio ne peuvent pas être activés en même temps.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Camo PIN et conflit de protection Bio.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Changer Masque PIN",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Créer Masque PIN",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Si vous déverrouillez l'application avec le code PIN de camouflage, un faux solde FAIBLE sera affiché et l'option de configuration du code PIN de camouflage ne sera PAS visible dans les paramètres.",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "Masque PIN incorrect",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Masque PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "Masque PIN introuvable",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Off",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "On",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "Masque PIN sauvegardé",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Masque PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Entrer un nouveau Masque PIN",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Configuration Masque PIN",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Configuration Masque PIN",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "Annuler",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Annuler l'activation",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "Etes-vous sûr de vouloir annuler l'activation ?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "Annuler",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Annuler l'ordre",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Un problème est survenu. Réessayez plus tard.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ok",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": " est une pièce par défaut. Les pièces par défaut ne peuvent pas être désactivées.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "Désactivation impossible",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "Lecture impossible",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "Taux de change CEX",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "Données CEX",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Les données de marché (prix, graphiques, etc.) marquées de cette icône proviennent de sources tierces (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "Taux CEX",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "Changer code PIN",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Vérifier les mises à jours",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Check-out",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "Vérifier la passphrase",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "CONTINUER",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "RETOURNEZ ET VÉRIFIEZ À NOUVEAU",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "Entrez le {index} mot",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "Votre passphrase est importante - c'est pourquoi nous voulons nous assurer qu'elle est correcte. Nous vous poserons trois questions différentes sur votre passphrase pour vous assurer que vous pourrez facilement restaurer votre portefeuille à tout moment.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "Quel est le {index} mot dans votre passphrase?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "VERIFIONS UNE NOUVELLE FOIS VOTRE PASSPHRASE",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Chinois",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "réclamer",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "Réclamer votre récompense KMD?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Cliquez pour voir",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "Copié dans le presse-papiers",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "Copier dans le presse-papiers",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Fermer",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Fermer Message d'Erreur",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Fermer aperçu",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Code:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "Etes-vous sûr de vouloir annuler l'activation ?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Vous avez sélectionné le nombre maximum d'éléments",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "Les pièces {protocolName} sont activées",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} pièces activées avec succès",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "Les pièces {protocolName} ne sont pas activées",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Effacer",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "Aucune crypto-monnaie active",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Choisir crypto-monnaie",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "A venir...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "TX détails à venir!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "Détails à venir!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "frais de commission",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "par rapport à la moyenne Prix CEX 24h",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "comparé au CEX",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "Portefeuille en cours de configuration, veuillez patienter...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "Confirmer",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Confirmer Masque PIN",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "Êtes-vous sûr d'annuler l'odre",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "En cliquant sur le bouton ci-dessous vous confrimez avec lu et accepté les CGV et CGU",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Confirmez le mot de passe",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "Confirmer le code PIN",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "Confirmer la passphrase",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Connexion…",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "Annuler",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Supprimer Contact",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "Supprimer",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "Voulez-vous supprimer le contact {name}?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Annuler",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Editer",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Fermer",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Annuler vos modifications ?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "Aucun contact trouvé",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Enregistrer",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Détail Contact",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "Nom",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Contracter",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Convertir",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "Impossible de lancer l'URL",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "Import impossible:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "Échange",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "CRÉER UN PORTEFEUILLE",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Créer contact",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "Créer PIN",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Monnaie",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Monnaie",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Prix actuel:",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Frais personnalisés",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "N'utiliser les frais personnalisés que si vous savez ce que vous faite!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Les phrases de départ personnalisées peuvent être moins sécurisées et plus faciles à déchiffrer qu'une phrase de départ ou une clé privée (WIF) conforme à BIP39. Pour confirmer que vous comprenez le risque et savez ce que vous faites, saisissez \" {iUnderstand}\" dans la case ci-dessous.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Date",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Décryptage du portefeuille...",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Supprimer",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Confirmer désactivation",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "Voulez-vous supprimer",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": " de votre portefeuille ? Toutes les commandes sans correspondance seront annulées.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " sera également désactivé",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Supprimer le portefeuille",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Supression portefeuille…",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "recevez des frais de transaction {coinName}",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "envoyer des frais de transaction à {coinName}",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "envoyer des frais de négociation frais de transaction",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "frais de négociation",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "détails",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Allemand",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Développeur",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "Cette crypto-monnaie n'est pas supporté par DEX",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Désactiver les captures d'écran/aperçu",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Avertissement et Conditions d'utilisation",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Terminé",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Ne fermez pas l'application. Appuyez pour plus d'informations...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "Ne plus demander",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "Je ne veux pas de mot de passe",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo sécurité dPoW",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Durée",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Editer contact",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "Entrez l'adresse {abbr} ",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "Le mot de passe chiffré ne peut être nul",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "Le mot de passe ne peut être nul",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "Le nom du contact ne peut être nul",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "Le nom du portefeuille ne peut être nul",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Vous pouvez toujours activer {remains}, Selected : {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Veuillez activer les notifications pour obtenir des mises à jour sur la progression de l'activation.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Activer les crypto-monnaies de Test",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "Vous avez",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": " actifs activés et tentative d'activation",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": " Suite. La limite maximale des éléments activés est",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Tentative d'activation d'un trop grand nombre d'éléments",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Chiffrement du portefeuille...",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "Anglais",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Enter votre nouveau PIN",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Entrer votre ancien PIN",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Veuillez entrer votre mot de passe pour continuer.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "Entrez votre code PIN",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Entrez votre passphrase",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Vous devez d'abord entrer le prix de vente",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "Solde insuffisant",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "Adresse non valide",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Adresses Segwit non supportées (pour le moment)",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "Pas assez de gas - veuillez utiliser au moins {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Erreur, veuillez réessayer",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Erreur, merci d'essayer plus tard",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "La valeur est trop élevée ou trop basse",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "S'il vous plaît entrer des données",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Valeur totale estimée",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Exemple: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Opportun",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Coûteux",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "Identique au CEX",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Taux de change:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "ÉCHANGE",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Exporter",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Contacts",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Veuillez selectionner les objets à exporter dans le fichier chiffré.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Exporter",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Notes",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "Les objets ont été exportés avec succès:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Échange",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Exporter",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Erreur",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Montant du faux solde :",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Foire aux questions",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Erreur",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "Envoi de la demande au robinet {coin} ...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "FAUCET",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Succès",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "La demande a expiré",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Envoyer des commentaires",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Actualités",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Rien ici",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} actualités",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Lire plus...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Fil",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Fil d'Actualités",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "Impossible de mettre à jour le fil d'actu",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "Impossible de recevoir les mises à jour du fil d'actu",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Fil d'actualité mis à jour",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Déjà à jour",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "Les frais doivent être jusqu'à {value}",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Tout",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Filtrer",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Effacer tous les filtres",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Échoué",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "du",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Maker",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Recevoir crypto-monnaie",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Vendre crypto-monnaie",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Statut",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Réussi",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Taker",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "au",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Taker/Maker",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Empreinte digitale",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Je termine, veuillez patienter",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "Code QR trouvé",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Français",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "De",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "Nous synchroniserons les futures transactions effectuées après l'activation associée à votre clé publique. C’est l’option la plus rapide et celle qui nécessite le moins de stockage.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} commission",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "limite Gas",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Veuillez activer {coin}.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "prix Gas",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "Protection PIN pas activé.\nCamouflage PIN non disponible.\nVeuillez activer la protection PIN.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Important: sauvegardez votre passphrase avant de continuer!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "En cours de transaction, veuillez patienter",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Ouvrir portfolio",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei doit atteindre {value}",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Aide",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Aide et Assistance",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Masquer balances",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Confirmez le Mot de passe",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Créer Mot de passe",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Mot de passe actuel",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Tapez votre Mot de passe",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Entrez votre passphrase",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Nommez votre portefeuille",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Mot de passe",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "historique",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "h",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Hongrois",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "Importer",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Données corrompues ou Mot de passe incorrect",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "données à importer:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Fichier non trouvé",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Données d'échange non valides. Veuillez fournir un fichier JSON d'état d'échange valide.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "Importer",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Veuillez selectionner le chiffré à importer.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Ouverture...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Veuillez selectionner le fichier texte d'échange à importer.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "Retour",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Ok",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Mot de passe",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Importer Échange Simple",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Importer Échange",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Des données ont été ignorées",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "Données importé avec succès:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "Impossible d'importer l'échange",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Erreur décodage fichier json",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "Importer",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Paramètres de protection des transmissions entrantes {coinName}",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Si vous n'entrez pas de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "La demande d'échange ne peut pas être annulée et constitue un événement final!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "Cette transaction peut prendre jusqu'à 10 minutes. NE FERMEZ PAS cette application!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Vous pouvez choisir de chiffrer votre portefeuille avec un mot de passe. Si vous choisissez de ne pas utiliser de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} balance insuffisante pour payer les frais de courtage",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "Le volume minimum requis pour cet ordre est",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Volume insuffisant",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Rafraichir",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "Connexion Internet Restauré",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Adresse {coin} invalide",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "Échange impossible",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Détails",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} est indisponible :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "Je comprends",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Japonais",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Coréen",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Langue",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Dernières Transactions",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Légal",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "Moins",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗Attention ! Le marché pour {coinName} a un volume de transactions inférieur à 10 000 $ sur 24 heures !",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "La limite doit aller jusqu'à {value}",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Chargement...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Chargement des ordres ...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "L'écran est verrouillé",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "S'il vous plaît authentifiez vous!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "se connecter",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Se Déconnecter",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Déconnexion à la sortie",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Paramètres de déconnexion",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "Êtes-vous sur de vouloir quitter?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "minutes",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "creer un ordre",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Maker",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Annuler ordre",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "Créer à",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Reçu",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "ID Ordre",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Aucun échange démarré par cet ordre",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Prix",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Vendre",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "Échange démarré par cet ordre",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Détails ordre des Maker",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Ordre des Maker",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Marché",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "Graphique",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Profondeur",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "aucune demande trouvée",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "Aucune offre trouvée",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "CARNET d'ORDRES",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Détail Ordre",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "PRIX",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Veuillez selectionner crypto-monnaies",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Marchés",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "MARCHÉS",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "Les mots de passes doivent être identiques",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Change",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Votre PIN et masque PIN sont identiques.\nLe mode Masquage ne sera pas activé.\nVeuillez changer le Masque PIN.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "PIN Incorrect",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "MAX",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Volume d'odre Max:",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Média",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "FEUILLETER",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "PARCOURIR",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "Par",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "VOUS N'AVEZ PAS D'ARTICLES ENREGISTRÉS",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "ENREGISTRÉ",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Note",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Fusionner",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Valeur fusionnée :",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "ms",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "MIN",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Avertissement : la réduction de l'application sur iOS mettra fin au processus d'activation.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "Volume d'odre Min:",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "m",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "Le montant minimum à vendre est {number} {coinName}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "Le montant minimum à acheter est {number} {coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "Le montant minimum de la commande est de {buyAmount}{buyCoin}({sellAmount}{sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "Le montant minimum à vendre est de {number}{coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "Doit être supérieur à {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Doit être inférieur au montant de la vente",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Volume Min requis",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "Utiliser le volume minimal personnalisé",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Veuillez noter que vous utilisez maintenant des données cellulaires et que votre participation au réseau {appName} P2P consomme du trafic Internet. Il est préférable d'utiliser un réseau WiFi si votre forfait de données cellulaires est coûteux.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Plus d'informations",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "Plus",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Activez {coin} et rechargez d'abord le solde",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Montant",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Crypto-monnaie",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Vendre",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "Annuler",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Confirmer",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "Créer {number} Ordre(s):",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Créer",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Ordre",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Ordres",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "frais",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "Annuler",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Veuillez entrer le montant fiat à recevoir:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Replissage auto",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Veuillez corriger toutes les erreurs avant de continuer",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Montant invalide",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Montant de vente invalide",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "Pas assez de {coin} pour payer les frais. Balance MIN necessaire {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "La balance {coin} est trop faible",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "Montant de vente Max est",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "Montant de reception Min est",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "Montant de vente Min est",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Recevoir:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Vendre:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Multi",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Montant reçu",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "Prix/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Frais de réseau",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "nouveau compte",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Nouveau compte",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Fil d'actualité",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Nouvel valeur:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "suivant",
+  "@next": {
+    "type": "text"
+  },
+  "no": "Non",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "Pas d'articles - s'il vous plaît revenez plus tard!",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "Pas de crypto-monnaie trouvé",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Pas de fonds",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "Pas de fonds disponibles - faire un dépot s'il vous plaît.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "Pas de connexion Internet",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "Pas d'articles sélectionnés",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "Pas d'articles sélectionnés",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "Pas d'ordres compatibles trouvés",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Aucun",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "Entrer une valeur numérique",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Aucun ordre {coinName} disponible - réessayez ultérieurement ou créez un ordre.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Cliquez pour créer un ordre",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "Pas d'ordres, veuillez ouvrir menu échange.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "Pas de bonus disponible",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "Aucune récompense ne peut être demandée - veuillez réessayer dans 1h.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "Pas une telle pièce",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "Pas d'historique.",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "Pas assez de {coin} pour la transaction!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "Pas assez de solde pour les frais - échangez un montant inférieur",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Remarque : La commande correspondante ne peut plus être annulée",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Ajouter une Note",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Note",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Pas de résultat",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": " L'échange{sell} / {buy} s'est terminé avec succès",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Échange terminé",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} échange échoué",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Échange échoué",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} échange démarré",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Nouvel échange démarré",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Statut de l'échange modifié",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} délais d'échange dépassé",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Délais d'échange dépassé",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "Vous avez reçu {coin}  transaction !",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Transaction entrante",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "Aucune transactions",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} Actifs",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "Communiqué de presse officiel",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Ok",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Supprimer",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Anciens logs",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Espace utilisé",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Ouvrir Message d'Erreur",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "Facultatif",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "Moins",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "Plus",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Tous les ordres {coin} seront annulés.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Ordre créée",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Ordre créée avec succès",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Adresses",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "Annuler",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "Expédient : CEX +{delta} %",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "Cher : CEX {delta} %",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "pour",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "Identique au CEX",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "min.",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Prix",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Recevoir",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Selectionner",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Ventes",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Ouvrez les détails en un seul clic et sélectionnez Commander en appuyant longuement",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Dépenser",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Détails",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% rempli",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Ordre trouvé",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Recherche d'ordre",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "ordres",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Actif",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "Historique",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "Mnt. ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "Prix ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "Total ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Ordre",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Type d'odre inconnu",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Écraser",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": " Ceci est votre propre commande!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Payé à partir du solde :",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Payé à partir du volume reçu :",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Payé avec",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "Le mot de passe doit contenir au moins 12 caractères, avec une minuscule, une majuscule et un symbole spécial.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "Votre portefeuille affichera vos transactions passées effectuées après la date spécifiée.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Payer",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "Acceptez-vous cette transaction?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "Adresser",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "Montant:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Crypto-monnaie:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "Annuler",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Paiement demandé",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} n'est pas actif. Veuillez activer et réessayer.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Passer votre ordre",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "\n\nÉcouter au volume max",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Veuillez ajouter une Crypto-monnaie",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Veuillez redémarrer l'application pour réessayer, ou appuyer sur le bouton ci-dessous.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Portfolio",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Propulsé par Komodo",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "prix",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Clé privée",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Clés privées",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Confirmations",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Utiliser les paramètres de protection personnalisés",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "OFF",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "ON",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Attention, cet \"atomic swap\" n'est pas protégé par dPoW.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Pubkey",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "Scanner de codes QR",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "Stockez-vous ma clé privé?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "Quels sont les appareils compatibles avec {appName}?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "En quoi le trading sur {appName} est-il différent du trading sur d'autres DEX ?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "Combien de temps dure chaque échange atomique ?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "Dois-je être en ligne pendant toute la durée de l'échange ?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "Comment sont calculés les frais sur {appName}  ?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Offrez-vous une assistance aux utilisateurs ?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "Avez-vous des restrictions par pays ?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "Qui est derrière {appName}?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "Est-il possible de développer mon propre échange en marque blanche sur {appName} ?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "C'est une nouvelle ère ! Nous avons officiellement changé notre nom de 'AtomicDEX' en 'Komodo Wallet'",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "RECEVOIR",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Recevoir",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Nous vous recommandons de la stocker hors ligne.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Désactivé",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Commerce demandé",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "EFFACER",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Réinitialiser le formulaire",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "RESTAURER",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Nouvelle tentative d'activation de toutes les pièces...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Réessayez d'activer tout",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Réclamer votre récompense",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Annuler",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Quelque chose s'est mal passé. Veuillez réessayer plus tard.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "La transaction est en cours",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "En traitement",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "Montant UTXO inférieur à 10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Une heure pas encore passée",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 hour",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "Ok",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Statut récompense:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "En savoir plus sur les récompenses des utilisateurs actifs KMD",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Recevoir",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "Succès! {amount} KMD reçu.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "Fiat",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "Récompense,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Statut",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Temps restant",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Information récompense:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "mnt UTXO,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} jour(s)",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}h {minutes}m",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}min",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Information récompense",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Russe",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Enregistrer fusionné",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "Faites défiler vers le bas pour continuer...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Rechercher une crypto-monnaie",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Sélectionner tous les tokens Avax",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Sélectionner tous les tokens BEP",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Tout sélectionner Cosmos Network",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Sélectionner tous les tokens ERC",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Sélectionner tous les tokens ETC",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Sélectionner tous les tokens Fantom",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Sélectionner tous les tokens HecoChain",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Sélectionner tous les tokens Harmony",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Tout sélectionner Réseau Iris",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Sélectionner tous les tokens Kucoin",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Sélectionner tous les tokens Moonriver",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Sélectionner tous les tokens Polygon",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Sélectionner tous les tokens QRC",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Sélectionner tous les tokens SmartBCH",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Sélectionner tous les jetons SLP",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Sélectionner tous les tokens SmartChains",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Sélectionner tous les tokens Test Assets",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Sélectionner tous les tokens Ubiq",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Sélectionner tous les tokens UTXO",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Sélectionnez toutes les pièces ZHTLC",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Rechercher un téléscripteur",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Sécurité",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "Passphrases",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Votre nouvelle passphrase",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "Cliquez pour voir {amount} orders",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "Voir l'historique de transaction",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Choisir crypto-monnaie",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Sélectionnez les crypto-monnaie que vous souhaitez ajouter à votre portefeuille.",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Activer les crypto-monnaie:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "Sélectionnez la crypto-monnaie que vous souhaitez acheter",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "Sélectionnez la crypto-monnaie que vous souhaitez vendre",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Sélectionnez une date",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Selectionner ordre:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Selectionner fichier",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Selectionner langue",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Sélectionnez votre méthode de paiement",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Vendre",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "Attention, vous êtes prêt à vendre des pièces de test SANS valeur réelle !",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "ENVOYER",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Etes-vous sûr que vous voulez supprimer",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "portefeuille?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Si oui, assurez-vous de",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "enregistrez votre passphrase.",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "Afin de restaurer votre portefeuille à l'avenir.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Langues",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Réglages",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "CONFIGURER UN MOT DE PASSE",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "Partager",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "Mon adresse {coinName}:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "Rechercher les transactions {coin} passées ?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Afficher l'adresse",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Afficher Détails",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "Affichage de {count} commandes sur {maxCount}.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "MONTRER MES COMMANDES",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Se connecter avec mot de passe",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "Connectez-vous avec la passphrase",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Facile",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Activer",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Veuillez entrer le montant de {coin} à acheter",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Acheter",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Fermer",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "Le nombre maximum de pièces actives est de {maxCoins}. Veuillez en désactiver certains.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} pas activé!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Recevoir",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Veuillez entrer le montant de {coin} à vendre",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Vendre",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Envoyer",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Afficher moins",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Afficher plus",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "Impossible d'activer {coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Passer",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Rejeter",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Son",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Choisissez un fichier mp3 ou wav s'il vous plaît. Nous y jouerons quand {description}.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "Joué quand {description}",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Sons",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Compris, ne plus afficher",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Son",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Paramètres son",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "Vous entendrez des notifications sonores pendant le processus d'échange et lorsqu'une commande de fabricant active sera passée.\nLe protocole d'échange atomique exige que les participants soient en ligne pour un échange réussi, et des notifications sonores aident à y parvenir.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Notez que vous pouvez définir vos sons personnalisés dans les paramètres de l'application.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "Espagnol",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Date de début",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Commencer l'échange",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Étape",
+  "@step": {
+    "type": "text"
+  },
+  "success": "Succès!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Support",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Si vous avez des questions ou si vous pensez avoir rencontré un problème technique avec l'application {appName} , vous pouvez le signaler et obtenir de l'aide de notre équipe.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "échanger",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Actuel",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "CONFIRMEZ LES DÉTAILS DE L’ÉCHANGE",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "Estimation",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "L'échange a échoué",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Veuillez d'abord activer {coin} et recharger le solde",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "{coin}  solde insuffisant pour payer les frais de transaction.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "{coin}  solde insuffisant pour payer les frais de transaction. {coin} {amount} requis.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Echange en cours",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "Détails de la progression",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "commencé",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Échange réussi",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Total",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "UUID échange",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Changer de thème",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Synchroniser à partir de la date spécifiée",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Synchronisation à partir de l'activation des jeunes arbres",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Synchroniser les nouvelles transactions",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "Quelles transactions {name} souhaitez-vous synchroniser ?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Taker",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Ordre Taker",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Temps écoulé",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "CRÉER UN MOT DE PASSE",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Ordre sélectionnés",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "À",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "Adresse de destination:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "Vous avez",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": " actifs activés. La limite maximale des éléments activés est",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Trop d'éléments activés",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Frais totaux:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "COMMERCE",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "ECHANGE TERMINÉ!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "DÉTAILS DE L'ÉCHANGE",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Échec du calcul des frais commerciaux",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "frais de négociation :",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Trading Mode:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "Adresse de transaction",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "Transaction masquée",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Cette transaction a été masquée en raison d'une éventuelle tentative de phishing.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "Si même alors certaines pièces ne sont toujours pas activées, essayez de redémarrer l'application.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Turque",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Bloc",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Confirmations",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "CONFIRMÉ",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Frais",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "frais transactions:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "Identifiant de transaction",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Transactions restantes : {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Trop de demandes.\nLimite de demandes d'historique des transactions dépassée.\nVeuillez réessayer plus tard.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "NON CONFIRMÉ",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Ukrainien",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "ouvrir",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Débloquer Fonds",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": " {amnt}  fonds ont été débloqués avec succès - TX : {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "indépensable",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Nouvelle version disponible",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Recherche de mise à jour...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "Version {version} en cours d'utilisation",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Nouvelle version disponible. Veuillez mettre à jour.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "Version {version} disponible. Veuillez mettre à jour.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Mise à jour disponible",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Ignorer pour l'instant",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "Mise à jour {appName}",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Update",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Déjà à jour",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "Pas assez de solde pour numériser",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "demander paiement.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Balance insuffisante",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Valeur:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "version",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Explorer",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Passphrases et Clés Privées",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Les volumes",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "Le nom du Portefeuille existe déjà",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "Le nom du Portefeuille ne doit pas dépasser 40 charactères",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Portefeuille uniquement",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "Attention!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Ok",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Attention - dans des cas particuliers, ces données de journal contiennent des informations sensibles qui peuvent être utilisées pour dépenser des pièces à partir d'échanges échoués !",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "Activation {coinAbbr} échoué",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "Activation {coinAbbr} échoué.\nVeuillez redémarrer l'application et réessayer.",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "Komodo Wallet est un portefeuille multi crypto-monnaies de nouvelle génération doté de la fonctionnalité DEX native de troisième génération et encore bien plus.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "CONFIGURONS!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "BIENVENUE",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "portefeuille",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "Vous serez redirigé vers la page du portfolio à la fin.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Cela prendra un certain temps et l'application doit rester au premier plan.\nLa fermeture de l'application pendant l'activation est en cours peut entraîner des problèmes.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Envoyer",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "Vous avez précédemment refusé à {appName} l'accès à la caméra.\nVeuillez modifier manuellement l'autorisation de l'appareil photo dans les paramètres de votre téléphone pour procéder à l'analyse du code QR.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Accès refusé",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Confirmer le retrait",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Un problème est survenu. Réessayez plus tard.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "ENVOYER {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "Vous essayez de scanner un code QR de paiement pour",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": " mais tu es sur",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": " retirer l'écran",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Mauvaise crypto-monnaie",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "Le mot de passe ne correspond pas. Veuillez réessayer.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Oui",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Vous envoyez:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "vous avez une nouvelle commande qui essaie de correspondre à une commande existante",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "vous avez un échange actif en cours",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "vous avez une commande avec laquelle de nouvelles commandes peuvent correspondre",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "votre portefeuille",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "Vous recevrez {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Vous allez recevoir:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -3621,6 +3621,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "Échec de l'annulation de l'activation de {coinAbbr}",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} est indisponible :(",
     "@isUnavailable": {
         "type": "text",
@@ -5460,6 +5470,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "Activation des pièces annulée",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "{coin} activé avec succès",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "Activation de {coin} annulée",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Veuillez accepter toutes les demandes spéciales d’activation de pièces ou désélectionner les pièces.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "Annuler l'activation",
     "@cancelActivation": {

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,3726 +1,5540 @@
 {
-  "@@locale": "fr",
-  "accepteula": "Accepter les conditions générales de ventes",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Accepter les conditions générales d'utilisations",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Activer la protection Biométrique",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "Activer la protection PIN",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "Activer les pièces {protocolName} ?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Veuillez noter que vous utilisez maintenant des données cellulaires et que votre participation au réseau {appName} P2P consomme du trafic Internet. Il est préférable d'utiliser un réseau WiFi si votre forfait de données cellulaires est coûteux.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Accès refusé",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "Vous avez précédemment refusé à {appName} l'accès à la caméra.\nVeuillez modifier manuellement l'autorisation de l'appareil photo dans les paramètres de votre téléphone pour procéder à l'analyse du code QR.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "BIENVENUE",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "portefeuille",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "Komodo Wallet est un portefeuille multi crypto-monnaies de nouvelle génération doté de la fonctionnalité DEX native de troisième génération et encore bien plus.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "CONFIGURONS!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "Mise à jour {appName}",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "Version {version} en cours d'utilisation",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Recherche de mise à jour...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Déjà à jour",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Nouvelle version disponible",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Update",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Ignorer pour l'instant",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Mise à jour disponible",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Nouvelle version disponible. Veuillez mettre à jour.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "Version {version} disponible. Veuillez mettre à jour.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Aide",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Aide et Assistance",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Foire aux questions",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Support",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Si vous avez des questions ou si vous pensez avoir rencontré un problème technique avec l'application {appName} , vous pouvez le signaler et obtenir de l'aide de notre équipe.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "Stockez-vous ma clé privé?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "Non ! {appName} est non-custodial. Aucune donnée sensible n'est sauvegardé, ni votre clé privé, ni votre passphrases, ni votre PIN. Toutes ces données sont stockées sur votre appareil et ne sont jamais transmises.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "En quoi le trading sur {appName} est-il différent du trading sur d'autres DEX ?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Les autres DEX ne vous permettent généralement que d'échanger des actifs basés sur un seul réseau de blockchain, d'utiliser des jetons proxy et de ne permettre de passer qu'une seule commande avec les mêmes fonds.\n\n{appName} vous permet d'échanger nativement sur deux réseaux blockchain différents sans jetons proxy. Vous pouvez également passer plusieurs commandes avec les mêmes fonds. Par exemple, vous pouvez vendre 0,1 BTC pour KMD, QTUM ou VRSC — la première commande exécutée annule automatiquement toutes les autres commandes.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "Combien de temps dure chaque échange atomique ?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Plusieurs facteurs déterminent le temps de traitement de chaque échange. Le temps de blocage des actifs échangés dépend de chaque réseau (Bitcoin étant généralement le plus lent). De plus, l'utilisateur peut personnaliser les préférences de sécurité. Par exemple, vous pouvez demander à {appName} de considérer une transaction KMD comme finale après seulement 3 confirmations, ce qui raccourcit le temps d'échange par rapport à l'attente d'une <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarisation</a>.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "Dois-je être en ligne pendant toute la durée de l'échange ?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Oui. Vous devez rester connecté à Internet et exécuter votre application pour réussir chaque échange atomique (de très courtes pauses de connectivité sont généralement acceptables). Sinon, il y a un risque d'annulation de transaction si vous êtes un fabricant et un risque de perte de fonds si vous êtes un preneur. Le protocole d'échange atomique exige que les deux participants restent en ligne et surveillent les chaînes de blocs impliquées pour que le processus reste atomique.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "Comment sont calculés les frais sur {appName}  ?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "Il existe deux catégories de frais à prendre en compte lors de la négociation sur {appName}.\n\n1. {appName} facture environ 0,13 % (1/777 du volume de négociation mais pas moins de 0,0001) comme frais de négociation pour les ordres preneurs, et les ordres fabricant n'ont aucun frais.\n\n2. Les fabricants et les preneurs devront payer des frais de réseau normaux aux chaînes de blocs impliquées lors des transactions d'échange atomique.\n\nLes frais de réseau peuvent varier considérablement en fonction de la paire de négociation que vous avez sélectionnée.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "Offrez-vous une assistance aux utilisateurs ?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "Oui! {appName} propose une assistance via le <a href=\"{link}\">{appCompanyShort} {name}</a>. L'équipe et la communauté sont toujours ravies de vous aider !",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "Avez-vous des restrictions par pays ?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "Non! {appName} est entièrement décentralisé. Il n'est pas possible de limiter l'accès des utilisateurs par un tiers.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "Qui est derrière {appName}?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} est développé par l'équipe {appCompanyShort} . {appCompanyShort} est l'un des projets de blockchain les plus établis travaillant sur des solutions innovantes telles que les swaps atomiques, la preuve de travail différée et une architecture multichaîne interopérable.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "Est-il possible de développer mon propre échange en marque blanche sur {appName} ?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "Absolument! Vous pouvez lire notre <a href=\"https://developers.komodoplatform.com/\">documentation pour les développeurs</a> pour plus de détails ou nous contacter pour vos demandes de partenariat. Vous avez une question technique spécifique ? La communauté de développeurs {appName} est toujours prête à vous aider !",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "Quels sont les appareils compatibles avec {appName}?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName} est disponible pour mobile sur Android et iPhone, et pour ordinateur sur <a href=\"https://komodoplatform.com/\">systèmes d'exploitation Windows, Mac et Linux</a>.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Fil",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Fil d'Actualités",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Lire plus...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Rien ici",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Fil d'actualité mis à jour",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Rejeter",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Actualités",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Durée",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "Impossible de recevoir les mises à jour du fil d'actu",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "Impossible de mettre à jour le fil d'actu",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Déjà à jour",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Date",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} actualités",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "Créer PIN",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "Entrez votre code PIN",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "se connecter",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "nouveau compte",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Nouveau compte",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} activé avec succès !",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Connexion…",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Activer la crypto-monnaie",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} Actifs",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Entrez votre passphrase",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Exemple: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "Confirmer",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "Attention, vous êtes prêt à acheter des pièces test SANS valeur réelle !",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "La charge de votre batterie est essentielle ({batteryLevelCritical} %) pour effectuer un échange en toute sécurité. Veuillez le mettre en charge et réessayer.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "La charge de votre batterie est inférieure à {batteryLevelLow} %. Veuillez considérer la recharge du téléphone.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "Votre téléphone est en mode d'économie de batterie. Veuillez désactiver ce mode ou ne PAS mettre l'application en arrière-plan, sinon l'application pourrait être tuée par le système d'exploitation et l'échange échouerait.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "Attention, vous êtes prêt à vendre des pièces de test SANS valeur réelle !",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Acheter",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Vendre",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "Mon adresse {coinName}:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Envoyer",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "La valeur est trop élevée ou trop basse",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Montant",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Adresse du destinataire",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "ENVOYER {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Confirmer le retrait",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Un problème est survenu. Réessayez plus tard.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Fermer",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "Confirmer la passphrase",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Votre nouvelle passphrase",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Important: sauvegardez votre passphrase avant de continuer!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Nous vous recommandons de la stocker hors ligne.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "suivant",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "Confirmer le code PIN",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Configuration Masque PIN",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Confirmer Masque PIN",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Erreur, veuillez réessayer",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Réglages",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Sécurité",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "Activer la protection PIN",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Désactiver les captures d'écran/aperçu",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "L'écran est verrouillé",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "Changer code PIN",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Se Déconnecter",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "MAX",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "MIN",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Frais totaux:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Payé à partir du solde :",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Trading Mode:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Passer",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Fusionner",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Écraser",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Prix actuel:",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Nouvel valeur:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Valeur fusionnée :",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Enregistrer fusionné",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "Doublon existant",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Facile",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Avancé",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Payé à partir du volume reçu :",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Montant à vendre",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Vous allez recevoir:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "Sélectionnez la crypto-monnaie que vous souhaitez vendre",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "Sélectionnez la crypto-monnaie que vous souhaitez acheter",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "échanger",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Échange émis, veuillez patienter!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "Ordre en cours, veuillez patienter {seconde} secondes!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Frais de réseau",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "frais de commission",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Portfolio",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Check-out",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Valeur totale estimée",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Sélectionnez votre méthode de paiement",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Les volumes",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Passer votre ordre",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "A venir...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Marché",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Vous envoyez:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Code:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Valeur:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Payé avec",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "S'il vous plaît entrer des données",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "Solde insuffisant",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Gwei doit atteindre {value}",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "Les frais doivent être jusqu'à {value}",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "La limite doit aller jusqu'à {value}",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "Adresse non valide",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Adresses Segwit non supportées (pour le moment)",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "Adresse de destination:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "RECEVOIR",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "ENVOYER",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Pubkey",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "retour",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "Annuler",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "détails",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Oui",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "Non",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Remarque : La commande correspondante ne peut plus être annulée",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "Ne plus demander",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Annuler l'ordre",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "Êtes-vous sûr d'annuler l'odre",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "indépensable",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "TX détails à venir!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "historique",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "Échange",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "Détails à venir!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Recherche d'ordre",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Ordre trouvé",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Echange en cours",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Échange réussi",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Temps écoulé",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Convertir",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "L'échange a échoué",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Erreur, merci d'essayer plus tard",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Dernières Transactions",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "En cours de transaction, veuillez patienter",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Je termine, veuillez patienter",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Envoyer des commentaires",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Chargement des ordres ...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "réclamer",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "Réclamer votre récompense KMD?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "Succès!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "Aucune récompense ne peut être demandée - veuillez réessayer dans 1h.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Chargement...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Transactions restantes : {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} balance insuffisante pour payer les frais de courtage",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Média",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Fil d'actualité",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "Copié dans le presse-papiers",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "De",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "À",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "CONFIRMÉ",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "NON CONFIRMÉ",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Bloc",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Confirmations",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Frais",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "Identifiant de transaction",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Note",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "Pas d'historique.",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "COMMERCE",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "EFFACER",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Réinitialiser le formulaire",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "ECHANGE TERMINÉ!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Étape",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "DÉTAILS DE L'ÉCHANGE",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Commerce demandé",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "UUID échange",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "FEUILLETER",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "ENREGISTRÉ",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "Vous pouvez toujours activer {remains}, Selected : {selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "VOUS N'AVEZ PAS D'ARTICLES ENREGISTRÉS",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "PARCOURIR",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "Par",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "S'il vous plaît authentifiez vous!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "Aucune transactions",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Terminé",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Activer les crypto-monnaie:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Sélectionnez les crypto-monnaie que vous souhaitez ajouter à votre portefeuille.",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "Pas d'articles - s'il vous plaît revenez plus tard!",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "La demande d'échange ne peut pas être annulée et constitue un événement final!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "Cette transaction peut prendre jusqu'à 10 minutes. NE FERMEZ PAS cette application!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "CONFIRMEZ LES DÉTAILS DE L’ÉCHANGE",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Volume Min requis",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "Utiliser le volume minimal personnalisé",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "Entrer une valeur numérique",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Doit être inférieur au montant de la vente",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "Doit être supérieur à {minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "Vérifier la passphrase",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "VERIFIONS UNE NOUVELLE FOIS VOTRE PASSPHRASE",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "Votre passphrase est importante - c'est pourquoi nous voulons nous assurer qu'elle est correcte. Nous vous poserons trois questions différentes sur votre passphrase pour vous assurer que vous pourrez facilement restaurer votre portefeuille à tout moment.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "Quel est le {index} mot dans votre passphrase?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "Entrez le {index} mot",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "CONTINUER",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "RETOURNEZ ET VÉRIFIEZ À NOUVEAU",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Explorer",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Activer la protection Biométrique",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Autoriser les passphrases personnalisées",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "Attention!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "Je comprends",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Les phrases de départ personnalisées peuvent être moins sécurisées et plus faciles à déchiffrer qu'une phrase de départ ou une clé privée (WIF) conforme à BIP39. Pour confirmer que vous comprenez le risque et savez ce que vous faites, saisissez \" {iUnderstand}\" dans la case ci-dessous.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Tapez votre Mot de passe",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "votre portefeuille",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "Connectez-vous avec la passphrase",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Se connecter avec mot de passe",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Entrez votre passphrase",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "Le mot de passe ne correspond pas. Veuillez réessayer.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Nommez votre portefeuille",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Vous pouvez choisir de chiffrer votre portefeuille avec un mot de passe. Si vous choisissez de ne pas utiliser de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Confirmez le mot de passe",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "Je ne veux pas de mot de passe",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "ÊTES-VOUS SÛR?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Si vous n'entrez pas de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "CONFIGURER UN MOT DE PASSE",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "CRÉER UN PORTEFEUILLE",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "RESTAURER",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Mot de passe",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "Le mot de passe doit contenir au moins 12 caractères, avec une minuscule, une majuscule et un symbole spécial.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Créer Mot de passe",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Confirmez le Mot de passe",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Mot de passe actuel",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Paramètres de déconnexion",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Déconnexion à la sortie",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Supprimer le portefeuille",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Supprimer",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Etes-vous sûr que vous voulez supprimer",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "portefeuille?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Si oui, assurez-vous de",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "enregistrez votre passphrase.",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "Afin de restaurer votre portefeuille à l'avenir.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Sauvegarde",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "version",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Passphrases et Clés Privées",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "Passphrases",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Clés privées",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Clé privée",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Veuillez entrer votre mot de passe pour continuer.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "Copier dans le presse-papiers",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "ouvrir",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": " {amnt}  fonds ont été débloqués avec succès - TX : {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Débloquer Fonds",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "Pas d'ordres, veuillez ouvrir menu échange.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Aucun ordre {coinName} disponible - réessayez ultérieurement ou créez un ordre.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "Meilleur tarif disponible",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Recevoir",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "creer un ordre",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "ÉCHANGE",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "ordres",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Choisir crypto-monnaie",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗Attention ! Le marché pour {coinName} a un volume de transactions inférieur à 10 000 $ sur 24 heures !",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Selectionner langue",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Pas de fonds",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "Pas de fonds disponibles - faire un dépot s'il vous plaît.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Ouvrir portfolio",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Cliquez pour créer un ordre",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Volume insuffisant",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "Le volume minimum requis pour cet ordre est",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Ordre créée",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Ordre créée avec succès",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "MONTRER MES COMMANDES",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "Le montant minimum à vendre est {number} {coinName}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "CRÉER UN MOT DE PASSE",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "Le montant minimum à acheter est {number} {coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "Le montant minimum à vendre est de {number}{coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "Le montant minimum de la commande est de {buyAmount}{buyCoin}({sellAmount}{sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Vous devez d'abord entrer le prix de vente",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Chiffrement du portefeuille...",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Décryptage du portefeuille...",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "Pas assez de solde pour les frais - échangez un montant inférieur",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "Pas de connexion Internet",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Conçu sur Komodo",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Veuillez ajouter une Crypto-monnaie",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "Connexion Internet Restauré",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Rafraichir",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Légal",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Avertissement et Conditions d'utilisation",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "Accepter les conditions générales de ventes",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "Accepter les conditions générales d'utilisations",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "En cliquant sur le bouton ci-dessous vous confrimez avec lu et accepté les CGV et CGU",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} commission",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "Pas assez de {coin} pour la transaction!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Veuillez activer {coin}.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "Vous recevrez {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "Cliquez pour voir {amount} orders",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Cliquez pour voir",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "prix",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "vol max",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "Portefeuille en cours de configuration, veuillez patienter...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Ordre sélectionnés",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "frais transactions:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "frais de négociation :",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "{coin}  solde insuffisant pour payer les frais de transaction.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "{coin}  solde insuffisant pour payer les frais de transaction. {coin} {amount} requis.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "Échange impossible",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Afficher Détails",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Taux de change:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Selectionner ordre:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "Volume d'odre Min:",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Volume d'odre Max:",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Détails",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Veuillez d'abord activer {coin} et recharger le solde",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Échec du calcul des frais commerciaux",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Désactivé",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Portefeuille uniquement",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "Le nom du portefeuille ne peut être nul",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "Le nom du Portefeuille ne doit pas dépasser 40 charactères",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "Le nom du Portefeuille existe déjà",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "Cette crypto-monnaie n'est pas supporté par DEX",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Rechercher une crypto-monnaie",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Sélectionner tous les tokens SmartChains",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Sélectionner tous les tokens Test Assets",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Sélectionner tous les tokens ERC",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Sélectionner tous les jetons SLP",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Tout sélectionner Cosmos Network",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Tout sélectionner Réseau Iris",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Sélectionner tous les tokens Kucoin",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Sélectionner tous les tokens Harmony",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Sélectionner tous les tokens ETC",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Sélectionner tous les tokens SmartBCH",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Sélectionner tous les tokens Avax",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Sélectionner tous les tokens Ubiq",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Sélectionner tous les tokens BEP",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Sélectionner tous les tokens Polygon",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Sélectionner tous les tokens QRC",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Sélectionner tous les tokens HecoChain",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Sélectionnez toutes les pièces ZHTLC",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Sélectionner tous les tokens Fantom",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Sélectionner tous les tokens Moonriver",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Frais personnalisés",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "limite Gas",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "prix Gas",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "N'utiliser les frais personnalisés que si vous savez ce que vous faite!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Sélectionner tous les tokens UTXO",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Conçu sur Komodo",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Propulsé par Komodo",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "Pas assez de gas - veuillez utiliser au moins {gas} Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Tous les ordres {coin} seront annulés.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Confirmer désactivation",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "Voulez-vous supprimer",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": " de votre portefeuille ? Toutes les commandes sans correspondance seront annulées.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " sera également désactivé",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "Désactivation impossible",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": " est une pièce par défaut. Les pièces par défaut ne peuvent pas être désactivées.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ok",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "Partager",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Attention - dans des cas particuliers, ces données de journal contiennent des informations sensibles qui peuvent être utilisées pour dépenser des pièces à partir d'échanges échoués !",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Entrer votre ancien PIN",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Enter votre nouveau PIN",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "authentification",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Langues",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "Anglais",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Français",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Allemand",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Chinois",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Russe",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Japonais",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Turque",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Hongrois",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "Espagnol",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Coréen",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Ukrainien",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "FAUCET",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Succès",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Erreur",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "La demande a expiré",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "Envoi de la demande au robinet {coin} ...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "Facultatif",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Son",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "\n\nÉcouter au volume max",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Taker",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "vous avez une nouvelle commande qui essaie de correspondre à une commande existante",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Maker",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "vous avez une commande avec laquelle de nouvelles commandes peuvent correspondre",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Active",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "vous avez un échange actif en cours",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Erreur",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "un échange a échoué",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Applause",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "un échange est en cours",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "Lecture impossible",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Choisissez un fichier mp3 ou wav s'il vous plaît. Nous y jouerons quand {description}.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "Joué quand {description}",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Sons",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "Vous entendrez des notifications sonores pendant le processus d'échange et lorsqu'une commande de fabricant active sera passée.\nLe protocole d'échange atomique exige que les participants soient en ligne pour un échange réussi, et des notifications sonores aident à y parvenir.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Notez que vous pouvez définir vos sons personnalisés dans les paramètres de l'application.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Compris, ne plus afficher",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Paramètres son",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Son",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Marchés",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "MARCHÉS",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "PRIX",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "CARNET d'ORDRES",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "Graphique",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Profondeur",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Prix",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Ventes",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "pour",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "min.",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Adresses",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "Expédient : CEX +{delta} %",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "Cher : CEX {delta} %",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "Identique au CEX",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Recevoir",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Dépenser",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": " Ceci est votre propre commande!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Veuillez selectionner crypto-monnaies",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Choisir crypto-monnaie",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "Aucune crypto-monnaie active",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Effacer",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "Prix ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "Mnt. ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "Total ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "Aucune offre trouvée",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "aucune demande trouvée",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Détail Ordre",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Un problème est survenu. Réessayez plus tard.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Information récompense",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "En savoir plus sur les récompenses des utilisateurs actifs KMD",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Annuler",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Recevoir",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "Pas de bonus disponible",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Information récompense:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "mnt UTXO,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "Récompense,\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "Fiat",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Temps restant",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Statut",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Statut récompense:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "Ok",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} jour(s)",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}h {minutes}m",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}min",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "Succès! {amount} KMD reçu.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Quelque chose s'est mal passé. Veuillez réessayer plus tard.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "Montant UTXO inférieur à 10 KMD",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "En traitement",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "La transaction est en cours",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 hour",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Une heure pas encore passée",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Réclamer votre récompense",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "Voir l'historique de transaction",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Nouvelle tentative d'activation de toutes les pièces...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "Vous serez redirigé vers la page du portfolio à la fin.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "Si même alors certaines pièces ne sont toujours pas activées, essayez de redémarrer l'application.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "Activation {coinAbbr} échoué",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Veuillez redémarrer l'application pour réessayer, ou appuyer sur le bouton ci-dessous.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Réessayez d'activer tout",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Vous serez automatiquement redirigé vers la page du portfolio une fois le processus de réactivation terminé.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "Activation {coinAbbr} échoué.\nVeuillez redémarrer l'application et réessayer.",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} est indisponible :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Multi",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Veuillez corriger toutes les erreurs avant de continuer",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Créer",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Ordre",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Ordres",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Crypto-monnaie",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Vendre:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Vendre",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Montant",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Recevoir:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "Prix/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Montant reçu",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Veuillez entrer le montant fiat à recevoir:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "Annuler",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Replissage auto",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "frais",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "Pas assez de {coin} pour payer les frais. Balance MIN necessaire {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "Créer {number} Ordre(s):",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "Annuler",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Confirmer",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Montant de vente invalide",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "Montant de vente Max est",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "Montant de vente Min est",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Montant invalide",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "Adresse {coin} invalide",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "Activez {coin} et rechargez d'abord le solde",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "La balance {coin} est trop faible",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "Montant de reception Min est",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Répertoire",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Répertoire",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Détail Contact",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "Répertoire vide",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Seules les adresses {title} sont affichées",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Créer contact",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "Nom",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Editer contact",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "Annuler",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Enregistrer",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Annuler",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Fermer",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Annuler vos modifications ?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Ajouter Adresse",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Choisir Crypto-monnaie",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Rechercher un téléscripteur",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Supprimer Contact",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "Voulez-vous supprimer le contact {name}?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "Supprimer",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "Aucun contact trouvé",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Editer",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Pas de résultats",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "Pas une telle pièce",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "Impossible d'envoyer les fonds sur l'adresse {abbr} car elle n'est pas activée. Veuillez ouvrir le portfolio.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Ok",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "Le nom du contact ne peut être nul",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "Entrez l'adresse {abbr} ",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Masque PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Masque PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "On",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Off",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "PIN Incorrect",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Change",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Si vous déverrouillez l'application avec le code PIN de camouflage, un faux solde FAIBLE sera affiché et l'option de configuration du code PIN de camouflage ne sera PAS visible dans les paramètres.",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Votre PIN et masque PIN sont identiques.\nLe mode Masquage ne sera pas activé.\nVeuillez changer le Masque PIN.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "Le code PIN de camouflage et la protection bio ne peuvent pas être activés en même temps.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Camo PIN et conflit de protection Bio.",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "Protection PIN pas activé.\nCamouflage PIN non disponible.\nVeuillez activer la protection PIN.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Montant du faux solde :",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "Masque PIN introuvable",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Créer Masque PIN",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "Masque PIN sauvegardé",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "Masque PIN incorrect",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Changer Masque PIN",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Configuration Masque PIN",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Entrer un nouveau Masque PIN",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "ON",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "OFF",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Confirmations",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo sécurité dPoW",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Utiliser les paramètres de protection personnalisés",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Attention, cet \"atomic swap\" n'est pas protégé par dPoW.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "Convertir en Maker s'il n'y a pas de correspondance",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "Taux de change CEX",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Opportun",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Coûteux",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "Identique au CEX",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "comparé au CEX",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "par rapport à la moyenne Prix CEX 24h",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Actif",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "Historique",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Détails",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Ouvrez les détails en un seul clic et sélectionnez Commander en appuyant longuement",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "Annuler",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Selectionner",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "Pas d'ordres compatibles trouvés",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Ordre des Maker",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Ordre Taker",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Actuel",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "Estimation",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "commencé",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Total",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "Détails de la progression",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Fermer Message d'Erreur",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Ouvrir Message d'Erreur",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Transaction entrante",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "Vous avez reçu {coin}  transaction !",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "Échange terminé",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": " L'échange{sell} / {buy} s'est terminé avec succès",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "Échange échoué",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} échange échoué",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Délais d'échange dépassé",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} délais d'échange dépassé",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Statut de l'échange modifié",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Nouvel échange démarré",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} échange démarré",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Langue",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Monnaie",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Masquer balances",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Changer de thème",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "Données CEX",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Les données de marché (prix, graphiques, etc.) marquées de cette icône proviennent de sources tierces (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Vérifier les mises à jours",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "Êtes-vous sur de vouloir quitter?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Monnaie",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Trop de demandes.\nLimite de demandes d'historique des transactions dépassée.\nVeuillez réessayer plus tard.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "ms",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "m",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "minutes",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "h",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "Plus",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "Moins",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Anciens logs",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Supprimer",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Supression portefeuille…",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Espace utilisé",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Ok",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Fermer aperçu",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "Annuler",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "Faites défiler vers le bas pour continuer...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Développeur",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Activer les crypto-monnaies de Test",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Détails ordre des Maker",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Vendre",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Reçu",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Prix",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Annuler ordre",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "ID Ordre",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "Créer à",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Aucun échange démarré par cet ordre",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "Échange démarré par cet ordre",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% rempli",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Note",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Ajouter une Note",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "Importer",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Importer Échange Simple",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Exporter",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "Importer",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Importer Échange",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Exporter",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Veuillez selectionner les objets à exporter dans le fichier chiffré.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Veuillez selectionner le chiffré à importer.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Veuillez selectionner le fichier texte d'échange à importer.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Ouverture...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "données à importer:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Notes",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Contacts",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Échange",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Pas de résultat",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Exporter",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "Importer",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "Le mot de passe chiffré ne peut être nul",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "Le mot de passe ne peut être nul",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "Les mots de passes doivent être identiques",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "Pas d'articles sélectionnés",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "Pas d'articles sélectionnés",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Selectionner fichier",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Fichier non trouvé",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Empreinte digitale",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Mot de passe",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "Retour",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Ok",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "Les objets ont été exportés avec succès:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "Données importé avec succès:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Données corrompues ou Mot de passe incorrect",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Erreur décodage fichier json",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Ordre",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Type d'odre inconnu",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "Import impossible:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Des données ont été ignorées",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "Impossible d'importer l'échange",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Données d'échange non valides. Veuillez fournir un fichier JSON d'état d'échange valide.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "Activation de {coinName}",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "Ne fermez pas l'application. Appuyez pour plus d'informations...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "Activation de {coinName}",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "Les pièces {protocolName} sont activées",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "Les pièces {protocolName} ne sont pas activées",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName} pièces activées avec succès",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} Activation en cours",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "Activer les pièces {protocolName} ?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Plus d'informations",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Afficher l'adresse",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Cette transaction a été masquée en raison d'une éventuelle tentative de phishing.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "Adresse de transaction",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "Transaction masquée",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "Impossible de lancer l'URL",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Cela prendra un certain temps et l'application doit rester au premier plan.\nLa fermeture de l'application pendant l'activation est en cours peut entraîner des problèmes.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Avertissement : la réduction de l'application sur iOS mettra fin au processus d'activation.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Veuillez activer les notifications pour obtenir des mises à jour sur la progression de l'activation.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "Scanner de codes QR",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "Code QR trouvé",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Contracter",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Commencer l'échange",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Aucun",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "Taux CEX",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Paramètres de protection des transmissions entrantes {coinName}",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "Affichage de {count} commandes sur {maxCount}.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "Moins",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "Plus",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "basé sur {coinName1}/{coinName2}",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "envoyer des frais de négociation frais de transaction",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "frais de négociation",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "envoyer des frais de transaction à {coinName}",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "recevez des frais de transaction {coinName}",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Filtrer",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Statut",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Tout",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Réussi",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Échoué",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "du",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "au",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Taker/Maker",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Maker",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "Tout",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Taker",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Vendre crypto-monnaie",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Recevoir crypto-monnaie",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Effacer tous les filtres",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Balance insuffisante",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "Pas assez de solde pour numériser",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "demander paiement.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Tentative d'activation d'un trop grand nombre d'éléments",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "Vous avez",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": " actifs activés et tentative d'activation",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": " Suite. La limite maximale des éléments activés est",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Vous avez sélectionné le nombre maximum d'éléments",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Trop d'éléments activés",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "Vous avez",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": " actifs activés. La limite maximale des éléments activés est",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Paiement demandé",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Crypto-monnaie:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "Adresser",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "Montant:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "Acceptez-vous cette transaction?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Payer",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "Annuler",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} n'est pas actif. Veuillez activer et réessayer.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Mauvaise crypto-monnaie",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "Vous essayez de scanner un code QR de paiement pour",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": " mais tu es sur",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": " retirer l'écran",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Vendre",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Acheter",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Recevoir",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Envoyer",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Fermer",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Activer",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "Le nombre maximum de pièces actives est de {maxCoins}. Veuillez en désactiver certains.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "Impossible d'activer {coin}",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} pas activé!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Veuillez entrer le montant de {coin} à acheter",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Veuillez entrer le montant de {coin} à vendre",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Afficher moins",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Afficher plus",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "Pas de crypto-monnaie trouvé",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "C'est une nouvelle ère ! Nous avons officiellement changé notre nom de 'AtomicDEX' en 'Komodo Wallet'",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "Communiqué de presse officiel",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "Rechercher les transactions {coin} passées ?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "Annuler l'activation",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "Etes-vous sûr de vouloir annuler l'activation ?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "Etes-vous sûr de vouloir annuler l'activation ?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "Quelles transactions {name} souhaitez-vous synchroniser ?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "Synchroniser les nouvelles transactions",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Synchroniser à partir de la date spécifiée",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Synchronisation à partir de l'activation des jeunes arbres",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Sélectionnez une date",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Date de début",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "Nous synchroniserons les futures transactions effectuées après l'activation associée à votre clé publique. C’est l’option la plus rapide et celle qui nécessite le moins de stockage.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "Votre portefeuille affichera toutes les transactions passées. Cela prendra beaucoup de temps et de stockage car tous les blocs seront téléchargés et analysés.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "Votre portefeuille affichera vos transactions passées effectuées après la date spécifiée.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "Activation de {coinName}",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "Activation de {coinName}",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} Activation en cours",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Active",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Activer la crypto-monnaie",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} activé avec succès !",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Ajouter Adresse",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Répertoire",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "Répertoire vide",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Seules les adresses {title} sont affichées",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Répertoire",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "Impossible d'envoyer les fonds sur l'adresse {abbr} car elle n'est pas activée. Veuillez ouvrir le portfolio.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Pas de résultats",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Choisir Crypto-monnaie",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Adresse du destinataire",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Avancé",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "Tout",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Autoriser les passphrases personnalisées",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "Votre portefeuille affichera toutes les transactions passées. Cela prendra beaucoup de temps et de stockage car tous les blocs seront téléchargés et analysés.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "Doublon existant",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Montant",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Montant à vendre",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "Non ! {appName} est non-custodial. Aucune donnée sensible n'est sauvegardé, ni votre clé privé, ni votre passphrases, ni votre PIN. Toutes ces données sont stockées sur votre appareil et ne sont jamais transmises.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName} est disponible pour mobile sur Android et iPhone, et pour ordinateur sur <a href=\"https://komodoplatform.com/\">systèmes d'exploitation Windows, Mac et Linux</a>.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Les autres DEX ne vous permettent généralement que d'échanger des actifs basés sur un seul réseau de blockchain, d'utiliser des jetons proxy et de ne permettre de passer qu'une seule commande avec les mêmes fonds.\n\n{appName} vous permet d'échanger nativement sur deux réseaux blockchain différents sans jetons proxy. Vous pouvez également passer plusieurs commandes avec les mêmes fonds. Par exemple, vous pouvez vendre 0,1 BTC pour KMD, QTUM ou VRSC — la première commande exécutée annule automatiquement toutes les autres commandes.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Plusieurs facteurs déterminent le temps de traitement de chaque échange. Le temps de blocage des actifs échangés dépend de chaque réseau (Bitcoin étant généralement le plus lent). De plus, l'utilisateur peut personnaliser les préférences de sécurité. Par exemple, vous pouvez demander à {appName} de considérer une transaction KMD comme finale après seulement 3 confirmations, ce qui raccourcit le temps d'échange par rapport à l'attente d'une <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarisation</a>.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Oui. Vous devez rester connecté à Internet et exécuter votre application pour réussir chaque échange atomique (de très courtes pauses de connectivité sont généralement acceptables). Sinon, il y a un risque d'annulation de transaction si vous êtes un fabricant et un risque de perte de fonds si vous êtes un preneur. Le protocole d'échange atomique exige que les deux participants restent en ligne et surveillent les chaînes de blocs impliquées pour que le processus reste atomique.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "Il existe deux catégories de frais à prendre en compte lors de la négociation sur {appName}.\n\n1. {appName} facture environ 0,13 % (1/777 du volume de négociation mais pas moins de 0,0001) comme frais de négociation pour les ordres preneurs, et les ordres fabricant n'ont aucun frais.\n\n2. Les fabricants et les preneurs devront payer des frais de réseau normaux aux chaînes de blocs impliquées lors des transactions d'échange atomique.\n\nLes frais de réseau peuvent varier considérablement en fonction de la paire de négociation que vous avez sélectionnée.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "Oui! {appName} propose une assistance via le <a href=\"{link}\">{appCompanyShort} {name}</a>. L'équipe et la communauté sont toujours ravies de vous aider !",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "Non! {appName} est entièrement décentralisé. Il n'est pas possible de limiter l'accès des utilisateurs par un tiers.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} est développé par l'équipe {appCompanyShort} . {appCompanyShort} est l'un des projets de blockchain les plus établis travaillant sur des solutions innovantes telles que les swaps atomiques, la preuve de travail différée et une architecture multichaîne interopérable.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "Absolument! Vous pouvez lire notre <a href=\"https://developers.komodoplatform.com/\">documentation pour les développeurs</a> pour plus de détails ou nous contacter pour vos demandes de partenariat. Vous avez une question technique spécifique ? La communauté de développeurs {appName} est toujours prête à vous aider !",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Applause",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "ÊTES-VOUS SÛR?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "un échange a échoué",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "un échange est en cours",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "authentification",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Vous serez automatiquement redirigé vers la page du portfolio une fois le processus de réactivation terminé.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "vol max",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "retour",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Sauvegarde",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "basé sur {coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "La charge de votre batterie est essentielle ({batteryLevelCritical} %) pour effectuer un échange en toute sécurité. Veuillez le mettre en charge et réessayer.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "La charge de votre batterie est inférieure à {batteryLevelLow} %. Veuillez considérer la recharge du téléphone.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "Votre téléphone est en mode d'économie de batterie. Veuillez désactiver ce mode ou ne PAS mettre l'application en arrière-plan, sinon l'application pourrait être tuée par le système d'exploitation et l'échange échouerait.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Meilleur tarif disponible",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Conçu sur Komodo",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Conçu sur Komodo",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Acheter",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Convertir en Maker s'il n'y a pas de correspondance",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Échange émis, veuillez patienter!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Ordre en cours, veuillez patienter {seconde} secondes!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "Attention, vous êtes prêt à acheter des pièces test SANS valeur réelle !",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Le code PIN de camouflage et la protection bio ne peuvent pas être activés en même temps.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Camo PIN et conflit de protection Bio.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Changer Masque PIN",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Créer Masque PIN",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Si vous déverrouillez l'application avec le code PIN de camouflage, un faux solde FAIBLE sera affiché et l'option de configuration du code PIN de camouflage ne sera PAS visible dans les paramètres.",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "Masque PIN incorrect",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Masque PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Masque PIN introuvable",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Off",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "On",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Masque PIN sauvegardé",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Masque PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Entrer un nouveau Masque PIN",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Configuration Masque PIN",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Configuration Masque PIN",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "Annuler",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Annuler l'activation",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "Etes-vous sûr de vouloir annuler l'activation ?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "Annuler",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Annuler l'ordre",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Un problème est survenu. Réessayez plus tard.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ok",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": " est une pièce par défaut. Les pièces par défaut ne peuvent pas être désactivées.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Désactivation impossible",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Lecture impossible",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "Taux de change CEX",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "Données CEX",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Les données de marché (prix, graphiques, etc.) marquées de cette icône proviennent de sources tierces (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "Taux CEX",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "Changer code PIN",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Vérifier les mises à jours",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Check-out",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Vérifier la passphrase",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "CONTINUER",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "RETOURNEZ ET VÉRIFIEZ À NOUVEAU",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "Entrez le {index} mot",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "Votre passphrase est importante - c'est pourquoi nous voulons nous assurer qu'elle est correcte. Nous vous poserons trois questions différentes sur votre passphrase pour vous assurer que vous pourrez facilement restaurer votre portefeuille à tout moment.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "Quel est le {index} mot dans votre passphrase?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "VERIFIONS UNE NOUVELLE FOIS VOTRE PASSPHRASE",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Chinois",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "réclamer",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "Réclamer votre récompense KMD?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Cliquez pour voir",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Copié dans le presse-papiers",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Copier dans le presse-papiers",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Fermer",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Fermer Message d'Erreur",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Fermer aperçu",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Code:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "Etes-vous sûr de vouloir annuler l'activation ?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Vous avez sélectionné le nombre maximum d'éléments",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "Les pièces {protocolName} sont activées",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName} pièces activées avec succès",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "Les pièces {protocolName} ne sont pas activées",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Effacer",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "Aucune crypto-monnaie active",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Choisir crypto-monnaie",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "A venir...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "TX détails à venir!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "Détails à venir!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "frais de commission",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "par rapport à la moyenne Prix CEX 24h",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "comparé au CEX",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Portefeuille en cours de configuration, veuillez patienter...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Confirmer",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Confirmer Masque PIN",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Êtes-vous sûr d'annuler l'odre",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "En cliquant sur le bouton ci-dessous vous confrimez avec lu et accepté les CGV et CGU",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Confirmez le mot de passe",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "Confirmer le code PIN",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Confirmer la passphrase",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Connexion…",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Annuler",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Supprimer Contact",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Supprimer",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "Voulez-vous supprimer le contact {name}?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Annuler",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Editer",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Fermer",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Annuler vos modifications ?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "Aucun contact trouvé",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Enregistrer",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Détail Contact",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Nom",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Contracter",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Convertir",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "Impossible de lancer l'URL",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "Import impossible:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "Échange",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "CRÉER UN PORTEFEUILLE",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Créer contact",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "Créer PIN",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Monnaie",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Monnaie",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Prix actuel:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Frais personnalisés",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "N'utiliser les frais personnalisés que si vous savez ce que vous faite!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Les phrases de départ personnalisées peuvent être moins sécurisées et plus faciles à déchiffrer qu'une phrase de départ ou une clé privée (WIF) conforme à BIP39. Pour confirmer que vous comprenez le risque et savez ce que vous faites, saisissez \" {iUnderstand}\" dans la case ci-dessous.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Date",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Décryptage du portefeuille...",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Supprimer",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Confirmer désactivation",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "Voulez-vous supprimer",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": " de votre portefeuille ? Toutes les commandes sans correspondance seront annulées.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " sera également désactivé",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Supprimer le portefeuille",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Supression portefeuille…",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "recevez des frais de transaction {coinName}",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "envoyer des frais de transaction à {coinName}",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "envoyer des frais de négociation frais de transaction",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "frais de négociation",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "détails",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Allemand",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Développeur",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "Cette crypto-monnaie n'est pas supporté par DEX",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Désactiver les captures d'écran/aperçu",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Avertissement et Conditions d'utilisation",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Terminé",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Ne fermez pas l'application. Appuyez pour plus d'informations...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Ne plus demander",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "Je ne veux pas de mot de passe",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo sécurité dPoW",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Durée",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Editer contact",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Entrez l'adresse {abbr} ",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "Le mot de passe chiffré ne peut être nul",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "Le mot de passe ne peut être nul",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Le nom du contact ne peut être nul",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "Le nom du portefeuille ne peut être nul",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Vous pouvez toujours activer {remains}, Selected : {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Veuillez activer les notifications pour obtenir des mises à jour sur la progression de l'activation.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Activer les crypto-monnaies de Test",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "Vous avez",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": " actifs activés et tentative d'activation",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": " Suite. La limite maximale des éléments activés est",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Tentative d'activation d'un trop grand nombre d'éléments",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Chiffrement du portefeuille...",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "Anglais",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Enter votre nouveau PIN",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Entrer votre ancien PIN",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Veuillez entrer votre mot de passe pour continuer.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Entrez votre code PIN",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Entrez votre passphrase",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Vous devez d'abord entrer le prix de vente",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Solde insuffisant",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Adresse non valide",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Adresses Segwit non supportées (pour le moment)",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Pas assez de gas - veuillez utiliser au moins {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Erreur, veuillez réessayer",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Erreur, merci d'essayer plus tard",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "La valeur est trop élevée ou trop basse",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "S'il vous plaît entrer des données",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Valeur totale estimée",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Exemple: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Opportun",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Coûteux",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Identique au CEX",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Taux de change:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "ÉCHANGE",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Exporter",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Contacts",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Veuillez selectionner les objets à exporter dans le fichier chiffré.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Exporter",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Notes",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Les objets ont été exportés avec succès:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Échange",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Exporter",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Erreur",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Montant du faux solde :",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Foire aux questions",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Erreur",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Envoi de la demande au robinet {coin} ...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "FAUCET",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Succès",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "La demande a expiré",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Envoyer des commentaires",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Actualités",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Rien ici",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} actualités",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Lire plus...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Fil",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Fil d'Actualités",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Impossible de mettre à jour le fil d'actu",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Impossible de recevoir les mises à jour du fil d'actu",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Fil d'actualité mis à jour",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Déjà à jour",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Les frais doivent être jusqu'à {value}",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Tout",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Filtrer",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Effacer tous les filtres",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Échoué",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "du",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Maker",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Recevoir crypto-monnaie",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Vendre crypto-monnaie",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Statut",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Réussi",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Taker",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "au",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Taker/Maker",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Empreinte digitale",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Je termine, veuillez patienter",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "Code QR trouvé",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Français",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "De",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "Nous synchroniserons les futures transactions effectuées après l'activation associée à votre clé publique. C’est l’option la plus rapide et celle qui nécessite le moins de stockage.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} commission",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "limite Gas",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Veuillez activer {coin}.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "prix Gas",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "Protection PIN pas activé.\nCamouflage PIN non disponible.\nVeuillez activer la protection PIN.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Important: sauvegardez votre passphrase avant de continuer!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "En cours de transaction, veuillez patienter",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Ouvrir portfolio",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei doit atteindre {value}",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Aide",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Aide et Assistance",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Masquer balances",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Confirmez le Mot de passe",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Créer Mot de passe",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Mot de passe actuel",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Tapez votre Mot de passe",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Entrez votre passphrase",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Nommez votre portefeuille",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Mot de passe",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "historique",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "h",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Hongrois",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Importer",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Données corrompues ou Mot de passe incorrect",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "données à importer:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Fichier non trouvé",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Données d'échange non valides. Veuillez fournir un fichier JSON d'état d'échange valide.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Importer",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Veuillez selectionner le chiffré à importer.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Ouverture...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Veuillez selectionner le fichier texte d'échange à importer.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Retour",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ok",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Mot de passe",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Importer Échange Simple",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Importer Échange",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Des données ont été ignorées",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Données importé avec succès:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Impossible d'importer l'échange",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Erreur décodage fichier json",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Importer",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Paramètres de protection des transmissions entrantes {coinName}",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Si vous n'entrez pas de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "La demande d'échange ne peut pas être annulée et constitue un événement final!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "Cette transaction peut prendre jusqu'à 10 minutes. NE FERMEZ PAS cette application!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Vous pouvez choisir de chiffrer votre portefeuille avec un mot de passe. Si vous choisissez de ne pas utiliser de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} balance insuffisante pour payer les frais de courtage",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "Le volume minimum requis pour cet ordre est",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Volume insuffisant",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Rafraichir",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Connexion Internet Restauré",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Adresse {coin} invalide",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "Échange impossible",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Détails",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} est indisponible :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "Je comprends",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Japonais",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Coréen",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Langue",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Dernières Transactions",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Légal",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Moins",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Attention ! Le marché pour {coinName} a un volume de transactions inférieur à 10 000 $ sur 24 heures !",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "La limite doit aller jusqu'à {value}",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Chargement...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Chargement des ordres ...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "L'écran est verrouillé",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "S'il vous plaît authentifiez vous!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "se connecter",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Se Déconnecter",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Déconnexion à la sortie",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Paramètres de déconnexion",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "Êtes-vous sur de vouloir quitter?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "minutes",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "creer un ordre",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Maker",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Annuler ordre",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Créer à",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Reçu",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "ID Ordre",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Aucun échange démarré par cet ordre",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Prix",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Vendre",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Échange démarré par cet ordre",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Détails ordre des Maker",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Ordre des Maker",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Marché",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Graphique",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Profondeur",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "aucune demande trouvée",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "Aucune offre trouvée",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "CARNET d'ORDRES",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Détail Ordre",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "PRIX",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Veuillez selectionner crypto-monnaies",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Marchés",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "MARCHÉS",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Les mots de passes doivent être identiques",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Change",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Votre PIN et masque PIN sont identiques.\nLe mode Masquage ne sera pas activé.\nVeuillez changer le Masque PIN.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "PIN Incorrect",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAX",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Volume d'odre Max:",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Média",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "FEUILLETER",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "PARCOURIR",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "Par",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "VOUS N'AVEZ PAS D'ARTICLES ENREGISTRÉS",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "ENREGISTRÉ",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Note",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Fusionner",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Valeur fusionnée :",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "ms",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "MIN",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Avertissement : la réduction de l'application sur iOS mettra fin au processus d'activation.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "Volume d'odre Min:",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "m",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "Le montant minimum à vendre est {number} {coinName}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "Le montant minimum à acheter est {number} {coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "Le montant minimum de la commande est de {buyAmount}{buyCoin}({sellAmount}{sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "Le montant minimum à vendre est de {number}{coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "Doit être supérieur à {minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Doit être inférieur au montant de la vente",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Volume Min requis",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Utiliser le volume minimal personnalisé",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Veuillez noter que vous utilisez maintenant des données cellulaires et que votre participation au réseau {appName} P2P consomme du trafic Internet. Il est préférable d'utiliser un réseau WiFi si votre forfait de données cellulaires est coûteux.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Plus d'informations",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "Plus",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Activez {coin} et rechargez d'abord le solde",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Montant",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Crypto-monnaie",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Vendre",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Annuler",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Confirmer",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "Créer {number} Ordre(s):",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Créer",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Ordre",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Ordres",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "frais",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Annuler",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Veuillez entrer le montant fiat à recevoir:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Replissage auto",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Veuillez corriger toutes les erreurs avant de continuer",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Montant invalide",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Montant de vente invalide",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "Pas assez de {coin} pour payer les frais. Balance MIN necessaire {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "La balance {coin} est trop faible",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "Montant de vente Max est",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "Montant de reception Min est",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "Montant de vente Min est",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Recevoir:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Vendre:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Multi",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Montant reçu",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Prix/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Frais de réseau",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "nouveau compte",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Nouveau compte",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Fil d'actualité",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Nouvel valeur:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "suivant",
-  "@next": {
-    "type": "text"
-  },
-  "no": "Non",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "Pas d'articles - s'il vous plaît revenez plus tard!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "Pas de crypto-monnaie trouvé",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Pas de fonds",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "Pas de fonds disponibles - faire un dépot s'il vous plaît.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "Pas de connexion Internet",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "Pas d'articles sélectionnés",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "Pas d'articles sélectionnés",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "Pas d'ordres compatibles trouvés",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Aucun",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "Entrer une valeur numérique",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Aucun ordre {coinName} disponible - réessayez ultérieurement ou créez un ordre.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Cliquez pour créer un ordre",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "Pas d'ordres, veuillez ouvrir menu échange.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "Pas de bonus disponible",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "Aucune récompense ne peut être demandée - veuillez réessayer dans 1h.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "Pas une telle pièce",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "Pas d'historique.",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "Pas assez de {coin} pour la transaction!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "Pas assez de solde pour les frais - échangez un montant inférieur",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Remarque : La commande correspondante ne peut plus être annulée",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Ajouter une Note",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Note",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Pas de résultat",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": " L'échange{sell} / {buy} s'est terminé avec succès",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Échange terminé",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} échange échoué",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Échange échoué",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} échange démarré",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Nouvel échange démarré",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Statut de l'échange modifié",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} délais d'échange dépassé",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Délais d'échange dépassé",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "Vous avez reçu {coin}  transaction !",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Transaction entrante",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "Aucune transactions",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} Actifs",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Communiqué de presse officiel",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ok",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Supprimer",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Anciens logs",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Espace utilisé",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Ouvrir Message d'Erreur",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Facultatif",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Moins",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "Plus",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Tous les ordres {coin} seront annulés.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Ordre créée",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Ordre créée avec succès",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Adresses",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Annuler",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Expédient : CEX +{delta} %",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Cher : CEX {delta} %",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "pour",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Identique au CEX",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "min.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Prix",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Recevoir",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Selectionner",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Ventes",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Ouvrez les détails en un seul clic et sélectionnez Commander en appuyant longuement",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Dépenser",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Détails",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% rempli",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Ordre trouvé",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Recherche d'ordre",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "ordres",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Actif",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "Historique",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Mnt. ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "Prix ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Total ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Ordre",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Type d'odre inconnu",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Écraser",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": " Ceci est votre propre commande!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Payé à partir du solde :",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Payé à partir du volume reçu :",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Payé avec",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "Le mot de passe doit contenir au moins 12 caractères, avec une minuscule, une majuscule et un symbole spécial.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "Votre portefeuille affichera vos transactions passées effectuées après la date spécifiée.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Payer",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Acceptez-vous cette transaction?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "Adresser",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Montant:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Crypto-monnaie:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Annuler",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Paiement demandé",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} n'est pas actif. Veuillez activer et réessayer.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Passer votre ordre",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "\n\nÉcouter au volume max",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Veuillez ajouter une Crypto-monnaie",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Veuillez redémarrer l'application pour réessayer, ou appuyer sur le bouton ci-dessous.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Portfolio",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Propulsé par Komodo",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "prix",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Clé privée",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Clés privées",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Confirmations",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Utiliser les paramètres de protection personnalisés",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "OFF",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "ON",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Attention, cet \"atomic swap\" n'est pas protégé par dPoW.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Pubkey",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "Scanner de codes QR",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Stockez-vous ma clé privé?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "Quels sont les appareils compatibles avec {appName}?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "En quoi le trading sur {appName} est-il différent du trading sur d'autres DEX ?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "Combien de temps dure chaque échange atomique ?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "Dois-je être en ligne pendant toute la durée de l'échange ?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "Comment sont calculés les frais sur {appName}  ?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Offrez-vous une assistance aux utilisateurs ?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Avez-vous des restrictions par pays ?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Qui est derrière {appName}?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "Est-il possible de développer mon propre échange en marque blanche sur {appName} ?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "C'est une nouvelle ère ! Nous avons officiellement changé notre nom de 'AtomicDEX' en 'Komodo Wallet'",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "RECEVOIR",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Recevoir",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Nous vous recommandons de la stocker hors ligne.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Désactivé",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Commerce demandé",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "EFFACER",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Réinitialiser le formulaire",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "RESTAURER",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Nouvelle tentative d'activation de toutes les pièces...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Réessayez d'activer tout",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Réclamer votre récompense",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Annuler",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Quelque chose s'est mal passé. Veuillez réessayer plus tard.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "La transaction est en cours",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "En traitement",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "Montant UTXO inférieur à 10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Une heure pas encore passée",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 hour",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Ok",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Statut récompense:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "En savoir plus sur les récompenses des utilisateurs actifs KMD",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Recevoir",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Succès! {amount} KMD reçu.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Fiat",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Récompense,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Statut",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Temps restant",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Information récompense:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "mnt UTXO,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} jour(s)",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}h {minutes}m",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}min",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Information récompense",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Russe",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Enregistrer fusionné",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Faites défiler vers le bas pour continuer...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Rechercher une crypto-monnaie",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Sélectionner tous les tokens Avax",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Sélectionner tous les tokens BEP",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Tout sélectionner Cosmos Network",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Sélectionner tous les tokens ERC",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Sélectionner tous les tokens ETC",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Sélectionner tous les tokens Fantom",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Sélectionner tous les tokens HecoChain",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Sélectionner tous les tokens Harmony",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Tout sélectionner Réseau Iris",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Sélectionner tous les tokens Kucoin",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Sélectionner tous les tokens Moonriver",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Sélectionner tous les tokens Polygon",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Sélectionner tous les tokens QRC",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Sélectionner tous les tokens SmartBCH",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Sélectionner tous les jetons SLP",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Sélectionner tous les tokens SmartChains",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Sélectionner tous les tokens Test Assets",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Sélectionner tous les tokens Ubiq",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Sélectionner tous les tokens UTXO",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Sélectionnez toutes les pièces ZHTLC",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Rechercher un téléscripteur",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Sécurité",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Passphrases",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Votre nouvelle passphrase",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "Cliquez pour voir {amount} orders",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "Voir l'historique de transaction",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Choisir crypto-monnaie",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Sélectionnez les crypto-monnaie que vous souhaitez ajouter à votre portefeuille.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Activer les crypto-monnaie:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Sélectionnez la crypto-monnaie que vous souhaitez acheter",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Sélectionnez la crypto-monnaie que vous souhaitez vendre",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Sélectionnez une date",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Selectionner ordre:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Selectionner fichier",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Selectionner langue",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Sélectionnez votre méthode de paiement",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Vendre",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Attention, vous êtes prêt à vendre des pièces de test SANS valeur réelle !",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "ENVOYER",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Etes-vous sûr que vous voulez supprimer",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "portefeuille?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Si oui, assurez-vous de",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "enregistrez votre passphrase.",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "Afin de restaurer votre portefeuille à l'avenir.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Langues",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Réglages",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "CONFIGURER UN MOT DE PASSE",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Partager",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "Mon adresse {coinName}:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "Rechercher les transactions {coin} passées ?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Afficher l'adresse",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Afficher Détails",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "Affichage de {count} commandes sur {maxCount}.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "MONTRER MES COMMANDES",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Se connecter avec mot de passe",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Connectez-vous avec la passphrase",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Facile",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Activer",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Veuillez entrer le montant de {coin} à acheter",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Acheter",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Fermer",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "Le nombre maximum de pièces actives est de {maxCoins}. Veuillez en désactiver certains.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} pas activé!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Recevoir",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Veuillez entrer le montant de {coin} à vendre",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Vendre",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Envoyer",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Afficher moins",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Afficher plus",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "Impossible d'activer {coin}",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Passer",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Rejeter",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Son",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Choisissez un fichier mp3 ou wav s'il vous plaît. Nous y jouerons quand {description}.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "Joué quand {description}",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Sons",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Compris, ne plus afficher",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Son",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Paramètres son",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "Vous entendrez des notifications sonores pendant le processus d'échange et lorsqu'une commande de fabricant active sera passée.\nLe protocole d'échange atomique exige que les participants soient en ligne pour un échange réussi, et des notifications sonores aident à y parvenir.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Notez que vous pouvez définir vos sons personnalisés dans les paramètres de l'application.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Espagnol",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Date de début",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Commencer l'échange",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Étape",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Succès!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Support",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Si vous avez des questions ou si vous pensez avoir rencontré un problème technique avec l'application {appName} , vous pouvez le signaler et obtenir de l'aide de notre équipe.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "échanger",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Actuel",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "CONFIRMEZ LES DÉTAILS DE L’ÉCHANGE",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Estimation",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "L'échange a échoué",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Veuillez d'abord activer {coin} et recharger le solde",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "{coin}  solde insuffisant pour payer les frais de transaction.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "{coin}  solde insuffisant pour payer les frais de transaction. {coin} {amount} requis.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Echange en cours",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "Détails de la progression",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "commencé",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Échange réussi",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Total",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "UUID échange",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Changer de thème",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Synchroniser à partir de la date spécifiée",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Synchronisation à partir de l'activation des jeunes arbres",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Synchroniser les nouvelles transactions",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "Quelles transactions {name} souhaitez-vous synchroniser ?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Taker",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Ordre Taker",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Temps écoulé",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "CRÉER UN MOT DE PASSE",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Ordre sélectionnés",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "À",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "Adresse de destination:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "Vous avez",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": " actifs activés. La limite maximale des éléments activés est",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". Veuillez en désactiver certains avant d'en ajouter de nouveaux.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Trop d'éléments activés",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Frais totaux:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "COMMERCE",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "ECHANGE TERMINÉ!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "DÉTAILS DE L'ÉCHANGE",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Échec du calcul des frais commerciaux",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "frais de négociation :",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Trading Mode:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Adresse de transaction",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Transaction masquée",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Cette transaction a été masquée en raison d'une éventuelle tentative de phishing.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "Si même alors certaines pièces ne sont toujours pas activées, essayez de redémarrer l'application.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Turque",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Bloc",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Confirmations",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "CONFIRMÉ",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Frais",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "frais transactions:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "Identifiant de transaction",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Transactions restantes : {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Trop de demandes.\nLimite de demandes d'historique des transactions dépassée.\nVeuillez réessayer plus tard.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "NON CONFIRMÉ",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Ukrainien",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "ouvrir",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Débloquer Fonds",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": " {amnt}  fonds ont été débloqués avec succès - TX : {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "indépensable",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Nouvelle version disponible",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Recherche de mise à jour...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "Version {version} en cours d'utilisation",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Nouvelle version disponible. Veuillez mettre à jour.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Version {version} disponible. Veuillez mettre à jour.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Mise à jour disponible",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Ignorer pour l'instant",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "Mise à jour {appName}",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Update",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Déjà à jour",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Pas assez de solde pour numériser",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "demander paiement.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Balance insuffisante",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Valeur:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "version",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Explorer",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Passphrases et Clés Privées",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Les volumes",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "Le nom du Portefeuille existe déjà",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "Le nom du Portefeuille ne doit pas dépasser 40 charactères",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Portefeuille uniquement",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "Attention!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ok",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Attention - dans des cas particuliers, ces données de journal contiennent des informations sensibles qui peuvent être utilisées pour dépenser des pièces à partir d'échanges échoués !",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "Activation {coinAbbr} échoué",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "Activation {coinAbbr} échoué.\nVeuillez redémarrer l'application et réessayer.",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "Komodo Wallet est un portefeuille multi crypto-monnaies de nouvelle génération doté de la fonctionnalité DEX native de troisième génération et encore bien plus.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "CONFIGURONS!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "BIENVENUE",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "portefeuille",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "Vous serez redirigé vers la page du portfolio à la fin.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Cela prendra un certain temps et l'application doit rester au premier plan.\nLa fermeture de l'application pendant l'activation est en cours peut entraîner des problèmes.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Envoyer",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "Vous avez précédemment refusé à {appName} l'accès à la caméra.\nVeuillez modifier manuellement l'autorisation de l'appareil photo dans les paramètres de votre téléphone pour procéder à l'analyse du code QR.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Accès refusé",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Confirmer le retrait",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Un problème est survenu. Réessayez plus tard.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "ENVOYER {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "Vous essayez de scanner un code QR de paiement pour",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": " mais tu es sur",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": " retirer l'écran",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Mauvaise crypto-monnaie",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "Le mot de passe ne correspond pas. Veuillez réessayer.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Oui",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Vous envoyez:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "vous avez une nouvelle commande qui essaie de correspondre à une commande existante",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "vous avez un échange actif en cours",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "vous avez une commande avec laquelle de nouvelles commandes peuvent correspondre",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "votre portefeuille",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "Vous recevrez {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Vous allez recevoir:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -1,3660 +1,3726 @@
 {
-    "accepteula": "Fogadja el az EULA-t",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "Fogadja el a feltételeket és a kondíciókat",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Biometrikus védelem aktiválása",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "PIN védelem aktviálása",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "Aktiválja a {protocolName} érméket?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "{coinName} aktiválása",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName} Aktiválás",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} Aktiválás folyamatban",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Aktív",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Aktív érme",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} sikeresen aktiválva !",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Cím hozzáadása",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Címjegyzék",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "A címjegyzék üres",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Csak a {title} címekkel rendelkező kapcsolatok megjelenítése",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Címjegyzék",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "Nem tud pénzt küldeni a {abbr} címre, mert a {abbr} nincs aktiválva. Kérjük, menjen a portfólióhoz.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Semmi sem található",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Válassza ki az érmét",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Címzett címe",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Haladó",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "Minden",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Egyedi SEED engedélyezése",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "Már létezik",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Összeg",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Eladandó összeg",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "Nem! Az {appName} nem felügyeleti joggal rendelkezik. Soha nem tárolunk semmilyen érzékeny adatot, beleértve az Ön privát kulcsait, magvas kifejezéseit vagy PIN-kódját. Ezeket az adatokat csak a felhasználó készülékén tároljuk, és soha nem hagyják el azt. Ön teljes mértékben ura az eszközeinek.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "Az {appName} mobilra Androidon és iPhone-on, asztali számítógépen pedig <a href=\"https://komodoplatform.com/\">Windows, Mac és Linux operációs rendszeren</a> érhető el.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Más DEX-ek általában csak olyan eszközökkel lehet kereskedni, amelyek egyetlen blokklánc-hálózaton alapulnak, proxy tokeneket használnak, és csak egyetlen megbízás leadását teszik lehetővé ugyanazokkal az eszközökkel.\n\nAz {appName} lehetővé teszi, hogy natívan, proxy tokenek nélkül kereskedhessen két különböző blokklánc hálózaton. Több megbízást is adhat ugyanazokkal az alapokkal. Például 0,1 BTC-t adhatsz el KMD, QTUM vagy VRSC ellenében - az első teljesített megbízás automatikusan törli az összes többi megbízást.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Az egyes swapok feldolgozási idejét több tényező határozza meg. A kereskedett eszközök blokkolási ideje az egyes hálózatoktól függ (a Bitcoin jellemzően a leglassabb) Ezen kívül a felhasználó testre szabhatja a biztonsági beállításokat. Például kérheti az {appName}-t, hogy egy KMD tranzakciót már 3 megerősítés után véglegesnek tekintsen, ami rövidebbé teszi a csereidőt, mintha <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">jegyesítésre</a> kellene várni.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Igen. Az egyes atomi cserék sikeres végrehajtásához továbbra is kapcsolódnia kell az internethez, és az alkalmazásnak futnia kell (a kapcsolat nagyon rövid megszakításai általában rendben vannak). Ellenkező esetben fennáll a kereskedés törlésének kockázata, ha Ön a döntéshozó, és a pénzeszközök elvesztésének kockázata, ha Ön a vevő. Az atomi swap protokoll megköveteli, hogy mindkét résztvevő online maradjon és figyelje az érintett blokkláncokat, hogy a folyamat atomi maradjon.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "Két díjkategóriát kell figyelembe venni a {appName}-on történő kereskedés során.\n\n 1. Az {appName} körülbelül 0,13%-ot (a kereskedési volumen 1/777-ét, de nem kevesebb, mint 0,0001) számít fel kereskedési díjként a taker megbízásokért, a maker megbízásoknak pedig nulla a díja.\n\n 2. Mind a makereknek, mind a takeereknek normál hálózati díjakat kell fizetniük az érintett blokkláncoknak, amikor atomi swap tranzakciókat hajtanak végre.\n\n A hálózati díjak a kiválasztott kereskedési párostól függően nagymértékben eltérhetnek.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "Igen! A {appName} támogatást nyújt az <a href=\"{link}\">{appCompanyShort} {name}</a>-n keresztül. A csapat és a közösség mindig szívesen segít!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "Nem! Az {appName} teljesen decentralizált. Nem lehetséges a felhasználók hozzáférését harmadik fél által korlátozni.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "Az {appName}-t az {appCompanyShort} csapata fejleszti. Az {appCompanyShort} az egyik legelismertebb blokkláncprojekt, amely olyan innovatív megoldásokon dolgozik, mint az atomic swap, a Delayed Proof of Work és az interoperábilis multi-chain architektúra.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "Teljesen! További részletekért olvassa el <a href=\"https://developers.komodoplatform.com/\">fejlesztői dokumentációnkat</a>, vagy forduljon hozzánk partnerségi kérdéseivel. Konkrét technikai kérdése van? A {appName} fejlesztői közössége mindig készen áll a segítségére!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Taps",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "BIZTOS?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "a csere meghiúsul",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "a csere befejeződik",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "hitelesítse a",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Az újbóli aktiválási folyamat befejeztével automatikusan átirányítjuk a portfólió oldalra.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "max vol",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "vissza",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Mentés",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "{coinName1}/{coinName2} alapján",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "Az akkumulátor töltöttsége kritikus ({batteryLevelCritical}%) a biztonságos cseréhez. Kérjük, töltse fel, és próbálja meg újra.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "Az akkumulátor töltöttsége alacsonyabb, mint {batteryLevelLow}%. Kérjük, fontolja meg a telefon töltését.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "A telefon akkumulátor-takarékos üzemmódban van. Kérjük, kapcsolja ki ezt az üzemmódot, vagy NE tegye az alkalmazást a háttérbe, különben az alkalmazást az operációs rendszer megölheti, és a csere sikertelen lesz.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "A rendelkezésrre álló legjobb ár",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Komodo rendszerrel fejlesztve",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Komodo rendszerrel fejlesztve",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Vétel",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "Átalakítás vevővé, ha nem egyezik",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Csere kiadva, kérjük várjon!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "A rendelés egyeztetése folyamatban van, kérjük várjon {seconde} másodperceket!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "Figyelmeztetés, Ön hajlandó teszt érméket vásárolni NÉLKÜL valós értéket!",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "Az álcázó PIN és a Bio védelem nem engedélyezhető egyszerre.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Az álcázó PIN és a bio védelem konfliktusban van egymással.",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Álcázó PIN megváltoztatása",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Álcázó PIN létrehozása",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Ha az álcázó PIN kóddal nyitod fel az alkalmazást, egy hamis alacsony egyenleg fog megjelenni, és az álzácási PIN konfigurációs opció NEM lesz látható a beállításokban.",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "Érvénytelen álcázási PIN-kód",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Álcázó PIN-kód",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "Az álcázási PIN-kód nem található",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Off",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "Be",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "Álcázási PIN mentve",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Álcázó PIN-kód",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Új álcázási PIN megadása",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Álcázási PIN beállítása",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Álcázási PIN beállítása",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "visszamond",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "Visszavonás",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Megrendelés visszavonása",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Valami rosszul sült el. Próbálja meg később újra.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ok",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "egy alapértelmezett érme. Az alapértelmezett érméket nem lehet letiltani.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "Nem lehet letiltani",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "Ezt nem lehet lejátszani",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEX árfolyam",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "CEX adatok",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Az ezzel az ikonnal jelölt piaci adatok (árak, grafikonok stb.) harmadik féltől származó forrásokból származnak (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "CEX árfolyam",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "PIN módosítása",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Frissítések ellenőrzése",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Kifizetés",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "ellenőrizze a SEED-jét",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "FOLYTATÁS",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "Lépjen vissza és ellenőrizze ismét",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "Írja be a {index}. szót",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "A SEED-ed fontos - ezért szeretnénk ellenőrizni, hogy helyes-e. Három különféle kérdést fogunk feltenni a SEED-el kapcsolatban, hogy megbizonyosodjon arról, hogy bármikor könnyedén visszaállíthatja a pénztárcáját.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "Mi a {index}. szó a SEED-ben?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "DUPLÁN ellenőrizze a SEED-jét",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Kínai",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "Igényel",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "Igényelje meg KMD jutalmát?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Kattintson a megtekintéshez",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "Vágólapra másolva",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "Vágólapra másolva",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Bezár",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Hibaüzenet bezárása",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Előnézet bezárása",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Kód:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Kiválasztotta az eszközök maximális számát",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "{protocolName} érme aktiválva van",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName} érme sikeresen aktiválva",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "A(z) {protocolName} érmék nincsenek aktiválva",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Tiszta",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "Nincsenek aktív érmék",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Érme kiválasztása",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "Hamarosan...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "Tranzakció részletek hamarosan!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "A részletek hamarosan megjelennek!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "Jutalék díj",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "átlaghoz képest 24 órás CEX ár",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "a CEX-hez képest",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "A pénztárca konfigurálása, kérjük várjon...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "Megerősít",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Álcázási PIN megerősítése",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "Biztos, hogy törölni szeretné a rendelést",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "Az alábbi gombokra kattintva megerősítheti, hogy elolvasta a „EULA” és a „Általános Szerződési Feltételeket”, és elfogadja ezeket",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Jelszó megerősítése",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "PIN kód megerősítése",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "SEED megerősítése",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Csatlakozás...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "Megszüntetés",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Kapcsolat törlése",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "törlése",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "Biztos vagy benne, hogy törölni akarod a {name} kontaktot?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Elutasítás",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Szerkesztés",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Kilépés",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Elveti a módosításokat?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "Nem találtam kapcsolatot",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Mentés",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Kapcsolattartási adatok",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "Név",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Szerződés",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Megváltoztatni",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "Nem sikerült elindítani az URL-t",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "Nem sikerült importálni:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "Kereskedelem",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "PÉNZTÁRCA LÉTREHOZÁSA",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Kapcsolat létrehozása",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "PIN kód létrehozása",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Pénznem",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Pénznem",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Jelenlegi érték:",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Egyedi díj",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "Csak akkor használjon egyéni díjakat, ha tudja, mit csinál!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Az egyéni magvas kifejezések kevésbé biztonságosak és könnyebben feltörhetők, mint egy generált, BIP39 szabványnak megfelelő magvas kifejezés vagy magánkulcs (WIF). Annak megerősítéséhez, hogy tisztában van a kockázattal és tudja, mit csinál, írja be az alábbi mezőbe a \"{iUnderstand}\" szöveget.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Dátum",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Pénztárca dekódolása",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Törlés",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Hatályon kívül helyezés megerősítése",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "El akarja távolítani",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "a portfóliójából? Minden nem egyező megbízás törlésre kerül.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " is deaktiválva lesz",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Pénztárca törlése",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Pénztárca törlése...",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "megkapja a {coinName} tranzakciós díjat",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "küldje el a {coinName} tranzakciós díjat",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "kereskedési díj tranzakciós díj küldése",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "kereskedési díj",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "részletek",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Német",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Fejlesztő",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX nem elérhető ehhez az érméhez",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Képernyőképek/Előnézet letiltása",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Felelősségi nyilatkozat & használati feltételek",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Kész",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "Ne zárja be az alkalmazást. További információért koppintson...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "Ne kérdezze újra",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "Nem akarok jelszót",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo dPoW biztonság",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Időtartam",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Kapcsolat szerkesztése",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "Bemenet {abbr} cím",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "A titkosítási jelszó nem lehet üres",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "A jelszó nem lehet üres",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "Kapcsolattartó neve nem lehet üres",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "A tárca neve nem lehet üres",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "Továbbra is engedélyezheti a következőt: {remains}, Kijelölve: {selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "Kérjük, engedélyezze az értesítéseket, hogy értesüljön az aktiválás folyamatáról.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Tesztérmék engedélyezése",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "Ön rendelkezik",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "eszközök engedélyezve, és megpróbálja engedélyezni",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "többet. Az engedélyezett eszközök maximális korlátja",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": ". Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Túl sok eszközt próbál engedélyezni",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Pénztárca titkosítása",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "Angol",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Adja meg új PIN-kódját",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Adja meg régi PIN kódját",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Kérjük, írja be a jelszavát a folytatáshoz.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "Adja meg a PIN kódját",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Adja meg a Seed-jét",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Először az Eladási összeget kell megadnia",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "Nincs elég egyenleg",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "Hiba! Helytelen / nem valós cím!",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "A Segwit címek (még) nem támogatottak",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "Nincs elég gáz - használjon minimum {gas} Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Hiba, kérem próbálja újra",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Hiba, kérjük próbálja újra",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "Az érték túl magas vagy alacsony",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "Kérjük adjon meg adatokat",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Becsült Teljes Érték",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Például: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Célszerű",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Drága",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "Azonos a CEX-szel",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Árfolyam:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "KERESKEDŐOLDAL",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Exportálás",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Kapcsolatok",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Kérjük, válassza ki a titkosított fájlba exportálandó elemeket.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Exportálás",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Jegyzetek",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "A tételek exportálása sikeresen megtörtént:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Cserék",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Exportálás",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Sikertelen",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Hamis egyenleg összege:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Gyakran ismételt kérdések",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Hiba",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "Kérelem küldése a {coin} csaptelephez...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "FAUCET",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Siker",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "A kérés lejárt",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Visszajelzés küldése",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Hírek",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Itt nincs semmi",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} hírek",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Bővebben...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Feed",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Hírek",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "Nem folytatható a hírfrissítés",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "Nem lehetséges a hírfrissítés",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Hírfolyam frissítve",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Már naprakész",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "A díjak legfeljebb {value}",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Minden",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Szűrő",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Összes szűrő törlése",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Sikertelen",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "Dátumtól",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Gyártó",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Érmét kapott érme",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Érme eladása",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Státusz",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Sikeres",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Átvevő",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "Eddig",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Vevő/szerző",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Ujjlenyomat",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Befejezés, kérem várjon",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "Talált QR kódot",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Francia",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "Honnan",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} díj",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "Benzin limit",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Kérjük, aktiválja {coin}.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "Gáz ára",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "Az általános PIN-védelem nem aktív.\n Az álcázási mód nem lesz elérhető.\n Kérjük, aktiválja a PIN-védelmet.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Fontos: Mentse el a SEED-jét mielött tovább haladnánk!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "A tranzakció lebonyolítása, kérjük, várjon",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Ugrás a portfólióhoz",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "A Gwei értékének legfeljebb {value} értéknek kell lennie",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "Segítség",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Segítség és támogatás",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Egyenlegek elrejtése",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Jelszó megerősítése",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Jelszó létrehozása",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Jelenlegi jelszó",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Írja be a jelszavát",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Írja be a SEED-jét",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Pénztárcád neve",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Jelszó",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "előzmények",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "ó",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Magyar",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "Import",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Érvénytelen jelszó vagy sérült adatok",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "Importálandó tételek:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Fájl nem található",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Érvénytelen csereadatok. Kérjük, adjon meg egy érvényes swap-státusz JSON fájlt.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "Importálás",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Kérjük, válasszon titkosított fájlt az importáláshoz.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Megnyitás...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Kérjük, válasszon egyszerű szöveges swapfájlt az importáláshoz.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "Megszakítás",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Ok",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Jelszó",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Egyetlen swap importálása",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Swap importálása",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Néhány elemet kihagytunk",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "A tételek importálása sikeresen megtörtént:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "Nem sikerült a swap importálása",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Hiba a json fájl dekódolásában",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "Importálás",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Bejövő {coinName} txs-védelmi beállítások",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Ha nem ad meg jelszót, akkor minden alkalommal be kell írnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "A megkezdett cserét visszavonni nem lehet, ez végleges!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "Ez a tranzakció akár 10 percet is igénybe vehet - NE zárja be ezt az alkalmazást!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Dönthet úgy is, hogy jelszóval titkosítja a pénztárcáját. Ha úgy dönt, hogy nem használ jelszót, akkor minden alkalommal meg kell adnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} az egyenleg nem elegendő a kereskedési díj kifizetéséhez",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "A megbízáshoz szükséges minimális mennyiség",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Elégtelen mennyiség",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Frissítés",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "Internet kapcsolat helyreállt",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "Nem lehet folytatni a swapot",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Részletek",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} nem elérhető :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "Értem",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Japán",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Koreai",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Nyelv",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Legutóbbi tranzakciók",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Jogi",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "Kevesebb",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗Vigyázat! A(z) {coinName} piacán kevesebb, mint 10 000 USD 24 órás kereskedési volumen van!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "A korlát legfeljebb {value} lehet",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "Betöltés...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Rendelési könyv betöltése...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "Képernyő lezárva",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "Kérjük hitelesítse!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "belépés",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Kijelentkezés",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Kijelentkezés kilépéskor",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Kijelentkezés beállításai",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "Biztos, hogy most már ki akarsz jelentkezni?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "percek",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "Rendelés készítése",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Készítő",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Megrendelés törlése",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "Létrehozva",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Megkapja",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "Megrendelés azonosítója",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Ez a megbízás nem indított swapot",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Ár",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Eladni",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "A megbízás által indított swapok",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Maker megbízás részletei",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Maker megbízás",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Piactér",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "Diagram",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Mélység",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "Nem találtunk kéréseket",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "Nem találtak ajánlatot",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "MEGRENDELÉS KÖNYV",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Megrendelés részletei",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "ÁRA",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Kérjük, válasszon érméket",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Piacok",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "MARKETS",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "A jelszavaknak meg kell egyezniük",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Váltás",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Az általános PIN-kód és az álcázó PIN-kód ugyanaz.\n Az álcázó üzemmód nem lesz elérhető.\n Kérjük, változtassa meg a álcázó PIN-kódot.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "Érvénytelen PIN-kód",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "MAX",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Maximális rendelési mennyiség:",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Hírek",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "BÖNGÉSZÉS",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "BÖNGÉSZŐ FEED",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "Által",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "Nincsenek mentett cikkeid",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "MENTVE",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Memo",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Egyesítés",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Összevont érték:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "ezredmásodperc",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "MIN",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Figyelmeztetés: Az alkalmazás iOS rendszeren való minimalizálása leállítja az aktiválási folyamatot.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "Minimális rendelési mennyiség:",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "m",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "A minimális eladási összeg {number} {coinName}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "A minimális vásárlási összeg: {number}{coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "A megbízás minimális összege {buyAmount} {buyCoin} ({sellAmount} {sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "Az eladandó minimális összeg {number} {coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "Nagyobbnak kell lennie, mint {minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Alacsonyabbnak kell lennie, mint az eladási összeg",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Minimális mennyiség szükséges",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "Egyéni minimális mennyiség használata",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Kérjük, vegye figyelembe, hogy most mobiladatokat használ, és az {appName} P2P-hálózatban való részvétel internetforgalmat fogyaszt. Jobb, ha WiFi hálózatot használsz, ha a mobiladat-előfizetésed drága.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Több információ",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "További",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Aktiválja a {coin} és töltse fel először az egyenlegét",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Összeg",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Érme",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Eladás",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "Cancel",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Megerősítés",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "Create {number} Order(s):",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Létrehozása",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Megrendelés",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Megrendelések",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "díj",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "Cancel",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Kérjük, adja meg az átvenni kívánt fiat összeget:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Autofill",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Kérjük, a folytatás előtt javítson ki minden hibát",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Érvénytelen összeg",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Érvénytelen eladási összeg",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "Nincs elég {coin} a díjak kifizetéséhez. MIN egyenleg {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin} egyenleg túl alacsony",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "Max eladási összeg",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "A minimális vételi összeg",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "Min eladási összeg",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Receive:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Sell:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Multi",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Receive Amt.",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "Ár/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Hálózati díj",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "új számla",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Új Számla",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Hírcsatorna",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Új érték:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "tovább",
-    "@next": {
-        "type": "text"
-    },
-    "no": "Szám",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "Nincsenek hírek - kérjük nézzen vissza később!",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "Nem találtunk érmét",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Nincs alaptőke",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "Alaptőke nem elérhető - kérjük utaljon be.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "Nincs Internet Kapcsolat",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "Nincs kiválasztott tétel",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "Nincs kiválasztott tétel",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "Nem találtak megfelelő rendelést",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Egyik sem",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "Az értéknek numerikusnak kell lennie",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Nem érhető el {coinName} rendelés - próbálja újra később, vagy készítsen egy rendelést.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Kattintson a megrendelés létrehozásához",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "Nincs rendelés, kérem, menjen a kereskedelembe.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "Nincs igényelhető jutalom",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "Nincs igényelhető jutalom - próbálkozzon újra 1 óra múlva.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "Nincs ilyen érme",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "Nincs elözmény.",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "Nincs elég {coin} a tranzakcióhoz!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "Nincs elég egyenlege a jutalékhoz - kereskedjen kisebb mennyiséggel",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Megjegyzés: A párosított rendelés nem törölhető újra.",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Megjegyzés hozzáadása",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Megjegyzés",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Semmi sem található",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "Az {sell}/{buy} swap sikeresen befejeződött.",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "A csere befejeződött",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} csere sikertelen volt",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "A swap sikertelen",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} swap elindult",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Új swap indult",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Swap státusz megváltozott",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} swap időzítve volt",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Swap lejárt",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "Ön {coin} tranzakciót kapott!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Bejövő tranzakció",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "Nincs tranzakció",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} Aktív",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "Hivatalos sajtóközlemény",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Oké",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Törlés",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Régi naplók",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Használt hely",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Hibaüzenet megnyitása",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "Választható",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "Kevésbé",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "Több",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Minden {coin} megrendelés törlésre kerül.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Megrendelés létrehozva",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Megrendelés sikeresen létrehozva",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Cím:",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "Cancel",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "Célszerű: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "Drága: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "a esetében",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "Azonos a CEX-szel",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "min.",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Ár",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Vétel",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Válassza ki a",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Eladja",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Nyissa meg a részleteket egyetlen koppintással, és válassza a Megrendelés hosszú koppintással",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Töltse el a",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Részletek",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% betelt",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Rendelés megegyezett",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Rendelés egyeztetés",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "rendelések",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Aktív",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "Történelem",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "Mennyiség. ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "Ár ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "Összesen ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Megrendelés",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Ismeretlen típusú rendelés",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Felülírás",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "Ez a saját megrendelésed!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Az egyenlegből fizetett:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Kifizetve a kapott mennyiségből:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Fizetetve",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "A jelszónak legalább 12 karaktert kell tartalmaznia, egy kisbetűt, egy nagybetűt és egy speciális szimbólumot.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Fizetés",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "Elfogadja ezt a tranzakciót?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "Címre",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "Összeg:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Érme:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "Cancel",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Kért fizetés",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} nem aktív. Kérjük, aktiválja és próbálja újra.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Rendelés leadása",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "Játssz teljes hangerőn",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Kérjük, adjon hozzá egy érmét",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Kérjük, indítsa újra az alkalmazást, vagy nyomja meg az alábbi gombot.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Portfolió",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Komodo által működtetett",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "ár",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Privát kulcs",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Privát kulcsok",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Megerősítések",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Egyéni védelmi beállítások használata",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "KI",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "BE",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Figyelmeztetés, ez az atomi csere nem dPoW védett.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Publikációs kulcs",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "QR Code Scanner",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "Tárolja a privát kulcsaimat?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "Mely eszközökön használhatom az {appName}-t?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "Miben különbözik a kereskedés az {appName}-en a más DEX-eken folytatott kereskedéstől?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "Mennyi ideig tart egy-egy atomi swap?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "A csere időtartama alatt online kell lennem?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "Hogyan számítják ki a díjakat az {appName}-nél?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "Biztosítanak felhasználói támogatást?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "Vannak országos korlátozások?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "Ki áll az {appName} mögött?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "Lehetséges saját white-label csereprogramot kialakítani az {appName} oldalon?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "Ez egy új korszak! Hivatalosan megváltoztattuk a nevünket „AtomicDEX”-ről „Komodo Wallet”-ra",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "FOGAD",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Fogad",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Azt ajánljuk offline tárolja.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Kikapcsolás",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Kért Trade",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "ÜRES",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Formanyomtatvány visszaállítása",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "VISSZAÁLLÍTÁS",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Az összes érme aktiválásának újbóli próbálkozása...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Az összes érme aktiválásának újbóli próbálkozása",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Igényelje jutalmát",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Megszünteti",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Valami rosszul sült el. Kérjük, próbáld meg később újra.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "A tranzakció folyamatban van",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "feldolgozás",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXO összeg kevesebb, mint 10 KMD",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Egy óra még nem telt el",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 óra",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "Ok",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Jutalmak állapota:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "További információ a KMD aktív felhasználó jutalmakról",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Kapja meg a címet.",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "Siker! {amount} KMD kapott.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "Utalás",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "Jutalmak,\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Állapot",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Maradék idő",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Jutalom információ:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO amt,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} napok",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}h {minutes}m",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}min",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "Jutalom információk",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Orosz",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Mentés összevonva",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "A folytatáshoz görgessen lefelé...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Keressen egy érmét",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Válassza ki az összes Avax érmét",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Az összes BEP token kiválasztása",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Válassza ki az összes Cosmos hálózatot",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Válassza ki az összes ERC tokenet",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Az összes ETC token kiválasztása",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Válassza ki az összes FTM tokenet",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Válassza ki az összes HCO tokenet",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Válassza ki az összes HRC tokenet",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Válassza ki az összes Iris hálózatot",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Válassza ki az összes KRC tokenet",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Válassza ki az összes MVR tokenet",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Válassza ki az összes PLG tokenet",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Válassza ki az összes QRC tokenet",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Válassza ki az összes SBCH tokenet",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Válassza ki az összes SLP tokent",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Az összes SmartChains kiválasztása",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Válassza ki az összes teszteszközt",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Az összes Ubiq kiválasztása",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Az összes UTXO kiválasztása",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Válassza ki az összes ZHTLC-érmét",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Keresse meg a Tickert",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Biztonság",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "SEED kifejezés",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Új SEED-ed",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "Kattintson a megtekintéshez {amount} rendelések",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "Tranzakciós előzmények megtekintése",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Válasszon érmét",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Válassza ki az érmét amit hozzá kíván adni a portfóliójához",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Érme aktiválás:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "Válassza ki az érmét amit VÁSÁROLNI szeretne",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "Válassza ki az érmét amit ELADNI szeretne",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Kiválasztott sorrend:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Fájl kiválasztása",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Nyelv kiválasztása",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Válassza ki a fizetési metódust",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Eladás",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "Figyelmeztetés, Ön hajlandó eladni tesztérméket VALÓDI érték nélkül!",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "KÜLD",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Biztos benne, hogy törölni szeretné",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "pénztárca?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Ha igen, győződjön meg róla",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "rögzítse a SEED-jét.",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "A pénztárca jövőbeli helyreállítása érdekében.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Nyelvek",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Beállítások",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "JELSZÓ BEÁLLÍTÁSA",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "Megosztás",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "Az én {coinName} címem:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Cím megjelenítése",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Részletek megjelenítése",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "{count}/{maxCount} rendelés megjelenítése.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "Mutasd a rendeléseimet",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Jelentkezzen be jelszóval",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "Jelentkezzen be SEED-el",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Egyszerű",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Aktiválja a címet.",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Kérjük, adja meg a {coin} összeget a vásárláshoz",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Vásárlás",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Bezárás",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "A maximális aktív érmék száma {maxCoins}. Kérjük, néhányat deaktiváljon.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} nem aktív!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Fogadja",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Kérjük, adja meg az eladni kívánt {coin} összeget",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Eladni",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Küldje el a",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Kevesebb mutatása",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Többet mutasd meg",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "Nem sikerült aktiválni {coin}",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Kihagyás",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Dissississ",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Hang",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Válasszon egy mp3 vagy wav fájlt, kérem. Akkor fogjuk lejátszani, amikor {description}.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "Lejátsszuk, amikor {description}",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Hangok",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Értettem, többé nem jelenítjük meg",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Hang",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Hangbeállítások",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "A cserefolyamat során és akkor hallható hangjelzés, ha aktív készítői megbízásod van.\nAz atomi swap protokoll megköveteli, hogy a résztvevők online legyenek a sikeres kereskedéshez, és a hangos értesítések segítenek ennek elérésében.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Ne feledje, hogy az alkalmazás beállításaiban beállíthatja az egyéni hangokat.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "Spanyol",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Indítsa el a Swapot",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Lépés",
-    "@step": {
-        "type": "text"
-    },
-    "success": "Siker!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Támogatás",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Ha bármilyen kérdésed van, vagy úgy gondolod, hogy technikai problémát találtál az {appName} alkalmazással kapcsolatban, akkor jelentheted, és támogatást kaphatsz csapatunktól.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "csere",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Aktuális",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "Erősitse meg a csere részleteit",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "Becslés",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "Csere sikertelen",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Kérjük, először aktiválja {coin} és töltse fel egyenlegét",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "Az {coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "{coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez. {coin} {amount} szükséges.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Csere folyamatban",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "Haladás részletei",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "Elindult",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Csere sikeres",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Összesen",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "Swap UUID",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Switch téma",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Átvevő",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Vevő rendelés",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Időtúllépés",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "JELSZÓ LÉTREHOZÁSA",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Kiválasztott sorrend",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "Hova",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "Címzett:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "Van egy",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "eszközöd engedélyezve. Az engedélyezett eszközök maximális korlátja .",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": "Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Túl sok eszköz engedélyezve",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Összes díj:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "KERESKEDÉS",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "Csere végrehajtva!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "KERESKEDÉS részletek",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Nem sikerült kiszámítani a kereskedelmi díjakat",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "kereskedési díj:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Kereskedési mód:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "Tranzakció címe",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "Tranzakció rejtett",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Ez a tranzakció egy lehetséges adathalász kísérlet miatt el lett rejtve.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "Ha még ekkor sem aktiválódik néhány érme, próbálja meg újraindítani az alkalmazást.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Török",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Blokk",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Megerősítések",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "MERŐSÍTVE",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Díj",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "tranzakciós díj:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "Tranzakció azonosítója",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Tranzakciók Balra: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Túl sok a kérés.\n Tranzakciótörténeti kérések száma túllépte a limitet.\n Kérjük, próbálja meg később újra.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "NEM MEGERŐSÍTETT",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Ukrán",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "kinyit",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Alapok feloldása",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "Sikeresen feloldotta a {amnt} pénzeszközöket - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "elkölthetetlen",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Új verzió elérhető",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Frissítések keresése...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "Ön a {version} verziót használja.",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Új verzió elérhető. Kérjük, frissítse.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "A {version} verzió elérhető. Kérjük, frissítse.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Frissítés elérhető",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Egyelőre kihagyás",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "{appName} frissítés",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Frissítés",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Már naprakész",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "Nincs elég egyenleg a beolvasáshoz",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "fizetési kérelem.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Elégtelen egyenleg",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Érték:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "verzió",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Felfedező",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Magánkulcsok és magánkulcsok",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Volumes",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "A pénztárca neve már használatban van",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "A pénztárca neve legfeljebb 40 karakter lehet.",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Csak pénztárca",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "Figyelmeztetés!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Ok",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Figyelmeztetés - különleges esetekben ez a naplóadat érzékeny információkat tartalmaz, amelyek felhasználhatók a sikertelen cserékből származó érmék elköltésére!",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "Nem sikerült aktiválni a {coinAbbr}",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "Nem sikerült aktiválni a {coinAbbr}.\nKérjük, indítsa újra az alkalmazást, hogy újra megpróbálhassa.",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} mobil egy következő generációs többérmés pénztárca natív harmadik generációs DEX funkcióval és még sokkal több",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "KÉSZÍTSÜK FEL!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "Üdvözöljük",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "pénztárca",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "A kitöltés után átirányítjuk a portfólió oldalra.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Ez eltart egy ideig, és az alkalmazást az előtérben kell tartani.\nAz alkalmazás aktiválás közbeni leállítása problémákhoz vezethet.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Kifizetés",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "Ön korábban megtagadta a {appName} hozzáférést a kamerához.\n Kérjük, a QR-kód beolvasásának folytatásához manuálisan módosítsa a kameraengedélyt a telefon beállításaiban.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Hozzáférés megtagadva",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Kiutalás megerősítése",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Valami rosszul sült el. Próbálja meg később újra.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "KIFIZETÉS {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "Ön megpróbál beolvasni egy fizetési QR-kódot a következőhöz",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "de a",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "visszavonási képernyőn van",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Rossz érme",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "A jelszavak nem egyeznek. Próbálja újra.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Igen",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Ön küld:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "van egy új megrendelése, amelyet egy meglévő megrendeléssel próbál összevetni.",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "aktív csere folyamatban van",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "van egy megbízása, amellyel az új megbízások összeilleszthetők.",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "a pénztárcája",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "Kapni fog {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Fog kapni:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "hu",
+  "accepteula": "Fogadja el az EULA-t",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "Fogadja el a feltételeket és a kondíciókat",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Biometrikus védelem aktiválása",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "PIN védelem aktviálása",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "Aktiválja a {protocolName} érméket?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "{coinName} aktiválása",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName} Aktiválás",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} Aktiválás folyamatban",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Aktív",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Aktív érme",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} sikeresen aktiválva !",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Cím hozzáadása",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Címjegyzék",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "A címjegyzék üres",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Csak a {title} címekkel rendelkező kapcsolatok megjelenítése",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Címjegyzék",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "Nem tud pénzt küldeni a {abbr} címre, mert a {abbr} nincs aktiválva. Kérjük, menjen a portfólióhoz.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Semmi sem található",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Válassza ki az érmét",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Címzett címe",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Haladó",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "Minden",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Egyedi SEED engedélyezése",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "A pénztárcája minden korábbi tranzakciót mutat. Ez jelentős tárhelyet és időt vesz igénybe, mivel az összes blokkot letölti és átvizsgálja.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "Már létezik",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Összeg",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Eladandó összeg",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "Nem! Az {appName} nem felügyeleti joggal rendelkezik. Soha nem tárolunk semmilyen érzékeny adatot, beleértve az Ön privát kulcsait, magvas kifejezéseit vagy PIN-kódját. Ezeket az adatokat csak a felhasználó készülékén tároljuk, és soha nem hagyják el azt. Ön teljes mértékben ura az eszközeinek.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "Az {appName} mobilra Androidon és iPhone-on, asztali számítógépen pedig <a href=\"https://komodoplatform.com/\">Windows, Mac és Linux operációs rendszeren</a> érhető el.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Más DEX-ek általában csak olyan eszközökkel lehet kereskedni, amelyek egyetlen blokklánc-hálózaton alapulnak, proxy tokeneket használnak, és csak egyetlen megbízás leadását teszik lehetővé ugyanazokkal az eszközökkel.\n\nAz {appName} lehetővé teszi, hogy natívan, proxy tokenek nélkül kereskedhessen két különböző blokklánc hálózaton. Több megbízást is adhat ugyanazokkal az alapokkal. Például 0,1 BTC-t adhatsz el KMD, QTUM vagy VRSC ellenében - az első teljesített megbízás automatikusan törli az összes többi megbízást.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Az egyes swapok feldolgozási idejét több tényező határozza meg. A kereskedett eszközök blokkolási ideje az egyes hálózatoktól függ (a Bitcoin jellemzően a leglassabb) Ezen kívül a felhasználó testre szabhatja a biztonsági beállításokat. Például kérheti az {appName}-t, hogy egy KMD tranzakciót már 3 megerősítés után véglegesnek tekintsen, ami rövidebbé teszi a csereidőt, mintha <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">jegyesítésre</a> kellene várni.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Igen. Az egyes atomi cserék sikeres végrehajtásához továbbra is kapcsolódnia kell az internethez, és az alkalmazásnak futnia kell (a kapcsolat nagyon rövid megszakításai általában rendben vannak). Ellenkező esetben fennáll a kereskedés törlésének kockázata, ha Ön a döntéshozó, és a pénzeszközök elvesztésének kockázata, ha Ön a vevő. Az atomi swap protokoll megköveteli, hogy mindkét résztvevő online maradjon és figyelje az érintett blokkláncokat, hogy a folyamat atomi maradjon.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "Két díjkategóriát kell figyelembe venni a {appName}-on történő kereskedés során.\n\n 1. Az {appName} körülbelül 0,13%-ot (a kereskedési volumen 1/777-ét, de nem kevesebb, mint 0,0001) számít fel kereskedési díjként a taker megbízásokért, a maker megbízásoknak pedig nulla a díja.\n\n 2. Mind a makereknek, mind a takeereknek normál hálózati díjakat kell fizetniük az érintett blokkláncoknak, amikor atomi swap tranzakciókat hajtanak végre.\n\n A hálózati díjak a kiválasztott kereskedési párostól függően nagymértékben eltérhetnek.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "Igen! A {appName} támogatást nyújt az <a href=\"{link}\">{appCompanyShort} {name}</a>-n keresztül. A csapat és a közösség mindig szívesen segít!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "Nem! Az {appName} teljesen decentralizált. Nem lehetséges a felhasználók hozzáférését harmadik fél által korlátozni.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "Az {appName}-t az {appCompanyShort} csapata fejleszti. Az {appCompanyShort} az egyik legelismertebb blokkláncprojekt, amely olyan innovatív megoldásokon dolgozik, mint az atomic swap, a Delayed Proof of Work és az interoperábilis multi-chain architektúra.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "Teljesen! További részletekért olvassa el <a href=\"https://developers.komodoplatform.com/\">fejlesztői dokumentációnkat</a>, vagy forduljon hozzánk partnerségi kérdéseivel. Konkrét technikai kérdése van? A {appName} fejlesztői közössége mindig készen áll a segítségére!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Taps",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "BIZTOS?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "a csere meghiúsul",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "a csere befejeződik",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "hitelesítse a",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Az újbóli aktiválási folyamat befejeztével automatikusan átirányítjuk a portfólió oldalra.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "max vol",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "vissza",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Mentés",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "{coinName1}/{coinName2} alapján",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "Az akkumulátor töltöttsége kritikus ({batteryLevelCritical}%) a biztonságos cseréhez. Kérjük, töltse fel, és próbálja meg újra.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "Az akkumulátor töltöttsége alacsonyabb, mint {batteryLevelLow}%. Kérjük, fontolja meg a telefon töltését.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "A telefon akkumulátor-takarékos üzemmódban van. Kérjük, kapcsolja ki ezt az üzemmódot, vagy NE tegye az alkalmazást a háttérbe, különben az alkalmazást az operációs rendszer megölheti, és a csere sikertelen lesz.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "A rendelkezésrre álló legjobb ár",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Komodo rendszerrel fejlesztve",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Komodo rendszerrel fejlesztve",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Vétel",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "Átalakítás vevővé, ha nem egyezik",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Csere kiadva, kérjük várjon!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "A rendelés egyeztetése folyamatban van, kérjük várjon {seconde} másodperceket!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "Figyelmeztetés, Ön hajlandó teszt érméket vásárolni NÉLKÜL valós értéket!",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "Az álcázó PIN és a Bio védelem nem engedélyezhető egyszerre.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Az álcázó PIN és a bio védelem konfliktusban van egymással.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Álcázó PIN megváltoztatása",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Álcázó PIN létrehozása",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Ha az álcázó PIN kóddal nyitod fel az alkalmazást, egy hamis alacsony egyenleg fog megjelenni, és az álzácási PIN konfigurációs opció NEM lesz látható a beállításokban.",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "Érvénytelen álcázási PIN-kód",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Álcázó PIN-kód",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "Az álcázási PIN-kód nem található",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Off",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "Be",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "Álcázási PIN mentve",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Álcázó PIN-kód",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Új álcázási PIN megadása",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Álcázási PIN beállítása",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Álcázási PIN beállítása",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "visszamond",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Aktiválás megszakítása",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "Biztosan megszakítja az aktiválást?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "Visszavonás",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Megrendelés visszavonása",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Valami rosszul sült el. Próbálja meg később újra.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ok",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "egy alapértelmezett érme. Az alapértelmezett érméket nem lehet letiltani.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "Nem lehet letiltani",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "Ezt nem lehet lejátszani",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEX árfolyam",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "CEX adatok",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Az ezzel az ikonnal jelölt piaci adatok (árak, grafikonok stb.) harmadik féltől származó forrásokból származnak (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "CEX árfolyam",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "PIN módosítása",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Frissítések ellenőrzése",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Kifizetés",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "ellenőrizze a SEED-jét",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "FOLYTATÁS",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "Lépjen vissza és ellenőrizze ismét",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "Írja be a {index}. szót",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "A SEED-ed fontos - ezért szeretnénk ellenőrizni, hogy helyes-e. Három különféle kérdést fogunk feltenni a SEED-el kapcsolatban, hogy megbizonyosodjon arról, hogy bármikor könnyedén visszaállíthatja a pénztárcáját.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "Mi a {index}. szó a SEED-ben?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "DUPLÁN ellenőrizze a SEED-jét",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Kínai",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "Igényel",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "Igényelje meg KMD jutalmát?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Kattintson a megtekintéshez",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "Vágólapra másolva",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "Vágólapra másolva",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Bezár",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Hibaüzenet bezárása",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Előnézet bezárása",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Kód:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "Biztosan megszakítja az aktiválást?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Kiválasztotta az eszközök maximális számát",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "{protocolName} érme aktiválva van",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} érme sikeresen aktiválva",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "A(z) {protocolName} érmék nincsenek aktiválva",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Tiszta",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "Nincsenek aktív érmék",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Érme kiválasztása",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "Hamarosan...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "Tranzakció részletek hamarosan!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "A részletek hamarosan megjelennek!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "Jutalék díj",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "átlaghoz képest 24 órás CEX ár",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "a CEX-hez képest",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "A pénztárca konfigurálása, kérjük várjon...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "Megerősít",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Álcázási PIN megerősítése",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "Biztos, hogy törölni szeretné a rendelést",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "Az alábbi gombokra kattintva megerősítheti, hogy elolvasta a „EULA” és a „Általános Szerződési Feltételeket”, és elfogadja ezeket",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Jelszó megerősítése",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "PIN kód megerősítése",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "SEED megerősítése",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Csatlakozás...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "Megszüntetés",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Kapcsolat törlése",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "törlése",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "Biztos vagy benne, hogy törölni akarod a {name} kontaktot?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Elutasítás",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Szerkesztés",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Kilépés",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Elveti a módosításokat?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "Nem találtam kapcsolatot",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Mentés",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Kapcsolattartási adatok",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "Név",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Szerződés",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Megváltoztatni",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "Nem sikerült elindítani az URL-t",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "Nem sikerült importálni:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "Kereskedelem",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "PÉNZTÁRCA LÉTREHOZÁSA",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Kapcsolat létrehozása",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "PIN kód létrehozása",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Pénznem",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Pénznem",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Jelenlegi érték:",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Egyedi díj",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "Csak akkor használjon egyéni díjakat, ha tudja, mit csinál!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Az egyéni magvas kifejezések kevésbé biztonságosak és könnyebben feltörhetők, mint egy generált, BIP39 szabványnak megfelelő magvas kifejezés vagy magánkulcs (WIF). Annak megerősítéséhez, hogy tisztában van a kockázattal és tudja, mit csinál, írja be az alábbi mezőbe a \"{iUnderstand}\" szöveget.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Dátum",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Pénztárca dekódolása",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Törlés",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Hatályon kívül helyezés megerősítése",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "El akarja távolítani",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "a portfóliójából? Minden nem egyező megbízás törlésre kerül.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " is deaktiválva lesz",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Pénztárca törlése",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Pénztárca törlése...",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "megkapja a {coinName} tranzakciós díjat",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "küldje el a {coinName} tranzakciós díjat",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "kereskedési díj tranzakciós díj küldése",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "kereskedési díj",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "részletek",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Német",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Fejlesztő",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX nem elérhető ehhez az érméhez",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Képernyőképek/Előnézet letiltása",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Felelősségi nyilatkozat & használati feltételek",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Kész",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Ne zárja be az alkalmazást. További információért koppintson...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "Ne kérdezze újra",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "Nem akarok jelszót",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo dPoW biztonság",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Időtartam",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Kapcsolat szerkesztése",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "Bemenet {abbr} cím",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "A titkosítási jelszó nem lehet üres",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "A jelszó nem lehet üres",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "Kapcsolattartó neve nem lehet üres",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "A tárca neve nem lehet üres",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Továbbra is engedélyezheti a következőt: {remains}, Kijelölve: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Kérjük, engedélyezze az értesítéseket, hogy értesüljön az aktiválás folyamatáról.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Tesztérmék engedélyezése",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "Ön rendelkezik",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "eszközök engedélyezve, és megpróbálja engedélyezni",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "többet. Az engedélyezett eszközök maximális korlátja",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": ". Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Túl sok eszközt próbál engedélyezni",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Pénztárca titkosítása",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "Angol",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Adja meg új PIN-kódját",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Adja meg régi PIN kódját",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Kérjük, írja be a jelszavát a folytatáshoz.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "Adja meg a PIN kódját",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Adja meg a Seed-jét",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Először az Eladási összeget kell megadnia",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "Nincs elég egyenleg",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "Hiba! Helytelen / nem valós cím!",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "A Segwit címek (még) nem támogatottak",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "Nincs elég gáz - használjon minimum {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Hiba, kérem próbálja újra",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Hiba, kérjük próbálja újra",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "Az érték túl magas vagy alacsony",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "Kérjük adjon meg adatokat",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Becsült Teljes Érték",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Például: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Célszerű",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Drága",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "Azonos a CEX-szel",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Árfolyam:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "KERESKEDŐOLDAL",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Exportálás",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Kapcsolatok",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Kérjük, válassza ki a titkosított fájlba exportálandó elemeket.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Exportálás",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Jegyzetek",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "A tételek exportálása sikeresen megtörtént:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Cserék",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Exportálás",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Sikertelen",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Hamis egyenleg összege:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Gyakran ismételt kérdések",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Hiba",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "Kérelem küldése a {coin} csaptelephez...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "FAUCET",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Siker",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "A kérés lejárt",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Visszajelzés küldése",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Hírek",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Itt nincs semmi",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} hírek",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Bővebben...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Feed",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Hírek",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "Nem folytatható a hírfrissítés",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "Nem lehetséges a hírfrissítés",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Hírfolyam frissítve",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Már naprakész",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "A díjak legfeljebb {value}",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Minden",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Szűrő",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Összes szűrő törlése",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Sikertelen",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "Dátumtól",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Gyártó",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Érmét kapott érme",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Érme eladása",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Státusz",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Sikeres",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Átvevő",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "Eddig",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Vevő/szerző",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Ujjlenyomat",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Befejezés, kérem várjon",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "Talált QR kódot",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Francia",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "Honnan",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "A jövőbeni tranzakciókat szinkronizálni fogjuk a nyilvános kulcsához társított aktiválás után. Ez a leggyorsabb lehetőség, és a legkevesebb tárhelyet foglalja el.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} díj",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "Benzin limit",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Kérjük, aktiválja {coin}.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "Gáz ára",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "Az általános PIN-védelem nem aktív.\n Az álcázási mód nem lesz elérhető.\n Kérjük, aktiválja a PIN-védelmet.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Fontos: Mentse el a SEED-jét mielött tovább haladnánk!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "A tranzakció lebonyolítása, kérjük, várjon",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Ugrás a portfólióhoz",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "A Gwei értékének legfeljebb {value} értéknek kell lennie",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Segítség",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Segítség és támogatás",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Egyenlegek elrejtése",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Jelszó megerősítése",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Jelszó létrehozása",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Jelenlegi jelszó",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Írja be a jelszavát",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Írja be a SEED-jét",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Pénztárcád neve",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Jelszó",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "előzmények",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "ó",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Magyar",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "Import",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Érvénytelen jelszó vagy sérült adatok",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "Importálandó tételek:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Fájl nem található",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Érvénytelen csereadatok. Kérjük, adjon meg egy érvényes swap-státusz JSON fájlt.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "Importálás",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Kérjük, válasszon titkosított fájlt az importáláshoz.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Megnyitás...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Kérjük, válasszon egyszerű szöveges swapfájlt az importáláshoz.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "Megszakítás",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Ok",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Jelszó",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Egyetlen swap importálása",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Swap importálása",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Néhány elemet kihagytunk",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "A tételek importálása sikeresen megtörtént:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "Nem sikerült a swap importálása",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Hiba a json fájl dekódolásában",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "Importálás",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Bejövő {coinName} txs-védelmi beállítások",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Ha nem ad meg jelszót, akkor minden alkalommal be kell írnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "A megkezdett cserét visszavonni nem lehet, ez végleges!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "Ez a tranzakció akár 10 percet is igénybe vehet - NE zárja be ezt az alkalmazást!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Dönthet úgy is, hogy jelszóval titkosítja a pénztárcáját. Ha úgy dönt, hogy nem használ jelszót, akkor minden alkalommal meg kell adnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} az egyenleg nem elegendő a kereskedési díj kifizetéséhez",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "A megbízáshoz szükséges minimális mennyiség",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Elégtelen mennyiség",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Frissítés",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "Internet kapcsolat helyreállt",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Érvénytelen {coin} cím",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "Nem lehet folytatni a swapot",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Részletek",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} nem elérhető :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "Értem",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Japán",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Koreai",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Nyelv",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Legutóbbi tranzakciók",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Jogi",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "Kevesebb",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗Vigyázat! A(z) {coinName} piacán kevesebb, mint 10 000 USD 24 órás kereskedési volumen van!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "A korlát legfeljebb {value} lehet",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Betöltés...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Rendelési könyv betöltése...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "Képernyő lezárva",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "Kérjük hitelesítse!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "belépés",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Kijelentkezés",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Kijelentkezés kilépéskor",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Kijelentkezés beállításai",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "Biztos, hogy most már ki akarsz jelentkezni?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "percek",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "Rendelés készítése",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Készítő",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Megrendelés törlése",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "Létrehozva",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Megkapja",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "Megrendelés azonosítója",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Ez a megbízás nem indított swapot",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Ár",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Eladni",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "A megbízás által indított swapok",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Maker megbízás részletei",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Maker megbízás",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Piactér",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "Diagram",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Mélység",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "Nem találtunk kéréseket",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "Nem találtak ajánlatot",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "MEGRENDELÉS KÖNYV",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Megrendelés részletei",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "ÁRA",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Kérjük, válasszon érméket",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Piacok",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "MARKETS",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "A jelszavaknak meg kell egyezniük",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Váltás",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Az általános PIN-kód és az álcázó PIN-kód ugyanaz.\n Az álcázó üzemmód nem lesz elérhető.\n Kérjük, változtassa meg a álcázó PIN-kódot.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "Érvénytelen PIN-kód",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "MAX",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Maximális rendelési mennyiség:",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Hírek",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "BÖNGÉSZÉS",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "BÖNGÉSZŐ FEED",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "Által",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "Nincsenek mentett cikkeid",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "MENTVE",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Memo",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Egyesítés",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Összevont érték:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "ezredmásodperc",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "MIN",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Figyelmeztetés: Az alkalmazás iOS rendszeren való minimalizálása leállítja az aktiválási folyamatot.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "Minimális rendelési mennyiség:",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "m",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "A minimális eladási összeg {number} {coinName}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "A minimális vásárlási összeg: {number}{coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "A megbízás minimális összege {buyAmount} {buyCoin} ({sellAmount} {sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "Az eladandó minimális összeg {number} {coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "Nagyobbnak kell lennie, mint {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Alacsonyabbnak kell lennie, mint az eladási összeg",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Minimális mennyiség szükséges",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "Egyéni minimális mennyiség használata",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Kérjük, vegye figyelembe, hogy most mobiladatokat használ, és az {appName} P2P-hálózatban való részvétel internetforgalmat fogyaszt. Jobb, ha WiFi hálózatot használsz, ha a mobiladat-előfizetésed drága.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Több információ",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "További",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Aktiválja a {coin} és töltse fel először az egyenlegét",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Összeg",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Érme",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Eladás",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "Cancel",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Megerősítés",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "Create {number} Order(s):",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Létrehozása",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Megrendelés",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Megrendelések",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "díj",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "Cancel",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Kérjük, adja meg az átvenni kívánt fiat összeget:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Autofill",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Kérjük, a folytatás előtt javítson ki minden hibát",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Érvénytelen összeg",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Érvénytelen eladási összeg",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "Nincs elég {coin} a díjak kifizetéséhez. MIN egyenleg {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin} egyenleg túl alacsony",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "Max eladási összeg",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "A minimális vételi összeg",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "Min eladási összeg",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Receive:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Sell:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Multi",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Receive Amt.",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "Ár/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Hálózati díj",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "új számla",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Új Számla",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Hírcsatorna",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Új érték:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "tovább",
+  "@next": {
+    "type": "text"
+  },
+  "no": "Szám",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "Nincsenek hírek - kérjük nézzen vissza később!",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "Nem találtunk érmét",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Nincs alaptőke",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "Alaptőke nem elérhető - kérjük utaljon be.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "Nincs Internet Kapcsolat",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "Nincs kiválasztott tétel",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "Nincs kiválasztott tétel",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "Nem találtak megfelelő rendelést",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Egyik sem",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "Az értéknek numerikusnak kell lennie",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Nem érhető el {coinName} rendelés - próbálja újra később, vagy készítsen egy rendelést.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Kattintson a megrendelés létrehozásához",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "Nincs rendelés, kérem, menjen a kereskedelembe.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "Nincs igényelhető jutalom",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "Nincs igényelhető jutalom - próbálkozzon újra 1 óra múlva.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "Nincs ilyen érme",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "Nincs elözmény.",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "Nincs elég {coin} a tranzakcióhoz!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "Nincs elég egyenlege a jutalékhoz - kereskedjen kisebb mennyiséggel",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Megjegyzés: A párosított rendelés nem törölhető újra.",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Megjegyzés hozzáadása",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Megjegyzés",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Semmi sem található",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "Az {sell}/{buy} swap sikeresen befejeződött.",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "A csere befejeződött",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} csere sikertelen volt",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "A swap sikertelen",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} swap elindult",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Új swap indult",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Swap státusz megváltozott",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} swap időzítve volt",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Swap lejárt",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "Ön {coin} tranzakciót kapott!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Bejövő tranzakció",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "Nincs tranzakció",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} Aktív",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "Hivatalos sajtóközlemény",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Oké",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Törlés",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Régi naplók",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Használt hely",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Hibaüzenet megnyitása",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "Választható",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "Kevésbé",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "Több",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Minden {coin} megrendelés törlésre kerül.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Megrendelés létrehozva",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Megrendelés sikeresen létrehozva",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Cím:",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "Cancel",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "Célszerű: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "Drága: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "a esetében",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "Azonos a CEX-szel",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "min.",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Ár",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Vétel",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Válassza ki a",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Eladja",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Nyissa meg a részleteket egyetlen koppintással, és válassza a Megrendelés hosszú koppintással",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Töltse el a",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Részletek",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% betelt",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Rendelés megegyezett",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Rendelés egyeztetés",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "rendelések",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Aktív",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "Történelem",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "Mennyiség. ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "Ár ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "Összesen ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Megrendelés",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Ismeretlen típusú rendelés",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Felülírás",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "Ez a saját megrendelésed!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Az egyenlegből fizetett:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Kifizetve a kapott mennyiségből:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Fizetetve",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "A jelszónak legalább 12 karaktert kell tartalmaznia, egy kisbetűt, egy nagybetűt és egy speciális szimbólumot.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "A pénztárcája megmutatja a megadott dátum után végrehajtott korábbi tranzakcióit.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Fizetés",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "Elfogadja ezt a tranzakciót?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "Címre",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "Összeg:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Érme:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "Cancel",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Kért fizetés",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} nem aktív. Kérjük, aktiválja és próbálja újra.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Rendelés leadása",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "Játssz teljes hangerőn",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Kérjük, adjon hozzá egy érmét",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Kérjük, indítsa újra az alkalmazást, vagy nyomja meg az alábbi gombot.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Portfolió",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Komodo által működtetett",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "ár",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Privát kulcs",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Privát kulcsok",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Megerősítések",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Egyéni védelmi beállítások használata",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "KI",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "BE",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Figyelmeztetés, ez az atomi csere nem dPoW védett.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Publikációs kulcs",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "QR Code Scanner",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "Tárolja a privát kulcsaimat?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "Mely eszközökön használhatom az {appName}-t?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "Miben különbözik a kereskedés az {appName}-en a más DEX-eken folytatott kereskedéstől?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "Mennyi ideig tart egy-egy atomi swap?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "A csere időtartama alatt online kell lennem?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "Hogyan számítják ki a díjakat az {appName}-nél?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Biztosítanak felhasználói támogatást?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "Vannak országos korlátozások?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "Ki áll az {appName} mögött?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "Lehetséges saját white-label csereprogramot kialakítani az {appName} oldalon?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "Ez egy új korszak! Hivatalosan megváltoztattuk a nevünket „AtomicDEX”-ről „Komodo Wallet”-ra",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "FOGAD",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Fogad",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Azt ajánljuk offline tárolja.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Kikapcsolás",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Kért Trade",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "ÜRES",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Formanyomtatvány visszaállítása",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "VISSZAÁLLÍTÁS",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Az összes érme aktiválásának újbóli próbálkozása...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Az összes érme aktiválásának újbóli próbálkozása",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Igényelje jutalmát",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Megszünteti",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Valami rosszul sült el. Kérjük, próbáld meg később újra.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "A tranzakció folyamatban van",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "feldolgozás",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXO összeg kevesebb, mint 10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Egy óra még nem telt el",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 óra",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "Ok",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Jutalmak állapota:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "További információ a KMD aktív felhasználó jutalmakról",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Kapja meg a címet.",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "Siker! {amount} KMD kapott.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "Utalás",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "Jutalmak,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Állapot",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Maradék idő",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Jutalom információ:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO amt,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} napok",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}h {minutes}m",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}min",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Jutalom információk",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Orosz",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Mentés összevonva",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "A folytatáshoz görgessen lefelé...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Keressen egy érmét",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Válassza ki az összes Avax érmét",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Az összes BEP token kiválasztása",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Válassza ki az összes Cosmos hálózatot",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Válassza ki az összes ERC tokenet",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Az összes ETC token kiválasztása",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Válassza ki az összes FTM tokenet",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Válassza ki az összes HCO tokenet",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Válassza ki az összes HRC tokenet",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Válassza ki az összes Iris hálózatot",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Válassza ki az összes KRC tokenet",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Válassza ki az összes MVR tokenet",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Válassza ki az összes PLG tokenet",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Válassza ki az összes QRC tokenet",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Válassza ki az összes SBCH tokenet",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Válassza ki az összes SLP tokent",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Az összes SmartChains kiválasztása",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Válassza ki az összes teszteszközt",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Az összes Ubiq kiválasztása",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Az összes UTXO kiválasztása",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Válassza ki az összes ZHTLC-érmét",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Keresse meg a Tickert",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Biztonság",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "SEED kifejezés",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Új SEED-ed",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "Kattintson a megtekintéshez {amount} rendelések",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "Tranzakciós előzmények megtekintése",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Válasszon érmét",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Válassza ki az érmét amit hozzá kíván adni a portfóliójához",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Érme aktiválás:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "Válassza ki az érmét amit VÁSÁROLNI szeretne",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "Válassza ki az érmét amit ELADNI szeretne",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Válasszon egy dátumot",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Kiválasztott sorrend:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Fájl kiválasztása",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Nyelv kiválasztása",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Válassza ki a fizetési metódust",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Eladás",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "Figyelmeztetés, Ön hajlandó eladni tesztérméket VALÓDI érték nélkül!",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "KÜLD",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Biztos benne, hogy törölni szeretné",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "pénztárca?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Ha igen, győződjön meg róla",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "rögzítse a SEED-jét.",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "A pénztárca jövőbeli helyreállítása érdekében.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Nyelvek",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Beállítások",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "JELSZÓ BEÁLLÍTÁSA",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "Megosztás",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "Az én {coinName} címem:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "Keresi a múltbeli {coin} tranzakciókat?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Cím megjelenítése",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Részletek megjelenítése",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "{count}/{maxCount} rendelés megjelenítése.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "Mutasd a rendeléseimet",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Jelentkezzen be jelszóval",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "Jelentkezzen be SEED-el",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Egyszerű",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Aktiválja a címet.",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Kérjük, adja meg a {coin} összeget a vásárláshoz",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Vásárlás",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Bezárás",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "A maximális aktív érmék száma {maxCoins}. Kérjük, néhányat deaktiváljon.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} nem aktív!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Fogadja",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Kérjük, adja meg az eladni kívánt {coin} összeget",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Eladni",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Küldje el a",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Kevesebb mutatása",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Többet mutasd meg",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "Nem sikerült aktiválni {coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Kihagyás",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Dissississ",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Hang",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Válasszon egy mp3 vagy wav fájlt, kérem. Akkor fogjuk lejátszani, amikor {description}.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "Lejátsszuk, amikor {description}",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Hangok",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Értettem, többé nem jelenítjük meg",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Hang",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Hangbeállítások",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "A cserefolyamat során és akkor hallható hangjelzés, ha aktív készítői megbízásod van.\nAz atomi swap protokoll megköveteli, hogy a résztvevők online legyenek a sikeres kereskedéshez, és a hangos értesítések segítenek ennek elérésében.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Ne feledje, hogy az alkalmazás beállításaiban beállíthatja az egyéni hangokat.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "Spanyol",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Kezdő dátum",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Indítsa el a Swapot",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Lépés",
+  "@step": {
+    "type": "text"
+  },
+  "success": "Siker!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Támogatás",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Ha bármilyen kérdésed van, vagy úgy gondolod, hogy technikai problémát találtál az {appName} alkalmazással kapcsolatban, akkor jelentheted, és támogatást kaphatsz csapatunktól.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "csere",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Aktuális",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "Erősitse meg a csere részleteit",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "Becslés",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "Csere sikertelen",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Kérjük, először aktiválja {coin} és töltse fel egyenlegét",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "Az {coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "{coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez. {coin} {amount} szükséges.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Csere folyamatban",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "Haladás részletei",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "Elindult",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Csere sikeres",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Összesen",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "Swap UUID",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Switch téma",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Szinkronizálás a megadott dátumtól",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Szinkronizálás a csemete aktiválásából",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Új tranzakciók szinkronizálása",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "Mely {name} tranzakciókat szeretné szinkronizálni?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Átvevő",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Vevő rendelés",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Időtúllépés",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "JELSZÓ LÉTREHOZÁSA",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Kiválasztott sorrend",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "Hova",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "Címzett:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "Van egy",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "eszközöd engedélyezve. Az engedélyezett eszközök maximális korlátja .",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": "Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Túl sok eszköz engedélyezve",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Összes díj:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "KERESKEDÉS",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "Csere végrehajtva!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "KERESKEDÉS részletek",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Nem sikerült kiszámítani a kereskedelmi díjakat",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "kereskedési díj:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Kereskedési mód:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "Tranzakció címe",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "Tranzakció rejtett",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Ez a tranzakció egy lehetséges adathalász kísérlet miatt el lett rejtve.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "Ha még ekkor sem aktiválódik néhány érme, próbálja meg újraindítani az alkalmazást.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Török",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Blokk",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Megerősítések",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "MERŐSÍTVE",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Díj",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "tranzakciós díj:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "Tranzakció azonosítója",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Tranzakciók Balra: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Túl sok a kérés.\n Tranzakciótörténeti kérések száma túllépte a limitet.\n Kérjük, próbálja meg később újra.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "NEM MEGERŐSÍTETT",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Ukrán",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "kinyit",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Alapok feloldása",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "Sikeresen feloldotta a {amnt} pénzeszközöket - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "elkölthetetlen",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Új verzió elérhető",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Frissítések keresése...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "Ön a {version} verziót használja.",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Új verzió elérhető. Kérjük, frissítse.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "A {version} verzió elérhető. Kérjük, frissítse.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Frissítés elérhető",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Egyelőre kihagyás",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "{appName} frissítés",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Frissítés",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Már naprakész",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "Nincs elég egyenleg a beolvasáshoz",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "fizetési kérelem.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Elégtelen egyenleg",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Érték:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "verzió",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Felfedező",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Magánkulcsok és magánkulcsok",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Volumes",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "A pénztárca neve már használatban van",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "A pénztárca neve legfeljebb 40 karakter lehet.",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Csak pénztárca",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "Figyelmeztetés!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Ok",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Figyelmeztetés - különleges esetekben ez a naplóadat érzékeny információkat tartalmaz, amelyek felhasználhatók a sikertelen cserékből származó érmék elköltésére!",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "Nem sikerült aktiválni a {coinAbbr}",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "Nem sikerült aktiválni a {coinAbbr}.\nKérjük, indítsa újra az alkalmazást, hogy újra megpróbálhassa.",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} mobil egy következő generációs többérmés pénztárca natív harmadik generációs DEX funkcióval és még sokkal több",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "KÉSZÍTSÜK FEL!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "Üdvözöljük",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "pénztárca",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "A kitöltés után átirányítjuk a portfólió oldalra.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Ez eltart egy ideig, és az alkalmazást az előtérben kell tartani.\nAz alkalmazás aktiválás közbeni leállítása problémákhoz vezethet.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Kifizetés",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "Ön korábban megtagadta a {appName} hozzáférést a kamerához.\n Kérjük, a QR-kód beolvasásának folytatásához manuálisan módosítsa a kameraengedélyt a telefon beállításaiban.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Hozzáférés megtagadva",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Kiutalás megerősítése",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Valami rosszul sült el. Próbálja meg később újra.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "KIFIZETÉS {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "Ön megpróbál beolvasni egy fizetési QR-kódot a következőhöz",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "de a",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "visszavonási képernyőn van",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Rossz érme",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "A jelszavak nem egyeznek. Próbálja újra.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Igen",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Ön küld:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "van egy új megrendelése, amelyet egy meglévő megrendeléssel próbál összevetni.",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "aktív csere folyamatban van",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "van egy megbízása, amellyel az új megbízások összeilleszthetők.",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "a pénztárcája",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "Kapni fog {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Fog kapni:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -1,3726 +1,5540 @@
 {
-  "@@locale": "hu",
-  "accepteula": "Fogadja el az EULA-t",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Fogadja el a feltételeket és a kondíciókat",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Biometrikus védelem aktiválása",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "PIN védelem aktviálása",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "Aktiválja a {protocolName} érméket?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Kérjük, vegye figyelembe, hogy most mobiladatokat használ, és az {appName} P2P-hálózatban való részvétel internetforgalmat fogyaszt. Jobb, ha WiFi hálózatot használsz, ha a mobiladat-előfizetésed drága.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Hozzáférés megtagadva",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "Ön korábban megtagadta a {appName} hozzáférést a kamerához.\n Kérjük, a QR-kód beolvasásának folytatásához manuálisan módosítsa a kameraengedélyt a telefon beállításaiban.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "Üdvözöljük",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "pénztárca",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} mobil egy következő generációs többérmés pénztárca natív harmadik generációs DEX funkcióval és még sokkal több",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "KÉSZÍTSÜK FEL!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "{appName} frissítés",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "Ön a {version} verziót használja.",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Frissítések keresése...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Már naprakész",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Új verzió elérhető",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Frissítés",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Egyelőre kihagyás",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Frissítés elérhető",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Új verzió elérhető. Kérjük, frissítse.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "A {version} verzió elérhető. Kérjük, frissítse.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Segítség",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Segítség és támogatás",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Gyakran ismételt kérdések",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Támogatás",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Ha bármilyen kérdésed van, vagy úgy gondolod, hogy technikai problémát találtál az {appName} alkalmazással kapcsolatban, akkor jelentheted, és támogatást kaphatsz csapatunktól.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "Tárolja a privát kulcsaimat?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "Nem! Az {appName} nem felügyeleti joggal rendelkezik. Soha nem tárolunk semmilyen érzékeny adatot, beleértve az Ön privát kulcsait, magvas kifejezéseit vagy PIN-kódját. Ezeket az adatokat csak a felhasználó készülékén tároljuk, és soha nem hagyják el azt. Ön teljes mértékben ura az eszközeinek.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "Miben különbözik a kereskedés az {appName}-en a más DEX-eken folytatott kereskedéstől?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Más DEX-ek általában csak olyan eszközökkel lehet kereskedni, amelyek egyetlen blokklánc-hálózaton alapulnak, proxy tokeneket használnak, és csak egyetlen megbízás leadását teszik lehetővé ugyanazokkal az eszközökkel.\n\nAz {appName} lehetővé teszi, hogy natívan, proxy tokenek nélkül kereskedhessen két különböző blokklánc hálózaton. Több megbízást is adhat ugyanazokkal az alapokkal. Például 0,1 BTC-t adhatsz el KMD, QTUM vagy VRSC ellenében - az első teljesített megbízás automatikusan törli az összes többi megbízást.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "Mennyi ideig tart egy-egy atomi swap?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Az egyes swapok feldolgozási idejét több tényező határozza meg. A kereskedett eszközök blokkolási ideje az egyes hálózatoktól függ (a Bitcoin jellemzően a leglassabb) Ezen kívül a felhasználó testre szabhatja a biztonsági beállításokat. Például kérheti az {appName}-t, hogy egy KMD tranzakciót már 3 megerősítés után véglegesnek tekintsen, ami rövidebbé teszi a csereidőt, mintha <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">jegyesítésre</a> kellene várni.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "A csere időtartama alatt online kell lennem?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Igen. Az egyes atomi cserék sikeres végrehajtásához továbbra is kapcsolódnia kell az internethez, és az alkalmazásnak futnia kell (a kapcsolat nagyon rövid megszakításai általában rendben vannak). Ellenkező esetben fennáll a kereskedés törlésének kockázata, ha Ön a döntéshozó, és a pénzeszközök elvesztésének kockázata, ha Ön a vevő. Az atomi swap protokoll megköveteli, hogy mindkét résztvevő online maradjon és figyelje az érintett blokkláncokat, hogy a folyamat atomi maradjon.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "Hogyan számítják ki a díjakat az {appName}-nél?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "Két díjkategóriát kell figyelembe venni a {appName}-on történő kereskedés során.\n\n 1. Az {appName} körülbelül 0,13%-ot (a kereskedési volumen 1/777-ét, de nem kevesebb, mint 0,0001) számít fel kereskedési díjként a taker megbízásokért, a maker megbízásoknak pedig nulla a díja.\n\n 2. Mind a makereknek, mind a takeereknek normál hálózati díjakat kell fizetniük az érintett blokkláncoknak, amikor atomi swap tranzakciókat hajtanak végre.\n\n A hálózati díjak a kiválasztott kereskedési párostól függően nagymértékben eltérhetnek.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "Biztosítanak felhasználói támogatást?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "Igen! A {appName} támogatást nyújt az <a href=\"{link}\">{appCompanyShort} {name}</a>-n keresztül. A csapat és a közösség mindig szívesen segít!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "Vannak országos korlátozások?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "Nem! Az {appName} teljesen decentralizált. Nem lehetséges a felhasználók hozzáférését harmadik fél által korlátozni.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "Ki áll az {appName} mögött?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "Az {appName}-t az {appCompanyShort} csapata fejleszti. Az {appCompanyShort} az egyik legelismertebb blokkláncprojekt, amely olyan innovatív megoldásokon dolgozik, mint az atomic swap, a Delayed Proof of Work és az interoperábilis multi-chain architektúra.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "Lehetséges saját white-label csereprogramot kialakítani az {appName} oldalon?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "Teljesen! További részletekért olvassa el <a href=\"https://developers.komodoplatform.com/\">fejlesztői dokumentációnkat</a>, vagy forduljon hozzánk partnerségi kérdéseivel. Konkrét technikai kérdése van? A {appName} fejlesztői közössége mindig készen áll a segítségére!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "Mely eszközökön használhatom az {appName}-t?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "Az {appName} mobilra Androidon és iPhone-on, asztali számítógépen pedig <a href=\"https://komodoplatform.com/\">Windows, Mac és Linux operációs rendszeren</a> érhető el.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Feed",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Hírek",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Bővebben...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Itt nincs semmi",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Hírfolyam frissítve",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Dissississ",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Hírek",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Időtartam",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "Nem lehetséges a hírfrissítés",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "Nem folytatható a hírfrissítés",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Már naprakész",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Dátum",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} hírek",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "PIN kód létrehozása",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "Adja meg a PIN kódját",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "belépés",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "új számla",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Új Számla",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} sikeresen aktiválva !",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Csatlakozás...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Aktív érme",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} Aktív",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Adja meg a Seed-jét",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Például: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "Megerősít",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "Figyelmeztetés, Ön hajlandó teszt érméket vásárolni NÉLKÜL valós értéket!",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "Az akkumulátor töltöttsége kritikus ({batteryLevelCritical}%) a biztonságos cseréhez. Kérjük, töltse fel, és próbálja meg újra.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "Az akkumulátor töltöttsége alacsonyabb, mint {batteryLevelLow}%. Kérjük, fontolja meg a telefon töltését.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "A telefon akkumulátor-takarékos üzemmódban van. Kérjük, kapcsolja ki ezt az üzemmódot, vagy NE tegye az alkalmazást a háttérbe, különben az alkalmazást az operációs rendszer megölheti, és a csere sikertelen lesz.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "Figyelmeztetés, Ön hajlandó eladni tesztérméket VALÓDI érték nélkül!",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Vétel",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Eladás",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "Az én {coinName} címem:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Kifizetés",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "Az érték túl magas vagy alacsony",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Összeg",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Címzett címe",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "KIFIZETÉS {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Kiutalás megerősítése",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Valami rosszul sült el. Próbálja meg később újra.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Bezár",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "SEED megerősítése",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Új SEED-ed",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Fontos: Mentse el a SEED-jét mielött tovább haladnánk!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Azt ajánljuk offline tárolja.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "tovább",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "PIN kód megerősítése",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Álcázási PIN beállítása",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Álcázási PIN megerősítése",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Hiba, kérem próbálja újra",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Beállítások",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Biztonság",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "PIN védelem aktviálása",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Képernyőképek/Előnézet letiltása",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "Képernyő lezárva",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "PIN módosítása",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Kijelentkezés",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "MAX",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "MIN",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Összes díj:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Az egyenlegből fizetett:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Kereskedési mód:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Kihagyás",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Egyesítés",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Felülírás",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Jelenlegi érték:",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Új érték:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Összevont érték:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Mentés összevonva",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "Már létezik",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Egyszerű",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Haladó",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Kifizetve a kapott mennyiségből:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Eladandó összeg",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Fog kapni:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "Válassza ki az érmét amit ELADNI szeretne",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "Válassza ki az érmét amit VÁSÁROLNI szeretne",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "csere",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Csere kiadva, kérjük várjon!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "A rendelés egyeztetése folyamatban van, kérjük várjon {seconde} másodperceket!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Hálózati díj",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "Jutalék díj",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Portfolió",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Kifizetés",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Becsült Teljes Érték",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Válassza ki a fizetési metódust",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Volumes",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Rendelés leadása",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "Hamarosan...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Piactér",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Ön küld:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Kód:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Érték:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Fizetetve",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "Kérjük adjon meg adatokat",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "Nincs elég egyenleg",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "A Gwei értékének legfeljebb {value} értéknek kell lennie",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "A díjak legfeljebb {value}",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "A korlát legfeljebb {value} lehet",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "Hiba! Helytelen / nem valós cím!",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "A Segwit címek (még) nem támogatottak",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "Címzett:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "FOGAD",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "KÜLD",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Publikációs kulcs",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "vissza",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "visszamond",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "részletek",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Igen",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "Szám",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Megjegyzés: A párosított rendelés nem törölhető újra.",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "Ne kérdezze újra",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Megrendelés visszavonása",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "Biztos, hogy törölni szeretné a rendelést",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "elkölthetetlen",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "Tranzakció részletek hamarosan!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "előzmények",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "Kereskedelem",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "A részletek hamarosan megjelennek!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Rendelés egyeztetés",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Rendelés megegyezett",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Csere folyamatban",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Csere sikeres",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Időtúllépés",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Megváltoztatni",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "Csere sikertelen",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Hiba, kérjük próbálja újra",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Legutóbbi tranzakciók",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "A tranzakció lebonyolítása, kérjük, várjon",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Befejezés, kérem várjon",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Visszajelzés küldése",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Rendelési könyv betöltése...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "Igényel",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "Igényelje meg KMD jutalmát?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "Siker!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "Nincs igényelhető jutalom - próbálkozzon újra 1 óra múlva.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Betöltés...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Tranzakciók Balra: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} az egyenleg nem elegendő a kereskedési díj kifizetéséhez",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Hírek",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Hírcsatorna",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "Vágólapra másolva",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "Honnan",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "Hova",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "MERŐSÍTVE",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "NEM MEGERŐSÍTETT",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Blokk",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Megerősítések",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Díj",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "Tranzakció azonosítója",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Memo",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "Nincs elözmény.",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "KERESKEDÉS",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "ÜRES",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Formanyomtatvány visszaállítása",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "Csere végrehajtva!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Lépés",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "KERESKEDÉS részletek",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Kért Trade",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "Swap UUID",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "BÖNGÉSZÉS",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "MENTVE",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "Továbbra is engedélyezheti a következőt: {remains}, Kijelölve: {selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "Nincsenek mentett cikkeid",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "BÖNGÉSZŐ FEED",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "Által",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "Kérjük hitelesítse!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "Nincs tranzakció",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Kész",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Érme aktiválás:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Válassza ki az érmét amit hozzá kíván adni a portfóliójához",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "Nincsenek hírek - kérjük nézzen vissza később!",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "A megkezdett cserét visszavonni nem lehet, ez végleges!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "Ez a tranzakció akár 10 percet is igénybe vehet - NE zárja be ezt az alkalmazást!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "Erősitse meg a csere részleteit",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Minimális mennyiség szükséges",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "Egyéni minimális mennyiség használata",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "Az értéknek numerikusnak kell lennie",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Alacsonyabbnak kell lennie, mint az eladási összeg",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "Nagyobbnak kell lennie, mint {minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "ellenőrizze a SEED-jét",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "DUPLÁN ellenőrizze a SEED-jét",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "A SEED-ed fontos - ezért szeretnénk ellenőrizni, hogy helyes-e. Három különféle kérdést fogunk feltenni a SEED-el kapcsolatban, hogy megbizonyosodjon arról, hogy bármikor könnyedén visszaállíthatja a pénztárcáját.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "Mi a {index}. szó a SEED-ben?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "Írja be a {index}. szót",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "FOLYTATÁS",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "Lépjen vissza és ellenőrizze ismét",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Felfedező",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Biometrikus védelem aktiválása",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Egyedi SEED engedélyezése",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "Figyelmeztetés!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "Értem",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Az egyéni magvas kifejezések kevésbé biztonságosak és könnyebben feltörhetők, mint egy generált, BIP39 szabványnak megfelelő magvas kifejezés vagy magánkulcs (WIF). Annak megerősítéséhez, hogy tisztában van a kockázattal és tudja, mit csinál, írja be az alábbi mezőbe a \"{iUnderstand}\" szöveget.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Írja be a jelszavát",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "a pénztárcája",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "Jelentkezzen be SEED-el",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Jelentkezzen be jelszóval",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Írja be a SEED-jét",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "A jelszavak nem egyeznek. Próbálja újra.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Pénztárcád neve",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Dönthet úgy is, hogy jelszóval titkosítja a pénztárcáját. Ha úgy dönt, hogy nem használ jelszót, akkor minden alkalommal meg kell adnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Jelszó megerősítése",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "Nem akarok jelszót",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "BIZTOS?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Ha nem ad meg jelszót, akkor minden alkalommal be kell írnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "JELSZÓ BEÁLLÍTÁSA",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "PÉNZTÁRCA LÉTREHOZÁSA",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "VISSZAÁLLÍTÁS",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Jelszó",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "A jelszónak legalább 12 karaktert kell tartalmaznia, egy kisbetűt, egy nagybetűt és egy speciális szimbólumot.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Jelszó létrehozása",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Jelszó megerősítése",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Jelenlegi jelszó",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Kijelentkezés beállításai",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Kijelentkezés kilépéskor",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Pénztárca törlése",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Törlés",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Biztos benne, hogy törölni szeretné",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "pénztárca?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Ha igen, győződjön meg róla",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "rögzítse a SEED-jét.",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "A pénztárca jövőbeli helyreállítása érdekében.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Mentés",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "verzió",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Magánkulcsok és magánkulcsok",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "SEED kifejezés",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Privát kulcsok",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Privát kulcs",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Kérjük, írja be a jelszavát a folytatáshoz.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "Vágólapra másolva",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "kinyit",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "Sikeresen feloldotta a {amnt} pénzeszközöket - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Alapok feloldása",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "Nincs rendelés, kérem, menjen a kereskedelembe.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Nem érhető el {coinName} rendelés - próbálja újra később, vagy készítsen egy rendelést.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "A rendelkezésrre álló legjobb ár",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Fogad",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "Rendelés készítése",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "KERESKEDŐOLDAL",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "rendelések",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Válasszon érmét",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗Vigyázat! A(z) {coinName} piacán kevesebb, mint 10 000 USD 24 órás kereskedési volumen van!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Nyelv kiválasztása",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Nincs alaptőke",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "Alaptőke nem elérhető - kérjük utaljon be.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Ugrás a portfólióhoz",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Kattintson a megrendelés létrehozásához",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Elégtelen mennyiség",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "A megbízáshoz szükséges minimális mennyiség",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Megrendelés létrehozva",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Megrendelés sikeresen létrehozva",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "Mutasd a rendeléseimet",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "A minimális eladási összeg {number} {coinName}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "JELSZÓ LÉTREHOZÁSA",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "A minimális vásárlási összeg: {number}{coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "Az eladandó minimális összeg {number} {coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "A megbízás minimális összege {buyAmount} {buyCoin} ({sellAmount} {sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Először az Eladási összeget kell megadnia",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Pénztárca titkosítása",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Pénztárca dekódolása",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "Nincs elég egyenlege a jutalékhoz - kereskedjen kisebb mennyiséggel",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "Nincs Internet Kapcsolat",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Komodo rendszerrel fejlesztve",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Kérjük, adjon hozzá egy érmét",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "Internet kapcsolat helyreállt",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Frissítés",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Jogi",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Felelősségi nyilatkozat & használati feltételek",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "Fogadja el az EULA-t",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "Fogadja el a feltételeket és a kondíciókat",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "Az alábbi gombokra kattintva megerősítheti, hogy elolvasta a „EULA” és a „Általános Szerződési Feltételeket”, és elfogadja ezeket",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} díj",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "Nincs elég {coin} a tranzakcióhoz!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Kérjük, aktiválja {coin}.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "Kapni fog {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "Kattintson a megtekintéshez {amount} rendelések",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Kattintson a megtekintéshez",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "ár",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "max vol",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "A pénztárca konfigurálása, kérjük várjon...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Kiválasztott sorrend",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "tranzakciós díj:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "kereskedési díj:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "Az {coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "{coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez. {coin} {amount} szükséges.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "Nem lehet folytatni a swapot",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Részletek megjelenítése",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Árfolyam:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Kiválasztott sorrend:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "Minimális rendelési mennyiség:",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Maximális rendelési mennyiség:",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Részletek",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Kérjük, először aktiválja {coin} és töltse fel egyenlegét",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Nem sikerült kiszámítani a kereskedelmi díjakat",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Kikapcsolás",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Csak pénztárca",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "A tárca neve nem lehet üres",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "A pénztárca neve legfeljebb 40 karakter lehet.",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "A pénztárca neve már használatban van",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX nem elérhető ehhez az érméhez",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Keressen egy érmét",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Az összes SmartChains kiválasztása",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Válassza ki az összes teszteszközt",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Válassza ki az összes ERC tokenet",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Válassza ki az összes SLP tokent",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Válassza ki az összes Cosmos hálózatot",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Válassza ki az összes Iris hálózatot",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Válassza ki az összes KRC tokenet",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Válassza ki az összes HRC tokenet",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Az összes ETC token kiválasztása",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Válassza ki az összes SBCH tokenet",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Válassza ki az összes Avax érmét",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Az összes Ubiq kiválasztása",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Az összes BEP token kiválasztása",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Válassza ki az összes PLG tokenet",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Válassza ki az összes QRC tokenet",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Válassza ki az összes HCO tokenet",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Válassza ki az összes ZHTLC-érmét",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Válassza ki az összes FTM tokenet",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Válassza ki az összes MVR tokenet",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Egyedi díj",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "Benzin limit",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "Gáz ára",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "Csak akkor használjon egyéni díjakat, ha tudja, mit csinál!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Az összes UTXO kiválasztása",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Komodo rendszerrel fejlesztve",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Komodo által működtetett",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "Nincs elég gáz - használjon minimum {gas} Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Minden {coin} megrendelés törlésre kerül.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Hatályon kívül helyezés megerősítése",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "El akarja távolítani",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "a portfóliójából? Minden nem egyező megbízás törlésre kerül.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " is deaktiválva lesz",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "Nem lehet letiltani",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "egy alapértelmezett érme. Az alapértelmezett érméket nem lehet letiltani.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ok",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "Megosztás",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Figyelmeztetés - különleges esetekben ez a naplóadat érzékeny információkat tartalmaz, amelyek felhasználhatók a sikertelen cserékből származó érmék elköltésére!",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Adja meg régi PIN kódját",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Adja meg új PIN-kódját",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "hitelesítse a",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Nyelvek",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "Angol",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Francia",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Német",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Kínai",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Orosz",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Japán",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Török",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Magyar",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "Spanyol",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Koreai",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Ukrán",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "FAUCET",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Siker",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Hiba",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "A kérés lejárt",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "Kérelem küldése a {coin} csaptelephez...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "Választható",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Hang",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "Játssz teljes hangerőn",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Átvevő",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "van egy új megrendelése, amelyet egy meglévő megrendeléssel próbál összevetni.",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Készítő",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "van egy megbízása, amellyel az új megbízások összeilleszthetők.",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Aktív",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "aktív csere folyamatban van",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Sikertelen",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "a csere meghiúsul",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Taps",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "a csere befejeződik",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "Ezt nem lehet lejátszani",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Válasszon egy mp3 vagy wav fájlt, kérem. Akkor fogjuk lejátszani, amikor {description}.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "Lejátsszuk, amikor {description}",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Hangok",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "A cserefolyamat során és akkor hallható hangjelzés, ha aktív készítői megbízásod van.\nAz atomi swap protokoll megköveteli, hogy a résztvevők online legyenek a sikeres kereskedéshez, és a hangos értesítések segítenek ennek elérésében.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Ne feledje, hogy az alkalmazás beállításaiban beállíthatja az egyéni hangokat.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Értettem, többé nem jelenítjük meg",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Hangbeállítások",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Hang",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Piacok",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "MARKETS",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "ÁRA",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "MEGRENDELÉS KÖNYV",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "Diagram",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Mélység",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Ár",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Eladja",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "a esetében",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "min.",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Cím:",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "Célszerű: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "Drága: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "Azonos a CEX-szel",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Vétel",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Töltse el a",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "Ez a saját megrendelésed!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Kérjük, válasszon érméket",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Érme kiválasztása",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "Nincsenek aktív érmék",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Tiszta",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "Ár ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "Mennyiség. ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "Összesen ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "Nem találtak ajánlatot",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "Nem találtunk kéréseket",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Megrendelés részletei",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Valami rosszul sült el. Próbálja meg később újra.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Jutalom információk",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "További információ a KMD aktív felhasználó jutalmakról",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Megszünteti",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Kapja meg a címet.",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "Nincs igényelhető jutalom",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Jutalom információ:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO amt,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "Jutalmak,\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "Utalás",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Maradék idő",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Állapot",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Jutalmak állapota:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "Ok",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} napok",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}h {minutes}m",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}min",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "Siker! {amount} KMD kapott.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Valami rosszul sült el. Kérjük, próbáld meg később újra.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXO összeg kevesebb, mint 10 KMD",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "feldolgozás",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "A tranzakció folyamatban van",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 óra",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Egy óra még nem telt el",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Igényelje jutalmát",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "Tranzakciós előzmények megtekintése",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Az összes érme aktiválásának újbóli próbálkozása...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "A kitöltés után átirányítjuk a portfólió oldalra.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "Ha még ekkor sem aktiválódik néhány érme, próbálja meg újraindítani az alkalmazást.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "Nem sikerült aktiválni a {coinAbbr}",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Kérjük, indítsa újra az alkalmazást, vagy nyomja meg az alábbi gombot.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Az összes érme aktiválásának újbóli próbálkozása",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Az újbóli aktiválási folyamat befejeztével automatikusan átirányítjuk a portfólió oldalra.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "Nem sikerült aktiválni a {coinAbbr}.\nKérjük, indítsa újra az alkalmazást, hogy újra megpróbálhassa.",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} nem elérhető :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Multi",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Kérjük, a folytatás előtt javítson ki minden hibát",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Létrehozása",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Megrendelés",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Megrendelések",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Érme",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Sell:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Eladás",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Összeg",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Receive:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "Ár/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Receive Amt.",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Kérjük, adja meg az átvenni kívánt fiat összeget:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "Cancel",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Autofill",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "díj",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "Nincs elég {coin} a díjak kifizetéséhez. MIN egyenleg {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "Create {number} Order(s):",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "Cancel",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Megerősítés",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Érvénytelen eladási összeg",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "Max eladási összeg",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "Min eladási összeg",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Érvénytelen összeg",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "Érvénytelen {coin} cím",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "Aktiválja a {coin} és töltse fel először az egyenlegét",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin} egyenleg túl alacsony",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "A minimális vételi összeg",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Címjegyzék",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Címjegyzék",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Kapcsolattartási adatok",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "A címjegyzék üres",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Csak a {title} címekkel rendelkező kapcsolatok megjelenítése",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Kapcsolat létrehozása",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "Név",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Kapcsolat szerkesztése",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "Megszüntetés",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Mentés",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Elutasítás",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Kilépés",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Elveti a módosításokat?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Cím hozzáadása",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Válassza ki az érmét",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Keresse meg a Tickert",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Kapcsolat törlése",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "Biztos vagy benne, hogy törölni akarod a {name} kontaktot?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "törlése",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "Nem találtam kapcsolatot",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Szerkesztés",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Semmi sem található",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "Nincs ilyen érme",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "Nem tud pénzt küldeni a {abbr} címre, mert a {abbr} nincs aktiválva. Kérjük, menjen a portfólióhoz.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Ok",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "Kapcsolattartó neve nem lehet üres",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "Bemenet {abbr} cím",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Álcázó PIN-kód",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Álcázó PIN-kód",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "Be",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Off",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "Érvénytelen PIN-kód",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Váltás",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Ha az álcázó PIN kóddal nyitod fel az alkalmazást, egy hamis alacsony egyenleg fog megjelenni, és az álzácási PIN konfigurációs opció NEM lesz látható a beállításokban.",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Az általános PIN-kód és az álcázó PIN-kód ugyanaz.\n Az álcázó üzemmód nem lesz elérhető.\n Kérjük, változtassa meg a álcázó PIN-kódot.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "Az álcázó PIN és a Bio védelem nem engedélyezhető egyszerre.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Az álcázó PIN és a bio védelem konfliktusban van egymással.",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "Az általános PIN-védelem nem aktív.\n Az álcázási mód nem lesz elérhető.\n Kérjük, aktiválja a PIN-védelmet.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Hamis egyenleg összege:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "Az álcázási PIN-kód nem található",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Álcázó PIN létrehozása",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "Álcázási PIN mentve",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "Érvénytelen álcázási PIN-kód",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Álcázó PIN megváltoztatása",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Álcázási PIN beállítása",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Új álcázási PIN megadása",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "BE",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "KI",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Megerősítések",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo dPoW biztonság",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Egyéni védelmi beállítások használata",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Figyelmeztetés, ez az atomi csere nem dPoW védett.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "Átalakítás vevővé, ha nem egyezik",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEX árfolyam",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Célszerű",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Drága",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "Azonos a CEX-szel",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "a CEX-hez képest",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "átlaghoz képest 24 órás CEX ár",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Aktív",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "Történelem",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Részletek",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Nyissa meg a részleteket egyetlen koppintással, és válassza a Megrendelés hosszú koppintással",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "Cancel",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Válassza ki a",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "Nem találtak megfelelő rendelést",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Maker megbízás",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Vevő rendelés",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Aktuális",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "Becslés",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "Elindult",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Összesen",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "Haladás részletei",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Hibaüzenet bezárása",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Hibaüzenet megnyitása",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Bejövő tranzakció",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "Ön {coin} tranzakciót kapott!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "A csere befejeződött",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "Az {sell}/{buy} swap sikeresen befejeződött.",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "A swap sikertelen",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} csere sikertelen volt",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Swap lejárt",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} swap időzítve volt",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Swap státusz megváltozott",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Új swap indult",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} swap elindult",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Nyelv",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Pénznem",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Egyenlegek elrejtése",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Switch téma",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "CEX adatok",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Az ezzel az ikonnal jelölt piaci adatok (árak, grafikonok stb.) harmadik féltől származó forrásokból származnak (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Frissítések ellenőrzése",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "Biztos, hogy most már ki akarsz jelentkezni?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Pénznem",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Túl sok a kérés.\n Tranzakciótörténeti kérések száma túllépte a limitet.\n Kérjük, próbálja meg később újra.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "ezredmásodperc",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "m",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "percek",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "ó",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "További",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "Kevesebb",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Régi naplók",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Törlés",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Pénztárca törlése...",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Használt hely",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Oké",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Előnézet bezárása",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "Visszavonás",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "A folytatáshoz görgessen lefelé...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Fejlesztő",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Tesztérmék engedélyezése",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Maker megbízás részletei",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Eladni",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Megkapja",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Ár",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Megrendelés törlése",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "Megrendelés azonosítója",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "Létrehozva",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Ez a megbízás nem indított swapot",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "A megbízás által indított swapok",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% betelt",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Megjegyzés",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Megjegyzés hozzáadása",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "Importálás",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Egyetlen swap importálása",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Exportálás",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "Importálás",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Swap importálása",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Exportálás",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Kérjük, válassza ki a titkosított fájlba exportálandó elemeket.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Kérjük, válasszon titkosított fájlt az importáláshoz.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Kérjük, válasszon egyszerű szöveges swapfájlt az importáláshoz.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Megnyitás...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "Importálandó tételek:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Jegyzetek",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Kapcsolatok",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Cserék",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Semmi sem található",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Exportálás",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "Import",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "A titkosítási jelszó nem lehet üres",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "A jelszó nem lehet üres",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "A jelszavaknak meg kell egyezniük",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "Nincs kiválasztott tétel",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "Nincs kiválasztott tétel",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Fájl kiválasztása",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Fájl nem található",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Ujjlenyomat",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Jelszó",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "Megszakítás",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Ok",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "A tételek exportálása sikeresen megtörtént:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "A tételek importálása sikeresen megtörtént:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Érvénytelen jelszó vagy sérült adatok",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Hiba a json fájl dekódolásában",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Megrendelés",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Ismeretlen típusú rendelés",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "Nem sikerült importálni:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Néhány elemet kihagytunk",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "Nem sikerült a swap importálása",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Érvénytelen csereadatok. Kérjük, adjon meg egy érvényes swap-státusz JSON fájlt.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "{coinName} aktiválása",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "Ne zárja be az alkalmazást. További információért koppintson...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName} Aktiválás",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "{protocolName} érme aktiválva van",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "A(z) {protocolName} érmék nincsenek aktiválva",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName} érme sikeresen aktiválva",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} Aktiválás folyamatban",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "Aktiválja a {protocolName} érméket?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Több információ",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Cím megjelenítése",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Ez a tranzakció egy lehetséges adathalász kísérlet miatt el lett rejtve.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "Tranzakció címe",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "Tranzakció rejtett",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "Nem sikerült elindítani az URL-t",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Ez eltart egy ideig, és az alkalmazást az előtérben kell tartani.\nAz alkalmazás aktiválás közbeni leállítása problémákhoz vezethet.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Figyelmeztetés: Az alkalmazás iOS rendszeren való minimalizálása leállítja az aktiválási folyamatot.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Kérjük, engedélyezze az értesítéseket, hogy értesüljön az aktiválás folyamatáról.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "QR Code Scanner",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "Talált QR kódot",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Szerződés",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Indítsa el a Swapot",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Egyik sem",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "CEX árfolyam",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Bejövő {coinName} txs-védelmi beállítások",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "{count}/{maxCount} rendelés megjelenítése.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "Kevésbé",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "Több",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "{coinName1}/{coinName2} alapján",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "kereskedési díj tranzakciós díj küldése",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "kereskedési díj",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "küldje el a {coinName} tranzakciós díjat",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "megkapja a {coinName} tranzakciós díjat",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Szűrő",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Státusz",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Minden",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Sikeres",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Sikertelen",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "Dátumtól",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "Eddig",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Vevő/szerző",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Gyártó",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "Minden",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Átvevő",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Érme eladása",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Érmét kapott érme",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Összes szűrő törlése",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Elégtelen egyenleg",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "Nincs elég egyenleg a beolvasáshoz",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "fizetési kérelem.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Túl sok eszközt próbál engedélyezni",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "Ön rendelkezik",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "eszközök engedélyezve, és megpróbálja engedélyezni",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "többet. Az engedélyezett eszközök maximális korlátja",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": ". Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Kiválasztotta az eszközök maximális számát",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Túl sok eszköz engedélyezve",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "Van egy",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "eszközöd engedélyezve. Az engedélyezett eszközök maximális korlátja .",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": "Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Kért fizetés",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Érme:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "Címre",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "Összeg:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "Elfogadja ezt a tranzakciót?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Fizetés",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "Cancel",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} nem aktív. Kérjük, aktiválja és próbálja újra.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Rossz érme",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "Ön megpróbál beolvasni egy fizetési QR-kódot a következőhöz",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "de a",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "visszavonási képernyőn van",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Eladni",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Vásárlás",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Fogadja",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Küldje el a",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Bezárás",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Aktiválja a címet.",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "A maximális aktív érmék száma {maxCoins}. Kérjük, néhányat deaktiváljon.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "Nem sikerült aktiválni {coin}",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} nem aktív!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Kérjük, adja meg a {coin} összeget a vásárláshoz",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Kérjük, adja meg az eladni kívánt {coin} összeget",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Kevesebb mutatása",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Többet mutasd meg",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "Nem találtunk érmét",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "Ez egy új korszak! Hivatalosan megváltoztattuk a nevünket „AtomicDEX”-ről „Komodo Wallet”-ra",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "Hivatalos sajtóközlemény",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "Keresi a múltbeli {coin} tranzakciókat?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "Aktiválás megszakítása",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "Biztosan megszakítja az aktiválást?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "Biztosan megszakítja az aktiválást?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "Mely {name} tranzakciókat szeretné szinkronizálni?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "Új tranzakciók szinkronizálása",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Szinkronizálás a megadott dátumtól",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Szinkronizálás a csemete aktiválásából",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Válasszon egy dátumot",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Kezdő dátum",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "A jövőbeni tranzakciókat szinkronizálni fogjuk a nyilvános kulcsához társított aktiválás után. Ez a leggyorsabb lehetőség, és a legkevesebb tárhelyet foglalja el.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "A pénztárcája minden korábbi tranzakciót mutat. Ez jelentős tárhelyet és időt vesz igénybe, mivel az összes blokkot letölti és átvizsgálja.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "A pénztárcája megmutatja a megadott dátum után végrehajtott korábbi tranzakcióit.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "{coinName} aktiválása",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} Aktiválás",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} Aktiválás folyamatban",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Aktív",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Aktív érme",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} sikeresen aktiválva !",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Cím hozzáadása",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Címjegyzék",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "A címjegyzék üres",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Csak a {title} címekkel rendelkező kapcsolatok megjelenítése",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Címjegyzék",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "Nem tud pénzt küldeni a {abbr} címre, mert a {abbr} nincs aktiválva. Kérjük, menjen a portfólióhoz.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Semmi sem található",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Válassza ki az érmét",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Címzett címe",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Haladó",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "Minden",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Egyedi SEED engedélyezése",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "A pénztárcája minden korábbi tranzakciót mutat. Ez jelentős tárhelyet és időt vesz igénybe, mivel az összes blokkot letölti és átvizsgálja.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "Már létezik",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Összeg",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Eladandó összeg",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "Nem! Az {appName} nem felügyeleti joggal rendelkezik. Soha nem tárolunk semmilyen érzékeny adatot, beleértve az Ön privát kulcsait, magvas kifejezéseit vagy PIN-kódját. Ezeket az adatokat csak a felhasználó készülékén tároljuk, és soha nem hagyják el azt. Ön teljes mértékben ura az eszközeinek.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "Az {appName} mobilra Androidon és iPhone-on, asztali számítógépen pedig <a href=\"https://komodoplatform.com/\">Windows, Mac és Linux operációs rendszeren</a> érhető el.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Más DEX-ek általában csak olyan eszközökkel lehet kereskedni, amelyek egyetlen blokklánc-hálózaton alapulnak, proxy tokeneket használnak, és csak egyetlen megbízás leadását teszik lehetővé ugyanazokkal az eszközökkel.\n\nAz {appName} lehetővé teszi, hogy natívan, proxy tokenek nélkül kereskedhessen két különböző blokklánc hálózaton. Több megbízást is adhat ugyanazokkal az alapokkal. Például 0,1 BTC-t adhatsz el KMD, QTUM vagy VRSC ellenében - az első teljesített megbízás automatikusan törli az összes többi megbízást.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Az egyes swapok feldolgozási idejét több tényező határozza meg. A kereskedett eszközök blokkolási ideje az egyes hálózatoktól függ (a Bitcoin jellemzően a leglassabb) Ezen kívül a felhasználó testre szabhatja a biztonsági beállításokat. Például kérheti az {appName}-t, hogy egy KMD tranzakciót már 3 megerősítés után véglegesnek tekintsen, ami rövidebbé teszi a csereidőt, mintha <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">jegyesítésre</a> kellene várni.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Igen. Az egyes atomi cserék sikeres végrehajtásához továbbra is kapcsolódnia kell az internethez, és az alkalmazásnak futnia kell (a kapcsolat nagyon rövid megszakításai általában rendben vannak). Ellenkező esetben fennáll a kereskedés törlésének kockázata, ha Ön a döntéshozó, és a pénzeszközök elvesztésének kockázata, ha Ön a vevő. Az atomi swap protokoll megköveteli, hogy mindkét résztvevő online maradjon és figyelje az érintett blokkláncokat, hogy a folyamat atomi maradjon.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "Két díjkategóriát kell figyelembe venni a {appName}-on történő kereskedés során.\n\n 1. Az {appName} körülbelül 0,13%-ot (a kereskedési volumen 1/777-ét, de nem kevesebb, mint 0,0001) számít fel kereskedési díjként a taker megbízásokért, a maker megbízásoknak pedig nulla a díja.\n\n 2. Mind a makereknek, mind a takeereknek normál hálózati díjakat kell fizetniük az érintett blokkláncoknak, amikor atomi swap tranzakciókat hajtanak végre.\n\n A hálózati díjak a kiválasztott kereskedési párostól függően nagymértékben eltérhetnek.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "Igen! A {appName} támogatást nyújt az <a href=\"{link}\">{appCompanyShort} {name}</a>-n keresztül. A csapat és a közösség mindig szívesen segít!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "Nem! Az {appName} teljesen decentralizált. Nem lehetséges a felhasználók hozzáférését harmadik fél által korlátozni.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "Az {appName}-t az {appCompanyShort} csapata fejleszti. Az {appCompanyShort} az egyik legelismertebb blokkláncprojekt, amely olyan innovatív megoldásokon dolgozik, mint az atomic swap, a Delayed Proof of Work és az interoperábilis multi-chain architektúra.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "Teljesen! További részletekért olvassa el <a href=\"https://developers.komodoplatform.com/\">fejlesztői dokumentációnkat</a>, vagy forduljon hozzánk partnerségi kérdéseivel. Konkrét technikai kérdése van? A {appName} fejlesztői közössége mindig készen áll a segítségére!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Taps",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "BIZTOS?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "a csere meghiúsul",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "a csere befejeződik",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "hitelesítse a",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Az újbóli aktiválási folyamat befejeztével automatikusan átirányítjuk a portfólió oldalra.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "max vol",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "vissza",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Mentés",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "{coinName1}/{coinName2} alapján",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "Az akkumulátor töltöttsége kritikus ({batteryLevelCritical}%) a biztonságos cseréhez. Kérjük, töltse fel, és próbálja meg újra.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "Az akkumulátor töltöttsége alacsonyabb, mint {batteryLevelLow}%. Kérjük, fontolja meg a telefon töltését.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "A telefon akkumulátor-takarékos üzemmódban van. Kérjük, kapcsolja ki ezt az üzemmódot, vagy NE tegye az alkalmazást a háttérbe, különben az alkalmazást az operációs rendszer megölheti, és a csere sikertelen lesz.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "A rendelkezésrre álló legjobb ár",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Komodo rendszerrel fejlesztve",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Komodo rendszerrel fejlesztve",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Vétel",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Átalakítás vevővé, ha nem egyezik",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Csere kiadva, kérjük várjon!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "A rendelés egyeztetése folyamatban van, kérjük várjon {seconde} másodperceket!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "Figyelmeztetés, Ön hajlandó teszt érméket vásárolni NÉLKÜL valós értéket!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Az álcázó PIN és a Bio védelem nem engedélyezhető egyszerre.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Az álcázó PIN és a bio védelem konfliktusban van egymással.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Álcázó PIN megváltoztatása",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Álcázó PIN létrehozása",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Ha az álcázó PIN kóddal nyitod fel az alkalmazást, egy hamis alacsony egyenleg fog megjelenni, és az álzácási PIN konfigurációs opció NEM lesz látható a beállításokban.",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "Érvénytelen álcázási PIN-kód",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Álcázó PIN-kód",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Az álcázási PIN-kód nem található",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Off",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "Be",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Álcázási PIN mentve",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Álcázó PIN-kód",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Új álcázási PIN megadása",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Álcázási PIN beállítása",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Álcázási PIN beállítása",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "visszamond",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Aktiválás megszakítása",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "Biztosan megszakítja az aktiválást?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "Visszavonás",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Megrendelés visszavonása",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Valami rosszul sült el. Próbálja meg később újra.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ok",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "egy alapértelmezett érme. Az alapértelmezett érméket nem lehet letiltani.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Nem lehet letiltani",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Ezt nem lehet lejátszani",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEX árfolyam",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEX adatok",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Az ezzel az ikonnal jelölt piaci adatok (árak, grafikonok stb.) harmadik féltől származó forrásokból származnak (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEX árfolyam",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "PIN módosítása",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Frissítések ellenőrzése",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Kifizetés",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "ellenőrizze a SEED-jét",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "FOLYTATÁS",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "Lépjen vissza és ellenőrizze ismét",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "Írja be a {index}. szót",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "A SEED-ed fontos - ezért szeretnénk ellenőrizni, hogy helyes-e. Három különféle kérdést fogunk feltenni a SEED-el kapcsolatban, hogy megbizonyosodjon arról, hogy bármikor könnyedén visszaállíthatja a pénztárcáját.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "Mi a {index}. szó a SEED-ben?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "DUPLÁN ellenőrizze a SEED-jét",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Kínai",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "Igényel",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "Igényelje meg KMD jutalmát?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Kattintson a megtekintéshez",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Vágólapra másolva",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Vágólapra másolva",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Bezár",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Hibaüzenet bezárása",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Előnézet bezárása",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Kód:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "Biztosan megszakítja az aktiválást?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Kiválasztotta az eszközök maximális számát",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName} érme aktiválva van",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName} érme sikeresen aktiválva",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "A(z) {protocolName} érmék nincsenek aktiválva",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Tiszta",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "Nincsenek aktív érmék",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Érme kiválasztása",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Hamarosan...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "Tranzakció részletek hamarosan!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "A részletek hamarosan megjelennek!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "Jutalék díj",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "átlaghoz képest 24 órás CEX ár",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "a CEX-hez képest",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "A pénztárca konfigurálása, kérjük várjon...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Megerősít",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Álcázási PIN megerősítése",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Biztos, hogy törölni szeretné a rendelést",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "Az alábbi gombokra kattintva megerősítheti, hogy elolvasta a „EULA” és a „Általános Szerződési Feltételeket”, és elfogadja ezeket",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Jelszó megerősítése",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "PIN kód megerősítése",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "SEED megerősítése",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Csatlakozás...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Megszüntetés",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Kapcsolat törlése",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "törlése",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "Biztos vagy benne, hogy törölni akarod a {name} kontaktot?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Elutasítás",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Szerkesztés",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Kilépés",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Elveti a módosításokat?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "Nem találtam kapcsolatot",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Mentés",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Kapcsolattartási adatok",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Név",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Szerződés",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Megváltoztatni",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "Nem sikerült elindítani az URL-t",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "Nem sikerült importálni:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "Kereskedelem",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "PÉNZTÁRCA LÉTREHOZÁSA",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Kapcsolat létrehozása",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "PIN kód létrehozása",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Pénznem",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Pénznem",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Jelenlegi érték:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Egyedi díj",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "Csak akkor használjon egyéni díjakat, ha tudja, mit csinál!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Az egyéni magvas kifejezések kevésbé biztonságosak és könnyebben feltörhetők, mint egy generált, BIP39 szabványnak megfelelő magvas kifejezés vagy magánkulcs (WIF). Annak megerősítéséhez, hogy tisztában van a kockázattal és tudja, mit csinál, írja be az alábbi mezőbe a \"{iUnderstand}\" szöveget.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Dátum",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Pénztárca dekódolása",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Törlés",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Hatályon kívül helyezés megerősítése",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "El akarja távolítani",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "a portfóliójából? Minden nem egyező megbízás törlésre kerül.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " is deaktiválva lesz",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Pénztárca törlése",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Pénztárca törlése...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "megkapja a {coinName} tranzakciós díjat",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "küldje el a {coinName} tranzakciós díjat",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "kereskedési díj tranzakciós díj küldése",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "kereskedési díj",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "részletek",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Német",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Fejlesztő",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX nem elérhető ehhez az érméhez",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Képernyőképek/Előnézet letiltása",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Felelősségi nyilatkozat & használati feltételek",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Kész",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Ne zárja be az alkalmazást. További információért koppintson...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Ne kérdezze újra",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "Nem akarok jelszót",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW biztonság",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Időtartam",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Kapcsolat szerkesztése",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Bemenet {abbr} cím",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "A titkosítási jelszó nem lehet üres",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "A jelszó nem lehet üres",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Kapcsolattartó neve nem lehet üres",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "A tárca neve nem lehet üres",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Továbbra is engedélyezheti a következőt: {remains}, Kijelölve: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Kérjük, engedélyezze az értesítéseket, hogy értesüljön az aktiválás folyamatáról.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Tesztérmék engedélyezése",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "Ön rendelkezik",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "eszközök engedélyezve, és megpróbálja engedélyezni",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "többet. Az engedélyezett eszközök maximális korlátja",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ". Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Túl sok eszközt próbál engedélyezni",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Pénztárca titkosítása",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "Angol",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Adja meg új PIN-kódját",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Adja meg régi PIN kódját",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Kérjük, írja be a jelszavát a folytatáshoz.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Adja meg a PIN kódját",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Adja meg a Seed-jét",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Először az Eladási összeget kell megadnia",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Nincs elég egyenleg",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Hiba! Helytelen / nem valós cím!",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "A Segwit címek (még) nem támogatottak",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Nincs elég gáz - használjon minimum {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Hiba, kérem próbálja újra",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Hiba, kérjük próbálja újra",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "Az érték túl magas vagy alacsony",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Kérjük adjon meg adatokat",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Becsült Teljes Érték",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Például: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Célszerű",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Drága",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Azonos a CEX-szel",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Árfolyam:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "KERESKEDŐOLDAL",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Exportálás",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Kapcsolatok",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Kérjük, válassza ki a titkosított fájlba exportálandó elemeket.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Exportálás",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Jegyzetek",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "A tételek exportálása sikeresen megtörtént:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Cserék",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Exportálás",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Sikertelen",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Hamis egyenleg összege:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Gyakran ismételt kérdések",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Hiba",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Kérelem küldése a {coin} csaptelephez...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "FAUCET",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Siker",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "A kérés lejárt",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Visszajelzés küldése",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Hírek",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Itt nincs semmi",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} hírek",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Bővebben...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Feed",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Hírek",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Nem folytatható a hírfrissítés",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Nem lehetséges a hírfrissítés",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Hírfolyam frissítve",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Már naprakész",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "A díjak legfeljebb {value}",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Minden",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Szűrő",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Összes szűrő törlése",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Sikertelen",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "Dátumtól",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Gyártó",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Érmét kapott érme",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Érme eladása",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Státusz",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Sikeres",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Átvevő",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "Eddig",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Vevő/szerző",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Ujjlenyomat",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Befejezés, kérem várjon",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "Talált QR kódot",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Francia",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "Honnan",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "A jövőbeni tranzakciókat szinkronizálni fogjuk a nyilvános kulcsához társított aktiválás után. Ez a leggyorsabb lehetőség, és a legkevesebb tárhelyet foglalja el.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} díj",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "Benzin limit",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Kérjük, aktiválja {coin}.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "Gáz ára",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "Az általános PIN-védelem nem aktív.\n Az álcázási mód nem lesz elérhető.\n Kérjük, aktiválja a PIN-védelmet.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Fontos: Mentse el a SEED-jét mielött tovább haladnánk!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "A tranzakció lebonyolítása, kérjük, várjon",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Ugrás a portfólióhoz",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "A Gwei értékének legfeljebb {value} értéknek kell lennie",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Segítség",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Segítség és támogatás",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Egyenlegek elrejtése",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Jelszó megerősítése",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Jelszó létrehozása",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Jelenlegi jelszó",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Írja be a jelszavát",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Írja be a SEED-jét",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Pénztárcád neve",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Jelszó",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "előzmények",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "ó",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Magyar",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Import",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Érvénytelen jelszó vagy sérült adatok",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "Importálandó tételek:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Fájl nem található",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Érvénytelen csereadatok. Kérjük, adjon meg egy érvényes swap-státusz JSON fájlt.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Importálás",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Kérjük, válasszon titkosított fájlt az importáláshoz.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Megnyitás...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Kérjük, válasszon egyszerű szöveges swapfájlt az importáláshoz.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Megszakítás",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ok",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Jelszó",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Egyetlen swap importálása",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Swap importálása",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Néhány elemet kihagytunk",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "A tételek importálása sikeresen megtörtént:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Nem sikerült a swap importálása",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Hiba a json fájl dekódolásában",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Importálás",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Bejövő {coinName} txs-védelmi beállítások",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Ha nem ad meg jelszót, akkor minden alkalommal be kell írnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "A megkezdett cserét visszavonni nem lehet, ez végleges!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "Ez a tranzakció akár 10 percet is igénybe vehet - NE zárja be ezt az alkalmazást!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Dönthet úgy is, hogy jelszóval titkosítja a pénztárcáját. Ha úgy dönt, hogy nem használ jelszót, akkor minden alkalommal meg kell adnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} az egyenleg nem elegendő a kereskedési díj kifizetéséhez",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "A megbízáshoz szükséges minimális mennyiség",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Elégtelen mennyiség",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Frissítés",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Internet kapcsolat helyreállt",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Érvénytelen {coin} cím",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "Nem lehet folytatni a swapot",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Részletek",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} nem elérhető :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "Értem",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Japán",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Koreai",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Nyelv",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Legutóbbi tranzakciók",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Jogi",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Kevesebb",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Vigyázat! A(z) {coinName} piacán kevesebb, mint 10 000 USD 24 órás kereskedési volumen van!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "A korlát legfeljebb {value} lehet",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Betöltés...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Rendelési könyv betöltése...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "Képernyő lezárva",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "Kérjük hitelesítse!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "belépés",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Kijelentkezés",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Kijelentkezés kilépéskor",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Kijelentkezés beállításai",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "Biztos, hogy most már ki akarsz jelentkezni?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "percek",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "Rendelés készítése",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Készítő",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Megrendelés törlése",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Létrehozva",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Megkapja",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "Megrendelés azonosítója",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Ez a megbízás nem indított swapot",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Ár",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Eladni",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "A megbízás által indított swapok",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Maker megbízás részletei",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Maker megbízás",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Piactér",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Diagram",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Mélység",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "Nem találtunk kéréseket",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "Nem találtak ajánlatot",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "MEGRENDELÉS KÖNYV",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Megrendelés részletei",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "ÁRA",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Kérjük, válasszon érméket",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Piacok",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "MARKETS",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "A jelszavaknak meg kell egyezniük",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Váltás",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Az általános PIN-kód és az álcázó PIN-kód ugyanaz.\n Az álcázó üzemmód nem lesz elérhető.\n Kérjük, változtassa meg a álcázó PIN-kódot.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "Érvénytelen PIN-kód",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAX",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Maximális rendelési mennyiség:",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Hírek",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "BÖNGÉSZÉS",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "BÖNGÉSZŐ FEED",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "Által",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "Nincsenek mentett cikkeid",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "MENTVE",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Memo",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Egyesítés",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Összevont érték:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "ezredmásodperc",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "MIN",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Figyelmeztetés: Az alkalmazás iOS rendszeren való minimalizálása leállítja az aktiválási folyamatot.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "Minimális rendelési mennyiség:",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "m",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "A minimális eladási összeg {number} {coinName}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "A minimális vásárlási összeg: {number}{coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "A megbízás minimális összege {buyAmount} {buyCoin} ({sellAmount} {sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "Az eladandó minimális összeg {number} {coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "Nagyobbnak kell lennie, mint {minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Alacsonyabbnak kell lennie, mint az eladási összeg",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Minimális mennyiség szükséges",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Egyéni minimális mennyiség használata",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Kérjük, vegye figyelembe, hogy most mobiladatokat használ, és az {appName} P2P-hálózatban való részvétel internetforgalmat fogyaszt. Jobb, ha WiFi hálózatot használsz, ha a mobiladat-előfizetésed drága.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Több információ",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "További",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Aktiválja a {coin} és töltse fel először az egyenlegét",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Összeg",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Érme",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Eladás",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Cancel",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Megerősítés",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "Create {number} Order(s):",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Létrehozása",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Megrendelés",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Megrendelések",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "díj",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Cancel",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Kérjük, adja meg az átvenni kívánt fiat összeget:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Autofill",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Kérjük, a folytatás előtt javítson ki minden hibát",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Érvénytelen összeg",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Érvénytelen eladási összeg",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "Nincs elég {coin} a díjak kifizetéséhez. MIN egyenleg {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} egyenleg túl alacsony",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "Max eladási összeg",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "A minimális vételi összeg",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "Min eladási összeg",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Receive:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Sell:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Multi",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Receive Amt.",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Ár/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Hálózati díj",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "új számla",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Új Számla",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Hírcsatorna",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Új érték:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "tovább",
-  "@next": {
-    "type": "text"
-  },
-  "no": "Szám",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "Nincsenek hírek - kérjük nézzen vissza később!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "Nem találtunk érmét",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Nincs alaptőke",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "Alaptőke nem elérhető - kérjük utaljon be.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "Nincs Internet Kapcsolat",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "Nincs kiválasztott tétel",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "Nincs kiválasztott tétel",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "Nem találtak megfelelő rendelést",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Egyik sem",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "Az értéknek numerikusnak kell lennie",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Nem érhető el {coinName} rendelés - próbálja újra később, vagy készítsen egy rendelést.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Kattintson a megrendelés létrehozásához",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "Nincs rendelés, kérem, menjen a kereskedelembe.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "Nincs igényelhető jutalom",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "Nincs igényelhető jutalom - próbálkozzon újra 1 óra múlva.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "Nincs ilyen érme",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "Nincs elözmény.",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "Nincs elég {coin} a tranzakcióhoz!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "Nincs elég egyenlege a jutalékhoz - kereskedjen kisebb mennyiséggel",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Megjegyzés: A párosított rendelés nem törölhető újra.",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Megjegyzés hozzáadása",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Megjegyzés",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Semmi sem található",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "Az {sell}/{buy} swap sikeresen befejeződött.",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "A csere befejeződött",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} csere sikertelen volt",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "A swap sikertelen",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} swap elindult",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Új swap indult",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Swap státusz megváltozott",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} swap időzítve volt",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Swap lejárt",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "Ön {coin} tranzakciót kapott!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Bejövő tranzakció",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "Nincs tranzakció",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} Aktív",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Hivatalos sajtóközlemény",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Oké",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Törlés",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Régi naplók",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Használt hely",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Hibaüzenet megnyitása",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Választható",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Kevésbé",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "Több",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Minden {coin} megrendelés törlésre kerül.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Megrendelés létrehozva",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Megrendelés sikeresen létrehozva",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Cím:",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Cancel",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Célszerű: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Drága: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "a esetében",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Azonos a CEX-szel",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "min.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Ár",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Vétel",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Válassza ki a",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Eladja",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Nyissa meg a részleteket egyetlen koppintással, és válassza a Megrendelés hosszú koppintással",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Töltse el a",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Részletek",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% betelt",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Rendelés megegyezett",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Rendelés egyeztetés",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "rendelések",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Aktív",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "Történelem",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Mennyiség. ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "Ár ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Összesen ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Megrendelés",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Ismeretlen típusú rendelés",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Felülírás",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "Ez a saját megrendelésed!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Az egyenlegből fizetett:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Kifizetve a kapott mennyiségből:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Fizetetve",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "A jelszónak legalább 12 karaktert kell tartalmaznia, egy kisbetűt, egy nagybetűt és egy speciális szimbólumot.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "A pénztárcája megmutatja a megadott dátum után végrehajtott korábbi tranzakcióit.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Fizetés",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Elfogadja ezt a tranzakciót?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "Címre",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Összeg:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Érme:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Cancel",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Kért fizetés",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} nem aktív. Kérjük, aktiválja és próbálja újra.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Rendelés leadása",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "Játssz teljes hangerőn",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Kérjük, adjon hozzá egy érmét",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Kérjük, indítsa újra az alkalmazást, vagy nyomja meg az alábbi gombot.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Portfolió",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Komodo által működtetett",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "ár",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Privát kulcs",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Privát kulcsok",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Megerősítések",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Egyéni védelmi beállítások használata",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "KI",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "BE",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Figyelmeztetés, ez az atomi csere nem dPoW védett.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Publikációs kulcs",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "QR Code Scanner",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Tárolja a privát kulcsaimat?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "Mely eszközökön használhatom az {appName}-t?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "Miben különbözik a kereskedés az {appName}-en a más DEX-eken folytatott kereskedéstől?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "Mennyi ideig tart egy-egy atomi swap?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "A csere időtartama alatt online kell lennem?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "Hogyan számítják ki a díjakat az {appName}-nél?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Biztosítanak felhasználói támogatást?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Vannak országos korlátozások?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Ki áll az {appName} mögött?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "Lehetséges saját white-label csereprogramot kialakítani az {appName} oldalon?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "Ez egy új korszak! Hivatalosan megváltoztattuk a nevünket „AtomicDEX”-ről „Komodo Wallet”-ra",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "FOGAD",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Fogad",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Azt ajánljuk offline tárolja.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Kikapcsolás",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Kért Trade",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "ÜRES",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Formanyomtatvány visszaállítása",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "VISSZAÁLLÍTÁS",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Az összes érme aktiválásának újbóli próbálkozása...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Az összes érme aktiválásának újbóli próbálkozása",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Igényelje jutalmát",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Megszünteti",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Valami rosszul sült el. Kérjük, próbáld meg később újra.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "A tranzakció folyamatban van",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "feldolgozás",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO összeg kevesebb, mint 10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Egy óra még nem telt el",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 óra",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Ok",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Jutalmak állapota:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "További információ a KMD aktív felhasználó jutalmakról",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Kapja meg a címet.",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Siker! {amount} KMD kapott.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Utalás",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Jutalmak,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Állapot",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Maradék idő",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Jutalom információ:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO amt,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} napok",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}h {minutes}m",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}min",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Jutalom információk",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Orosz",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Mentés összevonva",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "A folytatáshoz görgessen lefelé...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Keressen egy érmét",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Válassza ki az összes Avax érmét",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Az összes BEP token kiválasztása",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Válassza ki az összes Cosmos hálózatot",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Válassza ki az összes ERC tokenet",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Az összes ETC token kiválasztása",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Válassza ki az összes FTM tokenet",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Válassza ki az összes HCO tokenet",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Válassza ki az összes HRC tokenet",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Válassza ki az összes Iris hálózatot",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Válassza ki az összes KRC tokenet",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Válassza ki az összes MVR tokenet",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Válassza ki az összes PLG tokenet",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Válassza ki az összes QRC tokenet",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Válassza ki az összes SBCH tokenet",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Válassza ki az összes SLP tokent",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Az összes SmartChains kiválasztása",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Válassza ki az összes teszteszközt",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Az összes Ubiq kiválasztása",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Az összes UTXO kiválasztása",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Válassza ki az összes ZHTLC-érmét",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Keresse meg a Tickert",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Biztonság",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "SEED kifejezés",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Új SEED-ed",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "Kattintson a megtekintéshez {amount} rendelések",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "Tranzakciós előzmények megtekintése",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Válasszon érmét",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Válassza ki az érmét amit hozzá kíván adni a portfóliójához",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Érme aktiválás:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Válassza ki az érmét amit VÁSÁROLNI szeretne",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Válassza ki az érmét amit ELADNI szeretne",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Válasszon egy dátumot",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Kiválasztott sorrend:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Fájl kiválasztása",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Nyelv kiválasztása",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Válassza ki a fizetési metódust",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Eladás",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Figyelmeztetés, Ön hajlandó eladni tesztérméket VALÓDI érték nélkül!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "KÜLD",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Biztos benne, hogy törölni szeretné",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "pénztárca?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Ha igen, győződjön meg róla",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "rögzítse a SEED-jét.",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "A pénztárca jövőbeli helyreállítása érdekében.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Nyelvek",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Beállítások",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "JELSZÓ BEÁLLÍTÁSA",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Megosztás",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "Az én {coinName} címem:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "Keresi a múltbeli {coin} tranzakciókat?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Cím megjelenítése",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Részletek megjelenítése",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "{count}/{maxCount} rendelés megjelenítése.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "Mutasd a rendeléseimet",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Jelentkezzen be jelszóval",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Jelentkezzen be SEED-el",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Egyszerű",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Aktiválja a címet.",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Kérjük, adja meg a {coin} összeget a vásárláshoz",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Vásárlás",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Bezárás",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "A maximális aktív érmék száma {maxCoins}. Kérjük, néhányat deaktiváljon.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} nem aktív!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Fogadja",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Kérjük, adja meg az eladni kívánt {coin} összeget",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Eladni",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Küldje el a",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Kevesebb mutatása",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Többet mutasd meg",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "Nem sikerült aktiválni {coin}",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Kihagyás",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Dissississ",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Hang",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Válasszon egy mp3 vagy wav fájlt, kérem. Akkor fogjuk lejátszani, amikor {description}.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "Lejátsszuk, amikor {description}",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Hangok",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Értettem, többé nem jelenítjük meg",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Hang",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Hangbeállítások",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "A cserefolyamat során és akkor hallható hangjelzés, ha aktív készítői megbízásod van.\nAz atomi swap protokoll megköveteli, hogy a résztvevők online legyenek a sikeres kereskedéshez, és a hangos értesítések segítenek ennek elérésében.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Ne feledje, hogy az alkalmazás beállításaiban beállíthatja az egyéni hangokat.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Spanyol",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Kezdő dátum",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Indítsa el a Swapot",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Lépés",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Siker!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Támogatás",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Ha bármilyen kérdésed van, vagy úgy gondolod, hogy technikai problémát találtál az {appName} alkalmazással kapcsolatban, akkor jelentheted, és támogatást kaphatsz csapatunktól.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "csere",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Aktuális",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "Erősitse meg a csere részleteit",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Becslés",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Csere sikertelen",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Kérjük, először aktiválja {coin} és töltse fel egyenlegét",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "Az {coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "{coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez. {coin} {amount} szükséges.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Csere folyamatban",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "Haladás részletei",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "Elindult",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Csere sikeres",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Összesen",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "Swap UUID",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Switch téma",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Szinkronizálás a megadott dátumtól",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Szinkronizálás a csemete aktiválásából",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Új tranzakciók szinkronizálása",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "Mely {name} tranzakciókat szeretné szinkronizálni?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Átvevő",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Vevő rendelés",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Időtúllépés",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "JELSZÓ LÉTREHOZÁSA",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Kiválasztott sorrend",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "Hova",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "Címzett:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "Van egy",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "eszközöd engedélyezve. Az engedélyezett eszközök maximális korlátja .",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": "Kérjük, tiltson le néhányat, mielőtt újakat adna hozzá.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Túl sok eszköz engedélyezve",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Összes díj:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "KERESKEDÉS",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "Csere végrehajtva!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "KERESKEDÉS részletek",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Nem sikerült kiszámítani a kereskedelmi díjakat",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "kereskedési díj:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Kereskedési mód:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Tranzakció címe",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Tranzakció rejtett",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Ez a tranzakció egy lehetséges adathalász kísérlet miatt el lett rejtve.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "Ha még ekkor sem aktiválódik néhány érme, próbálja meg újraindítani az alkalmazást.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Török",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Blokk",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Megerősítések",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "MERŐSÍTVE",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Díj",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "tranzakciós díj:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "Tranzakció azonosítója",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Tranzakciók Balra: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Túl sok a kérés.\n Tranzakciótörténeti kérések száma túllépte a limitet.\n Kérjük, próbálja meg később újra.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "NEM MEGERŐSÍTETT",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Ukrán",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "kinyit",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Alapok feloldása",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "Sikeresen feloldotta a {amnt} pénzeszközöket - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "elkölthetetlen",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Új verzió elérhető",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Frissítések keresése...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "Ön a {version} verziót használja.",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Új verzió elérhető. Kérjük, frissítse.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "A {version} verzió elérhető. Kérjük, frissítse.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Frissítés elérhető",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Egyelőre kihagyás",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "{appName} frissítés",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Frissítés",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Már naprakész",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Nincs elég egyenleg a beolvasáshoz",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "fizetési kérelem.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Elégtelen egyenleg",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Érték:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "verzió",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Felfedező",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Magánkulcsok és magánkulcsok",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Volumes",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "A pénztárca neve már használatban van",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "A pénztárca neve legfeljebb 40 karakter lehet.",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Csak pénztárca",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "Figyelmeztetés!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ok",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Figyelmeztetés - különleges esetekben ez a naplóadat érzékeny információkat tartalmaz, amelyek felhasználhatók a sikertelen cserékből származó érmék elköltésére!",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "Nem sikerült aktiválni a {coinAbbr}",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "Nem sikerült aktiválni a {coinAbbr}.\nKérjük, indítsa újra az alkalmazást, hogy újra megpróbálhassa.",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} mobil egy következő generációs többérmés pénztárca natív harmadik generációs DEX funkcióval és még sokkal több",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "KÉSZÍTSÜK FEL!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "Üdvözöljük",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "pénztárca",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "A kitöltés után átirányítjuk a portfólió oldalra.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Ez eltart egy ideig, és az alkalmazást az előtérben kell tartani.\nAz alkalmazás aktiválás közbeni leállítása problémákhoz vezethet.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Kifizetés",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "Ön korábban megtagadta a {appName} hozzáférést a kamerához.\n Kérjük, a QR-kód beolvasásának folytatásához manuálisan módosítsa a kameraengedélyt a telefon beállításaiban.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Hozzáférés megtagadva",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Kiutalás megerősítése",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Valami rosszul sült el. Próbálja meg később újra.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "KIFIZETÉS {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "Ön megpróbál beolvasni egy fizetési QR-kódot a következőhöz",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "de a",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "visszavonási képernyőn van",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Rossz érme",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "A jelszavak nem egyeznek. Próbálja újra.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Igen",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Ön küld:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "van egy új megrendelése, amelyet egy meglévő megrendeléssel próbál összevetni.",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "aktív csere folyamatban van",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "van egy megbízása, amellyel az új megbízások összeilleszthetők.",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "a pénztárcája",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "Kapni fog {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Fog kapni:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -3621,6 +3621,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "Nem sikerült megszakítani a(z) {coinAbbr} aktiválását",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} nem elérhető :(",
     "@isUnavailable": {
         "type": "text",
@@ -5460,6 +5470,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "Az érme aktiválása megszakítva",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "{coin} sikeresen aktiválva",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "{coin} aktiválása megszakítva",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Kérjük, fogadjon el minden különleges érmeaktiválási kérést, vagy törölje az érmék kijelölését.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "Aktiválás megszakítása",
     "@cancelActivation": {

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,3726 +1,5540 @@
 {
-  "@@locale": "ja",
-  "accepteula": "EULA に同意する",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "利用規約に同意する",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "生体認証保護を有効にする",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "PIN 保護を有効にする",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "{protocolName} コインをアクティブにしますか?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "現在、携帯データ ネットワークを使用しており、{appName} P2P ネットワークに参加すると、インターネット トラフィックが消費されることに注意してください。携帯電話のデータ プランが高額な場合は、WiFi ネットワークを使用することをお勧めします。",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "アクセスが拒否されました",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "以前にカメラへの {appName} アクセスを拒否しました。 QR コードのスキャンを続行するには、電話の設定でカメラの許可を手動で変更してください。",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "ようこそ",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "財布",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} モバイルは、ネイティブの第 3 世代 DEX 機能などを備えた次世代のマルチコイン ウォレットです。",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "セットアップしましょう！",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "{appName} の更新",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "バージョン {version} を使用しています",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "アップデートの確認...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "すでに最新",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "新しいバージョンが利用可能",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "アップデート",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "今のところスキップ",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "利用可能なアップデート",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "新しいバージョンが利用可能です。更新してください。",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "バージョン {version} が利用可能です。更新してください。",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "ヘルプ",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "ヘルプとサポート",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "よくある質問",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "サポート",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "ご不明な点がある場合、または {appName} アプリで技術的な問題を発見したと思われる場合は、報告してチームからサポートを受けることができます。",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "私の秘密鍵を保管しますか?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "いいえ！ {appName} は非親権者です。秘密鍵、シード フレーズ、PIN などの機密データを保存することはありません。このデータはユーザーのデバイスにのみ保存され、デバイスから離れることはありません。あなたは自分の資産を完全に管理しています。",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "{appName} での取引は、他の DEX での取引とどう違うのですか?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "他の DEX では通常、単一のブロックチェーン ネットワークに基づく資産の取引のみが許可され、プロキシ トークンが使用され、同じ資金で単一の注文のみが許可されます。 {appName} を使用すると、プロキシ トークンを使用せずに、2 つの異なるブロックチェーン ネットワーク間でネイティブに取引できます。同じ資金で複数の注文を出すこともできます。たとえば、KMD、QTUM、または VRSC で 0.1 BTC を販売できます。最初に約定した注文は、他のすべての注文を自動的にキャンセルします。",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "各アトミック スワップにはどのくらいの時間がかかりますか?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "各スワップの処理時間は、いくつかの要因によって決まります。取引された資産のブロック時間は、各ネットワークによって異なります (通常、ビットコインが最も遅いです)。さらに、ユーザーはセキュリティ設定をカスタマイズできます。たとえば、{appName} に、わずか 3 回の確認後に KMD トランザクションを最終と見なすように依頼できます。これにより、<a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">公証</a>。",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "スワップ中はオンラインである必要がありますか?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "はい。各アトミック スワップを正常に完了するには、インターネットへの接続を維持し、アプリを実行している必要があります (通常、接続が非常に短時間中断しても問題ありません)。そうしないと、Maker の場合は取引キャンセルのリスクがあり、Taker の場合は資金を失うリスクがあります。アトミック スワップ プロトコルでは、両方の参加者がオンライン状態を維持し、関与するブロックチェーンを監視して、プロセスがアトミック状態を維持する必要があります。",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "{appName} の料金はどのように計算されますか?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "{appName} で取引する際に考慮すべき 2 つの手数料カテゴリがあります。 1. {appName} は、テイカー オーダーの取引手数料として約 0.13% (取引量の 1/777、ただし 0.0001 以上) を請求し、メイカー オーダーの手数料はゼロです。 2. メーカーとテイカーの両方が、アトミック スワップ トランザクションを行う際に、関連するブロックチェーンに通常のネットワーク料金を支払う必要があります。ネットワーク手数料は、選択した取引ペアによって大きく異なります。",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "ユーザーサポートは提供していますか？",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "はい！ {appName} は、<a href=\"{link}\">{appCompanyShort} {name}</a> を通じてサポートを提供しています。チームとコミュニティはいつでも喜んでお手伝いします!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "国の制限はありますか？",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "いいえ！ {appName} は完全に分散化されています。第三者によるユーザー アクセスを制限することはできません。",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "{appName} の背後にいるのは誰ですか?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} は {appCompanyShort} チームによって開発されました。 {appCompanyShort} は、アトミック スワップ、Delayed Proof of Work、相互運用可能なマルチチェーン アーキテクチャなどの革新的なソリューションに取り組んでいる、最も確立されたブロックチェーン プロジェクトの 1 つです。",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "{appName} で独自のホワイトラベル取引所を開発することは可能ですか?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "絶対！詳細については、<a href=\"https://developers.komodoplatform.com/\">開発者向けドキュメント</a>をご覧いただくか、パートナーシップに関するお問い合わせでご連絡ください。特定の技術的な質問がありますか? {appName} 開発者コミュニティはいつでもお手伝いいたします。",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "{appName} を使用できるデバイスはどれですか?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName} は、モバイルでは Android と iPhone の両方で利用でき、デスクトップでは <a href=\"https://komodoplatform.com/\">Windows、Mac、Linux オペレーティング システム</a> で利用できます。",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "餌",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "ニュースフィード",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "続きを読む...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "ここには何もない",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "ニュースフィードが更新されました",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "解散",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "ニュース",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "間隔",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "ニュースの更新を取得できません",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "ニュースの更新を続行できません",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "すでに最新",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "日にち",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} ニュース",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "PIN の作成",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "PINコードを入力してください",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "ログインする",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "新しいアカウント",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "新しいアカウント",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} の有効化に成功しました!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "接続中...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "コインを有効にする",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} アセット",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "シードフレーズを入力してください",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "例: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "確認",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "警告、本当の価値のないテスト コインを購入しても構わないと思っています。",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "交換を安全に行うには、バッテリーの充電が重要です ({batteryLevelCritical}%)。充電してからもう一度お試しください。",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "バッテリーの充電が {batteryLevelLow}% 未満です。電話の充電を検討してください。",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "お使いの携帯電話はバッテリー節約モードになっています。このモードを無効にするか、アプリケーションをバックグラウンドにしないでください。そうしないと、アプリが OS によって強制終了され、スワップが失敗する可能性があります。",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "警告、実際の価値のないテスト コインを販売しても構わないと思っています。",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "買う",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "売る",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "私の {coinName} アドレス: \n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "撤退",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "値が高すぎるか低すぎる",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "額",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "受取人住所",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "WITHDRAW {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "出金確認",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "エラーが発生しました。あとでもう一度試してみてください。",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "近い",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "シード フレーズの確認",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "あなたの新しいシードフレーズ",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "重要: 続行する前に、シード フレーズをバックアップしてください。",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "オフラインで保存することをお勧めします。",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "次",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "PIN コードの確認",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "カモフラージュ PIN の設定",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "カモフラージュ PIN の確認",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "エラーです。もう一度お試しください",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "設定",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "安全",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "PIN 保護を有効にする",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "スクリーンショット/プレビューを無効にする",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "画面がロックされています",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "PIN コードの変更",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "ログアウト",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "最大",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "最小",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "合計料金:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "残高から支払われる:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "取引モード:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "スキップ",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "マージ",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "上書き",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "現在の価値：",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "新しい値:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "マージされた値:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "結合して保存",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "もう存在している",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "単純",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "高度",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "受け取ったボリュームから支払われる:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "売却金額",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "受け取るもの:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "売りたいコインを選択",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "購入したいコインを選択",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "スワップ",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "スワップが発行されました。お待ちください!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "オーダーマッチが進行中です。{seconde} 秒お待ちください!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "ネットワーク料金",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "手数料",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "ポートフォリオ",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "チェックアウト",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "推定合計値",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "お支払い方法を選択してください",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "ボリューム",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "ご注文",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "近日公開...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "市場",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "あなたが送っているもの:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "コード：",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "価値：",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "で支払った",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "データを入力してください",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "バランスが足りない",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "グウェイは {value} までである必要があります",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "料金は {value} までである必要があります",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "制限は最大 {value} である必要があります",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "有効な住所ではありません",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Segwit アドレスはサポートされていません (まだ)",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "対処するには:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "受け取る",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "送信",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "公開鍵",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "戻る",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "キャンセル",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "詳細",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "はい",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "いいえ",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "注: 一致した注文は再度キャンセルできません",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "二度と聞かない",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "注文をキャンセルする",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "注文をキャンセルしてもよろしいですか",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "使えない",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "TXの詳細は近日公開！",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "歴史",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "トレード",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "詳細は近日公開！",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "オーダーマッチング",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "一致した注文",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "スワップ進行中",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "スワップ成功",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "タイムアウト",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "変換",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "スワップに失敗しました",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "エラーです。後で試してください",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "最新の取引",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "トランザクションを取得しています。お待ちください",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "完了しました、お待ちください",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "ログファイルの共有",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "オーダーブックを読み込んでいます...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "請求",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "KMD 報酬を受け取りますか？",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "成功！",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "報酬は請求できません - 1 時間後にもう一度お試しください。",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "読み込んでいます...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "残りのトランザクション: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} 取引手数料を支払うのに十分な残高がありません",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "デックス",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "ニュース",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "ニュースフィード",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "クリップボードにコピーしました",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "から",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "に",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "確認済み",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "未確認",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "ブロック",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "確認",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "費用",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "取引ID",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "メモ",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "履歴はありません。",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "トレード",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "クリア",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "フォームをリセット",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "スワップ完了！",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "ステップ",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "取引詳細",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "依頼された取引",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "UUIDを入れ替える",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "ブラウズ",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "保存しました",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "{remains} を引き続き有効にすることができます。選択済み: {selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "保存した記事はありません",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "フィードを閲覧します",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "に",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "認証してください！",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "取引なし",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "終わり",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "コインを有効にする:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "ポートフォリオに追加するコインを選択します。",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "ニュースはありません。後でもう一度確認してください。",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "スワップリクエストは元に戻すことができず、最終イベントです!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "スワップには最大 60 分かかる場合があります。このアプリケーションを閉じないでください！",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "交換の詳細を確認する",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "必要な最小ボリューム",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "カスタム最小ボリュームを使用",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "値は数値でなければなりません",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "販売額より低くなければなりません",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "{minValue} {coin} より大きくなければなりません",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "シード フレーズを確認する",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "シードフレーズを再確認しましょう",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "シード フレーズは重要です。そのため、正確であることを確認したいと考えています。いつでも簡単にウォレットを復元できるように、シード フレーズについて 3 つの異なる質問をします。",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "シード フレーズの {index} 単語は何ですか?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "{index}単語を入力してください",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "継続する",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "戻ってもう一度確認する",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "冒険者",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "生体認証保護を有効にする",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "カスタム シードを許可する",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "警告！",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "理解します",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "カスタム シード フレーズは、生成された BIP39 準拠のシード フレーズまたは秘密鍵 (WIF) よりも安全性が低く、クラックされやすい可能性があります。リスクを理解し、自分が何をしているかを理解していることを確認するには、下のボックスに「{iUnderstand}」と入力してください。",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "パスワードを入力してください",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "あなたの財布",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "パスワードをお忘れですか？シードからウォレットを復元する",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "パスワードでサインイン",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "シード フレーズを入力してください",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "パスワードが一致しません。もう一度やり直してください。",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "ウォレットに名前を付ける",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "セキュリティ上の理由から、ウォレット暗号化用のパスワードを提供する必要があります。",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "パスワードを認証する",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "パスワードはいらない",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "本気ですか？",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "安全なパスワードを使用し、同じデバイスに保存しないでください",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "パスワードを設定する",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "ウォレットを作成する",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "戻す",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "パスワード",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "パスワードには、小文字 1 つ、大文字 1 つ、特殊記号 1 つを含む 12 文字以上を含める必要があります。",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "パスワードの作成",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "パスワードを認証する",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "現在のパスワード",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "ログアウト設定",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "終了時にログアウト",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "ウォレットの削除",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "消去",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "消去してもよろしいですか",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "財布？",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "もしそうなら、あなたを確認してください",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "シード フレーズを記録します。",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "将来的にウォレットを復元するため。",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "バックアップ",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "バージョン",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "シードと秘密鍵",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "シードフレーズ",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "秘密鍵",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "秘密鍵",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "続行するには、パスワードを入力してください。",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "クリップボードにコピー",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "ロックを解除",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "{amnt} 資金のロックを解除しました - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "資金のロックを解除",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "注文はありません。取引に行ってください。",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "{coinName} の金額を入力してください。",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "為替レート",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "受け取る",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "注文する",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "両替",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "注文",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "コインを選択",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗注意！ {coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "言語を選択する",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "資金がない",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "資金がありません - 入金してください。",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "ポートフォリオに移動",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "クリックして注文を作成",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "ボリューム不足",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "この注文に必要な最小ボリュームは",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "オーダーが作成されました",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "注文が正常に作成されました",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "私の注文を表示",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "最低販売額は {number} {coinName} です",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "パスワードを作成",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "最低購入金額は {number} {coinName} です",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "最低販売額は {number} {coinName} です",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "注文の最小額は {buyAmount} {buyCoin} ({sellAmount} {sellCoin}) です",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "最初に販売金額を入力する必要があります",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "暗号化ウォレット",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "ウォレットの復号化",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "手数料に十分な残高がありません - 少額で取引してください",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "インターネット接続なし",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "コモドに建てられた",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "コインを追加してください",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "インターネット接続が回復しました",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "リフレッシュ",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "法的",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "免責事項と利用規約",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "EULA に同意する",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "利用規約に同意する",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "下のボタンをクリックすることで、「EULA」と「利用規約」を読んだことを確認し、これらに同意したことになります",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} 手数料",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "取引に十分な {coin} がありません!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "{coin}をアクティベートしてください。",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "{amount} {coin} を受け取ります",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "クリックして {amount} 件の注文を表示",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "クリックしてご覧ください",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "価格",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "最大ボリューム",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "ウォレットを設定しています。お待ちください...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "注文が選択されました",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "取引手数料：",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "取引手数料:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "{coin} の残高は、取引手数料を支払うのに十分ではありません。",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "{coin} の残高は、取引手数料を支払うのに十分ではありません。{coin} {amount} が必要です。",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "スワップを続行できません",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "詳細を表示",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "為替レート：",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "選択した注文:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "最小注文量:",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "最大注文量:",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "詳細",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "最初に {coin} を有効にして残高をチャージしてください",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "取引手数料の計算に失敗しました",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "無効にする",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "ウォレットのみ",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "ウォレット名を空にすることはできません",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "ウォレット名は最大 40 文字にする必要があります",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "ウォレット名はすでに使用されています",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "このコインではDEXは利用できません",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "コインを探す",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "すべての SmartChain を選択",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "すべてのテスト アセットを選択",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "すべてのERCトークンを選択",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "すべての SLP トークンを選択します",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "すべて選択 コスモネットワーク",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "アイリスネットワークをすべて選択",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "すべての Kucoin トークンを選択",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "すべてのハーモニートークンを選択",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "すべてのETCトークンを選択",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "すべての SmartBCH トークンを選択",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "すべての Avax トークンを選択",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "すべての Ubiq コインを選択",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "すべての BEP トークンを選択",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "すべてのポリゴン トークンを選択する",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "すべての QRC トークンを選択",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "すべての HecoChain トークンを選択",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "すべての ZHTLC コインを選択します",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "すべてのファントムトークンを選択",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "ムーンリバートークンをすべて選択",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "カスタム料金",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "ガスリミット",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "ガス料金",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "あなたが何をしているのかを知っている場合にのみ、カスタム料金を使用してください!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "すべてのUTXOコインを選択",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "コモドに建てられた",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "コモドによって供給",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "ガスが不足しています - 少なくとも {gas} Gwei を使用してください",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "{coin} の注文はすべてキャンセルされます。",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "非アクティブ化の確認",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "削除しますか",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "ポートフォリオから？一致しない注文はすべてキャンセルされます。",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " も無効化されます",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "無効にできません",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "デフォルトのコインです。デフォルトのコインを無効にすることはできません。",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ok",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "シェア",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "警告 - 特殊なケースでは、このログ データには機密情報が含まれており、失敗したスワップからのコインの使用に使用できる可能性があります。",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "古い PIN を入力してください",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "新しい PIN を入力してください",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "認証する",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "言語",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "英語",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "フランス語",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "ドイツ語",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "中国語",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "ロシア",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "日本",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "トルコ語",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "ハンガリー語",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "スペイン語",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "韓国語",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "ウクライナ語",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "蛇口",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "成功",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "エラー",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "要求がタイムアウトしました",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "{coin} フォーセットにリクエストを送信しています...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "オプション",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "音",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "フルボリュームで再生",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "テイカー",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "既存の注文と一致させようとしている新しい注文があります",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "メーカー",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "新しい注文と一致する注文があります",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "アクティブ",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "アクティブなスワップが進行中です",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "失敗した",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "スワップが失敗する",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "拍手",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "スワップは完了するまで実行されます",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "それは再生できません",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "mp3またはwavファイルを選択してください。 {description} になったら再生します。",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "{description} の場合にプレイ",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "サウンド",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "スワップ プロセス中、およびアクティブなメーカー注文が行われると、サウンド通知が聞こえます。アトミック スワップ プロトコルでは、取引を成功させるには参加者がオンラインである必要があり、サウンド通知はそれを達成するのに役立ちます。",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "アプリケーション設定でカスタムサウンドを設定できることに注意してください。",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "了解しました もう表示しないでください",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "サウンド設定",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "音",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "マーケット",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "市場",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "価格",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "オーダーブック",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "チャート",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "深さ",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "価格",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "売る",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "為に",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "分。",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "住所",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "便宜: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "高価: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "CEXと同じ",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "受け取る",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "費やす",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "これはあなた自身の注文です！",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "コインを選択してください",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "コインを選択",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "アクティブなコインはありません",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "クリア",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "価格 ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "金額 ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "合計 ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "入札が見つかりませんでした",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "質問が見つかりません",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "注文詳細",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "エラーが発生しました。あとでもう一度試してみてください。",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "特典情報",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "KMDアクティブユーザー特典について詳しく見る",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "キャンセル",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "受け取る",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "請求可能な報酬はありません",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "特典情報:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO金額、KMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "リワード、KMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "フィアット",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "残り時間",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "状態",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "報酬ステータス:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "Ok",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} 日",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}時 {minutes}分",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}分",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "成功！ {amount} KMD を受け取りました。",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "エラーが発生しました。後でもう一度やり直してください。",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXOの金額が10KMD未満",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "処理",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "取引が進行中です",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1時間",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "まだ1時間が経過していない",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "報酬を受け取る",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "取引履歴を見る",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "すべてのコインの有効化を再試行しています...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "完了すると、ポートフォリオ ページにリダイレクトされます。",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "それでも一部のコインが有効化されない場合は、アプリを再起動してみてください。",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "{coinAbbr} をアクティベートできませんでした",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "アプリを再起動してもう一度試すか、下のボタンを押してください。",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "すべてのアクティブ化を再試行",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "アクティベーションの再試行プロセスが完了すると、ポートフォリオ ページに自動的にリダイレクトされます。",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "{coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} は利用できません:(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "マルチ",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "続行する前にすべてのエラーを修正してください",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "作成",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "注文",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "注文",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "コイン",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "売る：",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "売る",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "額",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "受け取る：",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "価格/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "金額を受け取ります。",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "受け取る金額を入力してください:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "キャンセル",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "オートフィル",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "費用",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "料金を支払うのに十分な {coin} がありません。 MIN 残高は {fee} {coin} です",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "{number} オーダーを作成:",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "キャンセル",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "確認",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "販売金額が無効です",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "最大販売額は",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "最小販売額は",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "金額が無効です",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "無効な {coin} アドレスです",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "最初に {coin} を有効にして、残高をチャージしてください",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin} の残高が少なすぎます",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "最小受け取り金額は",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "住所録",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "住所録",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "連絡先の詳細",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "アドレス帳が空です",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "{title} 住所の連絡先のみを表示",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "連絡先の作成",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "名前",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "連絡先を編集",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "キャンセル",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "保存",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "破棄",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "出口",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "変更を破棄しますか?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "住所を追加",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "コインを選択",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "ティッカーを検索",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "連絡先を削除",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "連絡先 {name} を削除してもよろしいですか?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "消去",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "連絡先が見つかりません",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "編集",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "何も見つかりません",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "そのようなコインはありません",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "{abbr} が有効化されていないため、{abbr} アドレスに送金できません。ポートフォリオへどうぞ。",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Ok",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "連絡先の名前を空にすることはできません",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "入力 {abbr} アドレス",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "カモフラージュ PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "カモフラージュ PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "の上",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "オフ",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "無効な PIN",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "変化する",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "カモフラージュ PIN でアプリのロックを解除すると、偽の LOW 残高が表示され、カモフラージュ PIN 構成オプションは設定に表示されません。",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "一般暗証番号とカモフラージュ暗証番号は同じです。カモフラージュモードは利用できません。カモフラージュ PIN を変更してください。",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "カモフラージュ PIN とバイオ プロテクションを同時に有効にすることはできません。",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Camo PIN と Bio 保護の競合。",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "一般的な PIN 保護はアクティブではありません。カモフラージュモードは利用できません。 PIN 保護を有効にしてください。",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "偽の残高:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "カモフラージュ PIN が見つかりません",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "カモフラージュ PIN の作成",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "カモフラージュ PIN を保存しました",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "カモフラージュ PIN が無効です",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "カモフラージュ PIN の変更",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "カモフラージュ PIN の設定",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "新しいカモフラージュ PIN を入力してください",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "オン",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "オフ",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "確認",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo dPoW セキュリティ",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "カスタム保護設定を使用する",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "警告、このアトミック スワップは dPoW で保護されていません。",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "一致しない場合はMakerに変換",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEX為替レート",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "都合のよい",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "高い",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "CEXと同じ",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "CEXとの比較",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "平均と比較して。 24時間CEX価格",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "アクティブ",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "歴史",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "詳細",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "シングルタップで詳細を開き、ロングタップで注文を選択します",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "キャンセル",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "選択する",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "一致する注文が見つかりません",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "メーカー注文",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "テイカーオーダー",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "現時点の",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "見積もり",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "開始",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "合計",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "進捗詳細",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "エラーメッセージを閉じる",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "エラーメッセージを開く",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "着信トランザクション",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "{coin} のトランザクションを受け取りました!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "スワップ完了",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "{sell}/{buy} スワップが正常に完了しました",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "スワップに失敗しました",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} スワップに失敗しました",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "スワップ タイムアウト",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} スワップがタイムアウトしました",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "スワップ ステータスが変更されました",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "新しいスワップが開始されました",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} スワップ開始",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "言語",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "通貨",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "残高を非表示",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "テーマを切り替える",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "CEXデータ",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "このアイコンでマークされた市場データ (価格、チャートなど) は、サードパーティのソース (<a href=\"https://www.coingecko.com/\">coingecko.com</a>、<a href=\" https://openrates.io/\">openrates.io</a>)。",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "アップデートを確認",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "今すぐログアウトしてもよろしいですか?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "通貨",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "リクエストが多すぎます。トランザクション履歴リクエストの制限を超えました。後でもう一度やり直してください。",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "MS",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "メートル",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "分",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "時間",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "もっと",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "以下",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "古いログ",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "消去",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "ウォレットを削除しています...",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "使用スペース",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Ok",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "プレビューを閉じる",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "キャンセル",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "続行するには一番下までスクロールします...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "デベロッパー",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "テストコインを有効にする",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "メーカー注文内容",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "売る",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "受け取る",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "価格",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "注文をキャンセルする",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "オーダーID",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "で作成",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "この注文で開始されたスワップはありません",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "この注文で開始されたスワップ",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% 埋められました",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "ノート",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "メモを追加",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "輸入",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "シングル スワップのインポート",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "書き出す",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "輸入",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "輸入スワップ",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "書き出す",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "暗号化ファイルにエクスポートするアイテムを選択してください。",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "インポートする暗号化ファイルを選択してください。",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "インポートするプレーン テキスト スワップ ファイルを選択してください。",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "開いています...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "輸入する品目:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "ノート",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "連絡先",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "スワップ",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "何も見つかりません",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "書き出す",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "輸入",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "暗号化パスワードを空にすることはできません",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "パスワードを空にすることはできません",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "パスワードが一致する必要があります",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "項目が選択されていません",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "項目が選択されていません",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "ファイルを選ぶ",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "ファイルが見つかりません",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "指紋",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "パスワード",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "キャンセル",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Ok",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "アイテムは正常にエクスポートされました:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "アイテムが正常にインポートされました:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "無効なパスワードまたは破損したデータ",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "json ファイルのデコード中にエラーが発生しました",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "注文",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "不明な型順",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "インポートできませんでした:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "一部のアイテムがスキップされました",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "スワップのインポートに失敗しました",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "無効なスワップ データです。有効なスワップ ステータス JSON ファイルを提供してください。",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "{coinName}をアクティブ化しています",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "アプリを閉じないでください。詳細についてはタップしてください...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName} のアクティベーション",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "{protocolName} コインが有効化されました",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "{protocolName} コインは有効化されていません",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName} コインが正常に有効化されました",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} のアクティベーションが進行中です",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "{protocolName} コインをアクティブにしますか?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "より詳しい情報",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "住所を表示",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "このトランザクションはフィッシングの可能性があるため非表示になりました。",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "取引アドレス",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "非表示のトランザクション",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "URLを起動できませんでした",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "これには時間がかかるため、アプリをフォアグラウンドに維持する必要があります。\nアクティベーションの進行中にアプリを終了すると、問題が発生する可能性があります。",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "警告: iOS でアプリを最小化すると、アクティベーション プロセスが終了します。",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "アクティベーションの進行状況に関する最新情報を取得するには、通知を有効にしてください。",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "QRコードスキャナー",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "QRコードが見つかりました",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "契約",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "スワップの開始",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "なし",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "CEXレート",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "受信 {coinName} txs 保護設定",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "{maxCount} 件中 {count} 件の注文を表示しています。",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "少ない",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "もっと",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "{coinName1}/{coinName2} に基づく",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "送信取引手数料 取引手数料",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "取引手数料",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "{coinName} の取引手数料を送信します",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "{coinName} の取引手数料を受け取る",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "フィルター",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "状態",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "全て",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "成功",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "失敗した",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "開始日",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "現在まで",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "テイカー/メーカー",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "メーカー",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "全て",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "テイカー",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "コインを売る",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "コインを受け取る",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "すべてのフィルターをクリア",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "残高不足",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "スキャンするのに十分な残高がありません",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "支払い要求。",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "あまりにも多くのアセットを有効にしようとしています",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "あなたが持っている",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "アセットが有効になっており、有効にしようとしています",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "もっと。有効なアセットの上限は",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": ".新しいものを追加する前に、いくつかを無効にしてください。",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "アセットの最大数を選択しました",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "有効なアセットが多すぎます",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "あなたが持っている",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "アセットが有効になっています。有効なアセットの上限は",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ".新しいものを追加する前に、いくつかを無効にしてください。",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "支払いが要求されました",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "コイン：",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "住所へ",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "額：",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "この取引を受け入れますか？",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "支払い",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "キャンセル",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} はアクティブではありません。有効にしてからもう一度お試しください。",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "間違ったコイン",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "の支払い QR コードをスキャンしようとしています",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "しかし、あなたは上にいます",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "画面を撤回",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "売る",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "買う",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "受け取る",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "送信",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "近い",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "活性化",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "アクティブなコインの最大数は {maxCoins} です。いくつか無効にしてください。",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "{coin} をアクティベートできません",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} はアクティブではありません!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "購入する{coin}の金額を入力してください",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "売却する{coin}の金額を入力してください",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "表示を減らす",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "もっと見せる",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "コインが見つかりません",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "新しい時代です！ 「AtomicDEX」から「Komodo Wallet」に正式に名前を変更しました",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "公式プレスリリース",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "過去の {coin} 取引をスキャンしますか?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "アクティベーションのキャンセル",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "アクティベーションをキャンセルしてもよろしいですか?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "アクティベーションをキャンセルしてもよろしいですか?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "どの {name} トランザクションを同期しますか?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "新しいトランザクションを同期する",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "指定した日付から同期",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "苗木アクティベーションからの同期",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "日付を選択してください",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "開始日",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "公開キーに関連付けられたアクティベーション後に行われる今後のトランザクションは同期されます。これは最も迅速なオプションであり、必要なストレージの量も最小限です。",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "ウォレットには過去の取引が表示されます。すべてのブロックがダウンロードされてスキャンされるため、これにはかなりのストレージと時間がかかります。",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "ウォレットには、指定した日付以降に行われた過去の取引が表示されます。",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "{coinName}をアクティブ化しています",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} のアクティベーション",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} のアクティベーションが進行中です",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "アクティブ",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "コインを有効にする",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} の有効化に成功しました!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "住所を追加",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "住所録",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "アドレス帳が空です",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "{title} 住所の連絡先のみを表示",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "住所録",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "{abbr} が有効化されていないため、{abbr} アドレスに送金できません。ポートフォリオへどうぞ。",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "何も見つかりません",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "コインを選択",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "受取人住所",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "高度",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "全て",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "カスタム シードを許可する",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "ウォレットには過去の取引が表示されます。すべてのブロックがダウンロードされてスキャンされるため、これにはかなりのストレージと時間がかかります。",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "もう存在している",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "額",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "売却金額",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "いいえ！ {appName} は非親権者です。秘密鍵、シード フレーズ、PIN などの機密データを保存することはありません。このデータはユーザーのデバイスにのみ保存され、デバイスから離れることはありません。あなたは自分の資産を完全に管理しています。",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName} は、モバイルでは Android と iPhone の両方で利用でき、デスクトップでは <a href=\"https://komodoplatform.com/\">Windows、Mac、Linux オペレーティング システム</a> で利用できます。",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "他の DEX では通常、単一のブロックチェーン ネットワークに基づく資産の取引のみが許可され、プロキシ トークンが使用され、同じ資金で単一の注文のみが許可されます。 {appName} を使用すると、プロキシ トークンを使用せずに、2 つの異なるブロックチェーン ネットワーク間でネイティブに取引できます。同じ資金で複数の注文を出すこともできます。たとえば、KMD、QTUM、または VRSC で 0.1 BTC を販売できます。最初に約定した注文は、他のすべての注文を自動的にキャンセルします。",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "各スワップの処理時間は、いくつかの要因によって決まります。取引された資産のブロック時間は、各ネットワークによって異なります (通常、ビットコインが最も遅いです)。さらに、ユーザーはセキュリティ設定をカスタマイズできます。たとえば、{appName} に、わずか 3 回の確認後に KMD トランザクションを最終と見なすように依頼できます。これにより、<a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">公証</a>。",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "はい。各アトミック スワップを正常に完了するには、インターネットへの接続を維持し、アプリを実行している必要があります (通常、接続が非常に短時間中断しても問題ありません)。そうしないと、Maker の場合は取引キャンセルのリスクがあり、Taker の場合は資金を失うリスクがあります。アトミック スワップ プロトコルでは、両方の参加者がオンライン状態を維持し、関与するブロックチェーンを監視して、プロセスがアトミック状態を維持する必要があります。",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "{appName} で取引する際に考慮すべき 2 つの手数料カテゴリがあります。 1. {appName} は、テイカー オーダーの取引手数料として約 0.13% (取引量の 1/777、ただし 0.0001 以上) を請求し、メイカー オーダーの手数料はゼロです。 2. メーカーとテイカーの両方が、アトミック スワップ トランザクションを行う際に、関連するブロックチェーンに通常のネットワーク料金を支払う必要があります。ネットワーク手数料は、選択した取引ペアによって大きく異なります。",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "はい！ {appName} は、<a href=\"{link}\">{appCompanyShort} {name}</a> を通じてサポートを提供しています。チームとコミュニティはいつでも喜んでお手伝いします!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "いいえ！ {appName} は完全に分散化されています。第三者によるユーザー アクセスを制限することはできません。",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} は {appCompanyShort} チームによって開発されました。 {appCompanyShort} は、アトミック スワップ、Delayed Proof of Work、相互運用可能なマルチチェーン アーキテクチャなどの革新的なソリューションに取り組んでいる、最も確立されたブロックチェーン プロジェクトの 1 つです。",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "絶対！詳細については、<a href=\"https://developers.komodoplatform.com/\">開発者向けドキュメント</a>をご覧いただくか、パートナーシップに関するお問い合わせでご連絡ください。特定の技術的な質問がありますか? {appName} 開発者コミュニティはいつでもお手伝いいたします。",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "拍手",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "本気ですか？",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "スワップが失敗する",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "スワップは完了するまで実行されます",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "認証する",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "アクティベーションの再試行プロセスが完了すると、ポートフォリオ ページに自動的にリダイレクトされます。",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "最大ボリューム",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "戻る",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "バックアップ",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "{coinName1}/{coinName2} に基づく",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "交換を安全に行うには、バッテリーの充電が重要です ({batteryLevelCritical}%)。充電してからもう一度お試しください。",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "バッテリーの充電が {batteryLevelLow}% 未満です。電話の充電を検討してください。",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "お使いの携帯電話はバッテリー節約モードになっています。このモードを無効にするか、アプリケーションをバックグラウンドにしないでください。そうしないと、アプリが OS によって強制終了され、スワップが失敗する可能性があります。",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "為替レート",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "コモドに建てられた",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "コモドに建てられた",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "買う",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "一致しない場合はMakerに変換",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "スワップが発行されました。お待ちください!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "オーダーマッチが進行中です。{seconde} 秒お待ちください!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "警告、本当の価値のないテスト コインを購入しても構わないと思っています。",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "カモフラージュ PIN とバイオ プロテクションを同時に有効にすることはできません。",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Camo PIN と Bio 保護の競合。",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "カモフラージュ PIN の変更",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "カモフラージュ PIN の作成",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "カモフラージュ PIN でアプリのロックを解除すると、偽の LOW 残高が表示され、カモフラージュ PIN 構成オプションは設定に表示されません。",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "カモフラージュ PIN が無効です",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "カモフラージュ PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "カモフラージュ PIN が見つかりません",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "オフ",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "の上",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "カモフラージュ PIN を保存しました",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "カモフラージュ PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "新しいカモフラージュ PIN を入力してください",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "カモフラージュ PIN の設定",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "カモフラージュ PIN の設定",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "キャンセル",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "アクティベーションのキャンセル",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "アクティベーションをキャンセルしてもよろしいですか?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "キャンセル",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "注文をキャンセルする",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "エラーが発生しました。あとでもう一度試してみてください。",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ok",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "デフォルトのコインです。デフォルトのコインを無効にすることはできません。",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "無効にできません",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "それは再生できません",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEX為替レート",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEXデータ",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "このアイコンでマークされた市場データ (価格、チャートなど) は、サードパーティのソース (<a href=\"https://www.coingecko.com/\">coingecko.com</a>、<a href=\" https://openrates.io/\">openrates.io</a>)。",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEXレート",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "PIN コードの変更",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "アップデートを確認",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "チェックアウト",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "シード フレーズを確認する",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "継続する",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "戻ってもう一度確認する",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "{index}単語を入力してください",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "シード フレーズは重要です。そのため、正確であることを確認したいと考えています。いつでも簡単にウォレットを復元できるように、シード フレーズについて 3 つの異なる質問をします。",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "シード フレーズの {index} 単語は何ですか?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "シードフレーズを再確認しましょう",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "中国語",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "請求",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "KMD 報酬を受け取りますか？",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "クリックしてご覧ください",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "クリップボードにコピーしました",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "クリップボードにコピー",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "近い",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "エラーメッセージを閉じる",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "プレビューを閉じる",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "コード：",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "アクティベーションをキャンセルしてもよろしいですか?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "アセットの最大数を選択しました",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName} コインが有効化されました",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName} コインが正常に有効化されました",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "{protocolName} コインは有効化されていません",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "クリア",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "アクティブなコインはありません",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "コインを選択",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "近日公開...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "TXの詳細は近日公開！",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "詳細は近日公開！",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "手数料",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "平均と比較して。 24時間CEX価格",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "CEXとの比較",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "ウォレットを設定しています。お待ちください...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "確認",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "カモフラージュ PIN の確認",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "注文をキャンセルしてもよろしいですか",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "下のボタンをクリックすることで、「EULA」と「利用規約」を読んだことを確認し、これらに同意したことになります",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "パスワードを認証する",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "PIN コードの確認",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "シード フレーズの確認",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "接続中...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "キャンセル",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "連絡先を削除",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "消去",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "連絡先 {name} を削除してもよろしいですか?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "破棄",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "編集",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "出口",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "変更を破棄しますか?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "連絡先が見つかりません",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "保存",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "連絡先の詳細",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "名前",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "契約",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "変換",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "URLを起動できませんでした",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "インポートできませんでした:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "トレード",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "ウォレットを作成する",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "連絡先の作成",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "PIN の作成",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "通貨",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "通貨",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "現在の価値：",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "カスタム料金",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "あなたが何をしているのかを知っている場合にのみ、カスタム料金を使用してください!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "カスタム シード フレーズは、生成された BIP39 準拠のシード フレーズまたは秘密鍵 (WIF) よりも安全性が低く、クラックされやすい可能性があります。リスクを理解し、自分が何をしているかを理解していることを確認するには、下のボックスに「{iUnderstand}」と入力してください。",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "日にち",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "ウォレットの復号化",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "消去",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "非アクティブ化の確認",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "削除しますか",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "ポートフォリオから？一致しない注文はすべてキャンセルされます。",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " も無効化されます",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "ウォレットの削除",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "ウォレットを削除しています...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "{coinName} の取引手数料を受け取る",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "{coinName} の取引手数料を送信します",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "送信取引手数料 取引手数料",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "取引手数料",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "詳細",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "ドイツ語",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "デベロッパー",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "デックス",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "このコインではDEXは利用できません",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "スクリーンショット/プレビューを無効にする",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "免責事項と利用規約",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "終わり",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "アプリを閉じないでください。詳細についてはタップしてください...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "二度と聞かない",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "パスワードはいらない",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW セキュリティ",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "間隔",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "連絡先を編集",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "入力 {abbr} アドレス",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "暗号化パスワードを空にすることはできません",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "パスワードを空にすることはできません",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "連絡先の名前を空にすることはできません",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "ウォレット名を空にすることはできません",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "{remains} を引き続き有効にすることができます。選択済み: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "アクティベーションの進行状況に関する最新情報を取得するには、通知を有効にしてください。",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "テストコインを有効にする",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "あなたが持っている",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "アセットが有効になっており、有効にしようとしています",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "もっと。有効なアセットの上限は",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ".新しいものを追加する前に、いくつかを無効にしてください。",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "あまりにも多くのアセットを有効にしようとしています",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "暗号化ウォレット",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "英語",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "新しい PIN を入力してください",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "古い PIN を入力してください",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "続行するには、パスワードを入力してください。",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "PINコードを入力してください",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "シードフレーズを入力してください",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "最初に販売金額を入力する必要があります",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "バランスが足りない",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "有効な住所ではありません",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Segwit アドレスはサポートされていません (まだ)",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "ガスが不足しています - 少なくとも {gas} Gwei を使用してください",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "エラーです。もう一度お試しください",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "エラーです。後で試してください",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "値が高すぎるか低すぎる",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "データを入力してください",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "推定合計値",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "例: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "都合のよい",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "高い",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "CEXと同じ",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "為替レート：",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "両替",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "書き出す",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "連絡先",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "暗号化ファイルにエクスポートするアイテムを選択してください。",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "書き出す",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "ノート",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "アイテムは正常にエクスポートされました:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "スワップ",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "書き出す",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "失敗した",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "偽の残高:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "よくある質問",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "エラー",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "{coin} フォーセットにリクエストを送信しています...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "蛇口",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "成功",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "要求がタイムアウトしました",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "ログファイルの共有",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "ニュース",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "ここには何もない",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} ニュース",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "続きを読む...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "餌",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "ニュースフィード",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "ニュースの更新を続行できません",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "ニュースの更新を取得できません",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "ニュースフィードが更新されました",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "すでに最新",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "料金は {value} までである必要があります",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "全て",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "フィルター",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "すべてのフィルターをクリア",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "失敗した",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "開始日",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "メーカー",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "コインを受け取る",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "コインを売る",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "状態",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "成功",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "テイカー",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "現在まで",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "テイカー/メーカー",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "指紋",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "完了しました、お待ちください",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "QRコードが見つかりました",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "フランス語",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "から",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "公開キーに関連付けられたアクティベーション後に行われる今後のトランザクションは同期されます。これは最も迅速なオプションであり、必要なストレージの量も最小限です。",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} 手数料",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "ガスリミット",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "{coin}をアクティベートしてください。",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "ガス料金",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "一般的な PIN 保護はアクティブではありません。カモフラージュモードは利用できません。 PIN 保護を有効にしてください。",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "重要: 続行する前に、シード フレーズをバックアップしてください。",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "トランザクションを取得しています。お待ちください",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "ポートフォリオに移動",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "グウェイは {value} までである必要があります",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "ヘルプ",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "ヘルプとサポート",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "残高を非表示",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "パスワードを認証する",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "パスワードの作成",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "現在のパスワード",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "パスワードを入力してください",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "シード フレーズを入力してください",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "ウォレットに名前を付ける",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "パスワード",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "歴史",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "時間",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "ハンガリー語",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "輸入",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "無効なパスワードまたは破損したデータ",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "輸入する品目:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "ファイルが見つかりません",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "無効なスワップ データです。有効なスワップ ステータス JSON ファイルを提供してください。",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "輸入",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "インポートする暗号化ファイルを選択してください。",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "開いています...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "インポートするプレーン テキスト スワップ ファイルを選択してください。",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "キャンセル",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ok",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "パスワード",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "シングル スワップのインポート",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "輸入スワップ",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "一部のアイテムがスキップされました",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "アイテムが正常にインポートされました:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "スワップのインポートに失敗しました",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "json ファイルのデコード中にエラーが発生しました",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "輸入",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "受信 {coinName} txs 保護設定",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "安全なパスワードを使用し、同じデバイスに保存しないでください",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "スワップリクエストは元に戻すことができず、最終イベントです!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "スワップには最大 60 分かかる場合があります。このアプリケーションを閉じないでください！",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "セキュリティ上の理由から、ウォレット暗号化用のパスワードを提供する必要があります。",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} 取引手数料を支払うのに十分な残高がありません",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "この注文に必要な最小ボリュームは",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "ボリューム不足",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "リフレッシュ",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "インターネット接続が回復しました",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "無効な {coin} アドレスです",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "スワップを続行できません",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "詳細",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} は利用できません:(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "理解します",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "日本",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "韓国語",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "言語",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "最新の取引",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "法的",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "以下",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗注意！ {coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "制限は最大 {value} である必要があります",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "読み込んでいます...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "オーダーブックを読み込んでいます...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "画面がロックされています",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "認証してください！",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "ログインする",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "ログアウト",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "終了時にログアウト",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "ログアウト設定",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "今すぐログアウトしてもよろしいですか?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "分",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "注文する",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "メーカー",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "注文をキャンセルする",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "で作成",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "受け取る",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "オーダーID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "この注文で開始されたスワップはありません",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "価格",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "売る",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "この注文で開始されたスワップ",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "メーカー注文内容",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "メーカー注文",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "市場",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "チャート",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "深さ",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "質問が見つかりません",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "入札が見つかりませんでした",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "オーダーブック",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "注文詳細",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "価格",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "コインを選択してください",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "マーケット",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "市場",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "パスワードが一致する必要があります",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "変化する",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "一般暗証番号とカモフラージュ暗証番号は同じです。カモフラージュモードは利用できません。カモフラージュ PIN を変更してください。",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "無効な PIN",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "最大",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "最大注文量:",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "ニュース",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "ブラウズ",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "フィードを閲覧します",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "に",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "保存した記事はありません",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "保存しました",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "メモ",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "マージ",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "マージされた値:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "MS",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "最小",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "警告: iOS でアプリを最小化すると、アクティベーション プロセスが終了します。",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "最小注文量:",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "メートル",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "最低販売額は {number} {coinName} です",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "最低購入金額は {number} {coinName} です",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "注文の最小額は {buyAmount} {buyCoin} ({sellAmount} {sellCoin}) です",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "最低販売額は {number} {coinName} です",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "{minValue} {coin} より大きくなければなりません",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "販売額より低くなければなりません",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "必要な最小ボリューム",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "カスタム最小ボリュームを使用",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "現在、携帯データ ネットワークを使用しており、{appName} P2P ネットワークに参加すると、インターネット トラフィックが消費されることに注意してください。携帯電話のデータ プランが高額な場合は、WiFi ネットワークを使用することをお勧めします。",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "より詳しい情報",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "もっと",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "最初に {coin} を有効にして、残高をチャージしてください",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "額",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "コイン",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "売る",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "キャンセル",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "確認",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "{number} オーダーを作成:",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "作成",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "注文",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "注文",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "費用",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "キャンセル",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "受け取る金額を入力してください:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "オートフィル",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "続行する前にすべてのエラーを修正してください",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "金額が無効です",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "販売金額が無効です",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "料金を支払うのに十分な {coin} がありません。 MIN 残高は {fee} {coin} です",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} の残高が少なすぎます",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "最大販売額は",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "最小受け取り金額は",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "最小販売額は",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "受け取る：",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "売る：",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "マルチ",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "金額を受け取ります。",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "価格/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "ネットワーク料金",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "新しいアカウント",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "新しいアカウント",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "ニュースフィード",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "新しい値:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "次",
-  "@next": {
-    "type": "text"
-  },
-  "no": "いいえ",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "ニュースはありません。後でもう一度確認してください。",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "コインが見つかりません",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "資金がない",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "資金がありません - 入金してください。",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "インターネット接続なし",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "項目が選択されていません",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "項目が選択されていません",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "一致する注文が見つかりません",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "なし",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "値は数値でなければなりません",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "{coinName} の金額を入力してください。",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "クリックして注文を作成",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "注文はありません。取引に行ってください。",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "請求可能な報酬はありません",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "報酬は請求できません - 1 時間後にもう一度お試しください。",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "そのようなコインはありません",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "履歴はありません。",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "取引に十分な {coin} がありません!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "手数料に十分な残高がありません - 少額で取引してください",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "注: 一致した注文は再度キャンセルできません",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "メモを追加",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "ノート",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "何も見つかりません",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "{sell}/{buy} スワップが正常に完了しました",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "スワップ完了",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} スワップに失敗しました",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "スワップに失敗しました",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} スワップ開始",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "新しいスワップが開始されました",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "スワップ ステータスが変更されました",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} スワップがタイムアウトしました",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "スワップ タイムアウト",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "{coin} のトランザクションを受け取りました!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "着信トランザクション",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "取引なし",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} アセット",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "公式プレスリリース",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ok",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "消去",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "古いログ",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "使用スペース",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "エラーメッセージを開く",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "オプション",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "少ない",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "もっと",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "{coin} の注文はすべてキャンセルされます。",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "オーダーが作成されました",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "注文が正常に作成されました",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "住所",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "キャンセル",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "便宜: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "高価: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "為に",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "CEXと同じ",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "分。",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "価格",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "受け取る",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "選択する",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "売る",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "シングルタップで詳細を開き、ロングタップで注文を選択します",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "費やす",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "詳細",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% 埋められました",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "一致した注文",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "オーダーマッチング",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "注文",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "アクティブ",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "歴史",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "金額 ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "価格 ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "合計 ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "注文",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "不明な型順",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "上書き",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "これはあなた自身の注文です！",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "残高から支払われる:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "受け取ったボリュームから支払われる:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "で支払った",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "パスワードには、小文字 1 つ、大文字 1 つ、特殊記号 1 つを含む 12 文字以上を含める必要があります。",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "ウォレットには、指定した日付以降に行われた過去の取引が表示されます。",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "支払い",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "この取引を受け入れますか？",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "住所へ",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "額：",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "コイン：",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "キャンセル",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "支払いが要求されました",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} はアクティブではありません。有効にしてからもう一度お試しください。",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "ご注文",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "フルボリュームで再生",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "コインを追加してください",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "アプリを再起動してもう一度試すか、下のボタンを押してください。",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "ポートフォリオ",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "コモドによって供給",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "価格",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "秘密鍵",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "秘密鍵",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "確認",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "カスタム保護設定を使用する",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "オフ",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "オン",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "警告、このアトミック スワップは dPoW で保護されていません。",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "公開鍵",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "QRコードスキャナー",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "私の秘密鍵を保管しますか?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "{appName} を使用できるデバイスはどれですか?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "{appName} での取引は、他の DEX での取引とどう違うのですか?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "各アトミック スワップにはどのくらいの時間がかかりますか?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "スワップ中はオンラインである必要がありますか?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "{appName} の料金はどのように計算されますか?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "ユーザーサポートは提供していますか？",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "国の制限はありますか？",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "{appName} の背後にいるのは誰ですか?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "{appName} で独自のホワイトラベル取引所を開発することは可能ですか?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "新しい時代です！ 「AtomicDEX」から「Komodo Wallet」に正式に名前を変更しました",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "受け取る",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "受け取る",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "オフラインで保存することをお勧めします。",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "無効にする",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "依頼された取引",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "クリア",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "フォームをリセット",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "戻す",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "すべてのコインの有効化を再試行しています...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "すべてのアクティブ化を再試行",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "報酬を受け取る",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "キャンセル",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "エラーが発生しました。後でもう一度やり直してください。",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "取引が進行中です",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "処理",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXOの金額が10KMD未満",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "まだ1時間が経過していない",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1時間",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Ok",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "報酬ステータス:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "KMDアクティブユーザー特典について詳しく見る",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "受け取る",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "成功！ {amount} KMD を受け取りました。",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "フィアット",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "リワード、KMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "状態",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "残り時間",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "特典情報:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO金額、KMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} 日",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}時 {minutes}分",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}分",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "特典情報",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "ロシア",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "結合して保存",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "続行するには一番下までスクロールします...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "コインを探す",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "すべての Avax トークンを選択",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "すべての BEP トークンを選択",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "すべて選択 コスモネットワーク",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "すべてのERCトークンを選択",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "すべてのETCトークンを選択",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "すべてのファントムトークンを選択",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "すべての HecoChain トークンを選択",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "すべてのハーモニートークンを選択",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "アイリスネットワークをすべて選択",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "すべての Kucoin トークンを選択",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "ムーンリバートークンをすべて選択",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "すべてのポリゴン トークンを選択する",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "すべての QRC トークンを選択",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "すべての SmartBCH トークンを選択",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "すべての SLP トークンを選択します",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "すべての SmartChain を選択",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "すべてのテスト アセットを選択",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "すべての Ubiq コインを選択",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "すべてのUTXOコインを選択",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "すべての ZHTLC コインを選択します",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "ティッカーを検索",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "安全",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "シードフレーズ",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "あなたの新しいシードフレーズ",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "クリックして {amount} 件の注文を表示",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "取引履歴を見る",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "コインを選択",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "ポートフォリオに追加するコインを選択します。",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "コインを有効にする:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "購入したいコインを選択",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "売りたいコインを選択",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "日付を選択してください",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "選択した注文:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "ファイルを選ぶ",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "言語を選択する",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "お支払い方法を選択してください",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "売る",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "警告、実際の価値のないテスト コインを販売しても構わないと思っています。",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "送信",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "消去してもよろしいですか",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "財布？",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "もしそうなら、あなたを確認してください",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "シード フレーズを記録します。",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "将来的にウォレットを復元するため。",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "言語",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "設定",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "パスワードを設定する",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "シェア",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "私の {coinName} アドレス: \n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "過去の {coin} 取引をスキャンしますか?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "住所を表示",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "詳細を表示",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "{maxCount} 件中 {count} 件の注文を表示しています。",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "私の注文を表示",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "パスワードでサインイン",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "パスワードをお忘れですか？シードからウォレットを復元する",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "単純",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "活性化",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "購入する{coin}の金額を入力してください",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "買う",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "近い",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "アクティブなコインの最大数は {maxCoins} です。いくつか無効にしてください。",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} はアクティブではありません!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "受け取る",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "売却する{coin}の金額を入力してください",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "売る",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "送信",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "表示を減らす",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "もっと見せる",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "{coin} をアクティベートできません",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "スキップ",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "解散",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "音",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "mp3またはwavファイルを選択してください。 {description} になったら再生します。",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "{description} の場合にプレイ",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "サウンド",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "了解しました もう表示しないでください",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "音",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "サウンド設定",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "スワップ プロセス中、およびアクティブなメーカー注文が行われると、サウンド通知が聞こえます。アトミック スワップ プロトコルでは、取引を成功させるには参加者がオンラインである必要があり、サウンド通知はそれを達成するのに役立ちます。",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "アプリケーション設定でカスタムサウンドを設定できることに注意してください。",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "スペイン語",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "開始日",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "スワップの開始",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "ステップ",
-  "@step": {
-    "type": "text"
-  },
-  "success": "成功！",
-  "@success": {
-    "type": "text"
-  },
-  "support": "サポート",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "ご不明な点がある場合、または {appName} アプリで技術的な問題を発見したと思われる場合は、報告してチームからサポートを受けることができます。",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "スワップ",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "現時点の",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "交換の詳細を確認する",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "見積もり",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "スワップに失敗しました",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "最初に {coin} を有効にして残高をチャージしてください",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "{coin} の残高は、取引手数料を支払うのに十分ではありません。",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "{coin} の残高は、取引手数料を支払うのに十分ではありません。{coin} {amount} が必要です。",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "スワップ進行中",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "進捗詳細",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "開始",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "スワップ成功",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "合計",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "UUIDを入れ替える",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "テーマを切り替える",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "指定した日付から同期",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "苗木アクティベーションからの同期",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "新しいトランザクションを同期する",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "どの {name} トランザクションを同期しますか?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "テイカー",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "テイカーオーダー",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "タイムアウト",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "パスワードを作成",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "注文が選択されました",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "に",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "対処するには:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "あなたが持っている",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "アセットが有効になっています。有効なアセットの上限は",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ".新しいものを追加する前に、いくつかを無効にしてください。",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "有効なアセットが多すぎます",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "合計料金:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "トレード",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "スワップ完了！",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "取引詳細",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "取引手数料の計算に失敗しました",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "取引手数料:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "取引モード:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "取引アドレス",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "非表示のトランザクション",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "このトランザクションはフィッシングの可能性があるため非表示になりました。",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "それでも一部のコインが有効化されない場合は、アプリを再起動してみてください。",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "トルコ語",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "ブロック",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "確認",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "確認済み",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "費用",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "取引手数料：",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "取引ID",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "残りのトランザクション: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "リクエストが多すぎます。トランザクション履歴リクエストの制限を超えました。後でもう一度やり直してください。",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "未確認",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "ウクライナ語",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "ロックを解除",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "資金のロックを解除",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "{amnt} 資金のロックを解除しました - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "使えない",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "新しいバージョンが利用可能",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "アップデートの確認...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "バージョン {version} を使用しています",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "新しいバージョンが利用可能です。更新してください。",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "バージョン {version} が利用可能です。更新してください。",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "利用可能なアップデート",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "今のところスキップ",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "{appName} の更新",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "アップデート",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "すでに最新",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "スキャンするのに十分な残高がありません",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "支払い要求。",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "残高不足",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "価値：",
-  "@value": {
-    "type": "text"
-  },
-  "version": "バージョン",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "冒険者",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "シードと秘密鍵",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "ボリューム",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "ウォレット名はすでに使用されています",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "ウォレット名は最大 40 文字にする必要があります",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "ウォレットのみ",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "警告！",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ok",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "警告 - 特殊なケースでは、このログ データには機密情報が含まれており、失敗したスワップからのコインの使用に使用できる可能性があります。",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "{coinAbbr} をアクティベートできませんでした",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "{coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} モバイルは、ネイティブの第 3 世代 DEX 機能などを備えた次世代のマルチコイン ウォレットです。",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "セットアップしましょう！",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "ようこそ",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "財布",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "完了すると、ポートフォリオ ページにリダイレクトされます。",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "これには時間がかかるため、アプリをフォアグラウンドに維持する必要があります。\nアクティベーションの進行中にアプリを終了すると、問題が発生する可能性があります。",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "撤退",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "以前にカメラへの {appName} アクセスを拒否しました。 QR コードのスキャンを続行するには、電話の設定でカメラの許可を手動で変更してください。",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "アクセスが拒否されました",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "出金確認",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "エラーが発生しました。あとでもう一度試してみてください。",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "WITHDRAW {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "の支払い QR コードをスキャンしようとしています",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "しかし、あなたは上にいます",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "画面を撤回",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "間違ったコイン",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "パスワードが一致しません。もう一度やり直してください。",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "はい",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "あなたが送っているもの:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "既存の注文と一致させようとしている新しい注文があります",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "アクティブなスワップが進行中です",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "新しい注文と一致する注文があります",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "あなたの財布",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "{amount} {coin} を受け取ります",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "受け取るもの:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -3621,6 +3621,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "{coinAbbr} のアクティベーションをキャンセルできませんでした",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} は利用できません:(",
     "@isUnavailable": {
         "type": "text",
@@ -5460,6 +5470,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "コインのアクティベーションがキャンセルされました",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "{coin} を正常にアクティブ化しました",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "{coin} のアクティベーションがキャンセルされました",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "特別なコインの有効化リクエストをすべて受け入れるか、コインの選択を解除してください。",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "アクティベーションのキャンセル",
     "@cancelActivation": {

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,3660 +1,3726 @@
 {
-    "accepteula": "EULA に同意する",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "利用規約に同意する",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "生体認証保護を有効にする",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "PIN 保護を有効にする",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "{protocolName} コインをアクティブにしますか?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "{coinName}をアクティブ化しています",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName} のアクティベーション",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} のアクティベーションが進行中です",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "アクティブ",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "コインを有効にする",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} の有効化に成功しました!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "住所を追加",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "住所録",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "アドレス帳が空です",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "{title} 住所の連絡先のみを表示",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "住所録",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "{abbr} が有効化されていないため、{abbr} アドレスに送金できません。ポートフォリオへどうぞ。",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "何も見つかりません",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "コインを選択",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "受取人住所",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "高度",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "全て",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "カスタム シードを許可する",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "もう存在している",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "額",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "売却金額",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "いいえ！ {appName} は非親権者です。秘密鍵、シード フレーズ、PIN などの機密データを保存することはありません。このデータはユーザーのデバイスにのみ保存され、デバイスから離れることはありません。あなたは自分の資産を完全に管理しています。",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName} は、モバイルでは Android と iPhone の両方で利用でき、デスクトップでは <a href=\"https://komodoplatform.com/\">Windows、Mac、Linux オペレーティング システム</a> で利用できます。",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "他の DEX では通常、単一のブロックチェーン ネットワークに基づく資産の取引のみが許可され、プロキシ トークンが使用され、同じ資金で単一の注文のみが許可されます。 {appName} を使用すると、プロキシ トークンを使用せずに、2 つの異なるブロックチェーン ネットワーク間でネイティブに取引できます。同じ資金で複数の注文を出すこともできます。たとえば、KMD、QTUM、または VRSC で 0.1 BTC を販売できます。最初に約定した注文は、他のすべての注文を自動的にキャンセルします。",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "各スワップの処理時間は、いくつかの要因によって決まります。取引された資産のブロック時間は、各ネットワークによって異なります (通常、ビットコインが最も遅いです)。さらに、ユーザーはセキュリティ設定をカスタマイズできます。たとえば、{appName} に、わずか 3 回の確認後に KMD トランザクションを最終と見なすように依頼できます。これにより、<a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">公証</a>。",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "はい。各アトミック スワップを正常に完了するには、インターネットへの接続を維持し、アプリを実行している必要があります (通常、接続が非常に短時間中断しても問題ありません)。そうしないと、Maker の場合は取引キャンセルのリスクがあり、Taker の場合は資金を失うリスクがあります。アトミック スワップ プロトコルでは、両方の参加者がオンライン状態を維持し、関与するブロックチェーンを監視して、プロセスがアトミック状態を維持する必要があります。",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "{appName} で取引する際に考慮すべき 2 つの手数料カテゴリがあります。 1. {appName} は、テイカー オーダーの取引手数料として約 0.13% (取引量の 1/777、ただし 0.0001 以上) を請求し、メイカー オーダーの手数料はゼロです。 2. メーカーとテイカーの両方が、アトミック スワップ トランザクションを行う際に、関連するブロックチェーンに通常のネットワーク料金を支払う必要があります。ネットワーク手数料は、選択した取引ペアによって大きく異なります。",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "はい！ {appName} は、<a href=\"{link}\">{appCompanyShort} {name}</a> を通じてサポートを提供しています。チームとコミュニティはいつでも喜んでお手伝いします!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "いいえ！ {appName} は完全に分散化されています。第三者によるユーザー アクセスを制限することはできません。",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} は {appCompanyShort} チームによって開発されました。 {appCompanyShort} は、アトミック スワップ、Delayed Proof of Work、相互運用可能なマルチチェーン アーキテクチャなどの革新的なソリューションに取り組んでいる、最も確立されたブロックチェーン プロジェクトの 1 つです。",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "絶対！詳細については、<a href=\"https://developers.komodoplatform.com/\">開発者向けドキュメント</a>をご覧いただくか、パートナーシップに関するお問い合わせでご連絡ください。特定の技術的な質問がありますか? {appName} 開発者コミュニティはいつでもお手伝いいたします。",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "拍手",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "本気ですか？",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "スワップが失敗する",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "スワップは完了するまで実行されます",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "認証する",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "アクティベーションの再試行プロセスが完了すると、ポートフォリオ ページに自動的にリダイレクトされます。",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "最大ボリューム",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "戻る",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "バックアップ",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "{coinName1}/{coinName2} に基づく",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "交換を安全に行うには、バッテリーの充電が重要です ({batteryLevelCritical}%)。充電してからもう一度お試しください。",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "バッテリーの充電が {batteryLevelLow}% 未満です。電話の充電を検討してください。",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "お使いの携帯電話はバッテリー節約モードになっています。このモードを無効にするか、アプリケーションをバックグラウンドにしないでください。そうしないと、アプリが OS によって強制終了され、スワップが失敗する可能性があります。",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "為替レート",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "コモドに建てられた",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "コモドに建てられた",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "買う",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "一致しない場合はMakerに変換",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "スワップが発行されました。お待ちください!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "オーダーマッチが進行中です。{seconde} 秒お待ちください!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "警告、本当の価値のないテスト コインを購入しても構わないと思っています。",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "カモフラージュ PIN とバイオ プロテクションを同時に有効にすることはできません。",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Camo PIN と Bio 保護の競合。",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "カモフラージュ PIN の変更",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "カモフラージュ PIN の作成",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "カモフラージュ PIN でアプリのロックを解除すると、偽の LOW 残高が表示され、カモフラージュ PIN 構成オプションは設定に表示されません。",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "カモフラージュ PIN が無効です",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "カモフラージュ PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "カモフラージュ PIN が見つかりません",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "オフ",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "の上",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "カモフラージュ PIN を保存しました",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "カモフラージュ PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "新しいカモフラージュ PIN を入力してください",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "カモフラージュ PIN の設定",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "カモフラージュ PIN の設定",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "キャンセル",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "キャンセル",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "注文をキャンセルする",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "エラーが発生しました。あとでもう一度試してみてください。",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ok",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "デフォルトのコインです。デフォルトのコインを無効にすることはできません。",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "無効にできません",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "それは再生できません",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEX為替レート",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "CEXデータ",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "このアイコンでマークされた市場データ (価格、チャートなど) は、サードパーティのソース (<a href=\"https://www.coingecko.com/\">coingecko.com</a>、<a href=\" https://openrates.io/\">openrates.io</a>)。",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "CEXレート",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "PIN コードの変更",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "アップデートを確認",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "チェックアウト",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "シード フレーズを確認する",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "継続する",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "戻ってもう一度確認する",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "{index}単語を入力してください",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "シード フレーズは重要です。そのため、正確であることを確認したいと考えています。いつでも簡単にウォレットを復元できるように、シード フレーズについて 3 つの異なる質問をします。",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "シード フレーズの {index} 単語は何ですか?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "シードフレーズを再確認しましょう",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "中国語",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "請求",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "KMD 報酬を受け取りますか？",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "クリックしてご覧ください",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "クリップボードにコピーしました",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "クリップボードにコピー",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "近い",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "エラーメッセージを閉じる",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "プレビューを閉じる",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "コード：",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "アセットの最大数を選択しました",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "{protocolName} コインが有効化されました",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName} コインが正常に有効化されました",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "{protocolName} コインは有効化されていません",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "クリア",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "アクティブなコインはありません",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "コインを選択",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "近日公開...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "TXの詳細は近日公開！",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "詳細は近日公開！",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "手数料",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "平均と比較して。 24時間CEX価格",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "CEXとの比較",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "ウォレットを設定しています。お待ちください...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "確認",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "カモフラージュ PIN の確認",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "注文をキャンセルしてもよろしいですか",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "下のボタンをクリックすることで、「EULA」と「利用規約」を読んだことを確認し、これらに同意したことになります",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "パスワードを認証する",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "PIN コードの確認",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "シード フレーズの確認",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "接続中...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "キャンセル",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "連絡先を削除",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "消去",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "連絡先 {name} を削除してもよろしいですか?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "破棄",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "編集",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "出口",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "変更を破棄しますか?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "連絡先が見つかりません",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "保存",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "連絡先の詳細",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "名前",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "契約",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "変換",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "URLを起動できませんでした",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "インポートできませんでした:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "トレード",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "ウォレットを作成する",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "連絡先の作成",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "PIN の作成",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "通貨",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "通貨",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "現在の価値：",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "カスタム料金",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "あなたが何をしているのかを知っている場合にのみ、カスタム料金を使用してください!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "カスタム シード フレーズは、生成された BIP39 準拠のシード フレーズまたは秘密鍵 (WIF) よりも安全性が低く、クラックされやすい可能性があります。リスクを理解し、自分が何をしているかを理解していることを確認するには、下のボックスに「{iUnderstand}」と入力してください。",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "日にち",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "ウォレットの復号化",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "消去",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "非アクティブ化の確認",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "削除しますか",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "ポートフォリオから？一致しない注文はすべてキャンセルされます。",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " も無効化されます",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "ウォレットの削除",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "ウォレットを削除しています...",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "{coinName} の取引手数料を受け取る",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "{coinName} の取引手数料を送信します",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "送信取引手数料 取引手数料",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "取引手数料",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "詳細",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "ドイツ語",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "デベロッパー",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "デックス",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "このコインではDEXは利用できません",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "スクリーンショット/プレビューを無効にする",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "免責事項と利用規約",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "終わり",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "アプリを閉じないでください。詳細についてはタップしてください...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "二度と聞かない",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "パスワードはいらない",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo dPoW セキュリティ",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "間隔",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "連絡先を編集",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "入力 {abbr} アドレス",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "暗号化パスワードを空にすることはできません",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "パスワードを空にすることはできません",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "連絡先の名前を空にすることはできません",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "ウォレット名を空にすることはできません",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "{remains} を引き続き有効にすることができます。選択済み: {selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "アクティベーションの進行状況に関する最新情報を取得するには、通知を有効にしてください。",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "テストコインを有効にする",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "あなたが持っている",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "アセットが有効になっており、有効にしようとしています",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "もっと。有効なアセットの上限は",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": ".新しいものを追加する前に、いくつかを無効にしてください。",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "あまりにも多くのアセットを有効にしようとしています",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "暗号化ウォレット",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "英語",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "新しい PIN を入力してください",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "古い PIN を入力してください",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "続行するには、パスワードを入力してください。",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "PINコードを入力してください",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "シードフレーズを入力してください",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "最初に販売金額を入力する必要があります",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "バランスが足りない",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "有効な住所ではありません",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Segwit アドレスはサポートされていません (まだ)",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "ガスが不足しています - 少なくとも {gas} Gwei を使用してください",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "エラーです。もう一度お試しください",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "エラーです。後で試してください",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "値が高すぎるか低すぎる",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "データを入力してください",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "推定合計値",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "例: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "都合のよい",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "高い",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "CEXと同じ",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "為替レート：",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "両替",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "書き出す",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "連絡先",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "暗号化ファイルにエクスポートするアイテムを選択してください。",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "書き出す",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "ノート",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "アイテムは正常にエクスポートされました:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "スワップ",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "書き出す",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "失敗した",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "偽の残高:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "よくある質問",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "エラー",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "{coin} フォーセットにリクエストを送信しています...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "蛇口",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "成功",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "要求がタイムアウトしました",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "ログファイルの共有",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "ニュース",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "ここには何もない",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} ニュース",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "続きを読む...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "餌",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "ニュースフィード",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "ニュースの更新を続行できません",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "ニュースの更新を取得できません",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "ニュースフィードが更新されました",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "すでに最新",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "料金は {value} までである必要があります",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "全て",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "フィルター",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "すべてのフィルターをクリア",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "失敗した",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "開始日",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "メーカー",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "コインを受け取る",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "コインを売る",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "状態",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "成功",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "テイカー",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "現在まで",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "テイカー/メーカー",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "指紋",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "完了しました、お待ちください",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "QRコードが見つかりました",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "フランス語",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "から",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} 手数料",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "ガスリミット",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "{coin}をアクティベートしてください。",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "ガス料金",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "一般的な PIN 保護はアクティブではありません。カモフラージュモードは利用できません。 PIN 保護を有効にしてください。",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "重要: 続行する前に、シード フレーズをバックアップしてください。",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "トランザクションを取得しています。お待ちください",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "ポートフォリオに移動",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "グウェイは {value} までである必要があります",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "ヘルプ",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "ヘルプとサポート",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "残高を非表示",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "パスワードを認証する",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "パスワードの作成",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "現在のパスワード",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "パスワードを入力してください",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "シード フレーズを入力してください",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "ウォレットに名前を付ける",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "パスワード",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "歴史",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "時間",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "ハンガリー語",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "輸入",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "無効なパスワードまたは破損したデータ",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "輸入する品目:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "ファイルが見つかりません",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "無効なスワップ データです。有効なスワップ ステータス JSON ファイルを提供してください。",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "輸入",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "インポートする暗号化ファイルを選択してください。",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "開いています...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "インポートするプレーン テキスト スワップ ファイルを選択してください。",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "キャンセル",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Ok",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "パスワード",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "シングル スワップのインポート",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "輸入スワップ",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "一部のアイテムがスキップされました",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "アイテムが正常にインポートされました:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "スワップのインポートに失敗しました",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "json ファイルのデコード中にエラーが発生しました",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "輸入",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "受信 {coinName} txs 保護設定",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "安全なパスワードを使用し、同じデバイスに保存しないでください",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "スワップリクエストは元に戻すことができず、最終イベントです!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "スワップには最大 60 分かかる場合があります。このアプリケーションを閉じないでください！",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "セキュリティ上の理由から、ウォレット暗号化用のパスワードを提供する必要があります。",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} 取引手数料を支払うのに十分な残高がありません",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "この注文に必要な最小ボリュームは",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "ボリューム不足",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "リフレッシュ",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "インターネット接続が回復しました",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "スワップを続行できません",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "詳細",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} は利用できません:(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "理解します",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "日本",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "韓国語",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "言語",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "最新の取引",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "法的",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "以下",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗注意！ {coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "制限は最大 {value} である必要があります",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "読み込んでいます...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "オーダーブックを読み込んでいます...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "画面がロックされています",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "認証してください！",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "ログインする",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "ログアウト",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "終了時にログアウト",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "ログアウト設定",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "今すぐログアウトしてもよろしいですか?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "分",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "注文する",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "メーカー",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "注文をキャンセルする",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "で作成",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "受け取る",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "オーダーID",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "この注文で開始されたスワップはありません",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "価格",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "売る",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "この注文で開始されたスワップ",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "メーカー注文内容",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "メーカー注文",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "市場",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "チャート",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "深さ",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "質問が見つかりません",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "入札が見つかりませんでした",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "オーダーブック",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "注文詳細",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "価格",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "コインを選択してください",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "マーケット",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "市場",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "パスワードが一致する必要があります",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "変化する",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "一般暗証番号とカモフラージュ暗証番号は同じです。カモフラージュモードは利用できません。カモフラージュ PIN を変更してください。",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "無効な PIN",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "最大",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "最大注文量:",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "ニュース",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "ブラウズ",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "フィードを閲覧します",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "に",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "保存した記事はありません",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "保存しました",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "メモ",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "マージ",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "マージされた値:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "MS",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "最小",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "警告: iOS でアプリを最小化すると、アクティベーション プロセスが終了します。",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "最小注文量:",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "メートル",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "最低販売額は {number} {coinName} です",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "最低購入金額は {number} {coinName} です",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "注文の最小額は {buyAmount} {buyCoin} ({sellAmount} {sellCoin}) です",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "最低販売額は {number} {coinName} です",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "{minValue} {coin} より大きくなければなりません",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "販売額より低くなければなりません",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "必要な最小ボリューム",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "カスタム最小ボリュームを使用",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "現在、携帯データ ネットワークを使用しており、{appName} P2P ネットワークに参加すると、インターネット トラフィックが消費されることに注意してください。携帯電話のデータ プランが高額な場合は、WiFi ネットワークを使用することをお勧めします。",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "より詳しい情報",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "もっと",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "最初に {coin} を有効にして、残高をチャージしてください",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "額",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "コイン",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "売る",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "キャンセル",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "確認",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "{number} オーダーを作成:",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "作成",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "注文",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "注文",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "費用",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "キャンセル",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "受け取る金額を入力してください:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "オートフィル",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "続行する前にすべてのエラーを修正してください",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "金額が無効です",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "販売金額が無効です",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "料金を支払うのに十分な {coin} がありません。 MIN 残高は {fee} {coin} です",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin} の残高が少なすぎます",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "最大販売額は",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "最小受け取り金額は",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "最小販売額は",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "受け取る：",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "売る：",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "マルチ",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "金額を受け取ります。",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "価格/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "ネットワーク料金",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "新しいアカウント",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "新しいアカウント",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "ニュースフィード",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "新しい値:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "次",
-    "@next": {
-        "type": "text"
-    },
-    "no": "いいえ",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "ニュースはありません。後でもう一度確認してください。",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "コインが見つかりません",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "資金がない",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "資金がありません - 入金してください。",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "インターネット接続なし",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "項目が選択されていません",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "項目が選択されていません",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "一致する注文が見つかりません",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "なし",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "値は数値でなければなりません",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "{coinName} の金額を入力してください。",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "クリックして注文を作成",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "注文はありません。取引に行ってください。",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "請求可能な報酬はありません",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "報酬は請求できません - 1 時間後にもう一度お試しください。",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "そのようなコインはありません",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "履歴はありません。",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "取引に十分な {coin} がありません!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "手数料に十分な残高がありません - 少額で取引してください",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "注: 一致した注文は再度キャンセルできません",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "メモを追加",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "ノート",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "何も見つかりません",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "{sell}/{buy} スワップが正常に完了しました",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "スワップ完了",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} スワップに失敗しました",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "スワップに失敗しました",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} スワップ開始",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "新しいスワップが開始されました",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "スワップ ステータスが変更されました",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} スワップがタイムアウトしました",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "スワップ タイムアウト",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "{coin} のトランザクションを受け取りました!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "着信トランザクション",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "取引なし",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} アセット",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "公式プレスリリース",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Ok",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "消去",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "古いログ",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "使用スペース",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "エラーメッセージを開く",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "オプション",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "少ない",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "もっと",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "{coin} の注文はすべてキャンセルされます。",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "オーダーが作成されました",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "注文が正常に作成されました",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "住所",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "キャンセル",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "便宜: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "高価: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "為に",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "CEXと同じ",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "分。",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "価格",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "受け取る",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "選択する",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "売る",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "シングルタップで詳細を開き、ロングタップで注文を選択します",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "費やす",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "詳細",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% 埋められました",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "一致した注文",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "オーダーマッチング",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "注文",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "アクティブ",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "歴史",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "金額 ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "価格 ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "合計 ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "注文",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "不明な型順",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "上書き",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "これはあなた自身の注文です！",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "残高から支払われる:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "受け取ったボリュームから支払われる:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "で支払った",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "パスワードには、小文字 1 つ、大文字 1 つ、特殊記号 1 つを含む 12 文字以上を含める必要があります。",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "支払い",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "この取引を受け入れますか？",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "住所へ",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "額：",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "コイン：",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "キャンセル",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "支払いが要求されました",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} はアクティブではありません。有効にしてからもう一度お試しください。",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "ご注文",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "フルボリュームで再生",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "コインを追加してください",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "アプリを再起動してもう一度試すか、下のボタンを押してください。",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "ポートフォリオ",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "コモドによって供給",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "価格",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "秘密鍵",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "秘密鍵",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "確認",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "カスタム保護設定を使用する",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "オフ",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "オン",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "警告、このアトミック スワップは dPoW で保護されていません。",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "公開鍵",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "QRコードスキャナー",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "私の秘密鍵を保管しますか?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "{appName} を使用できるデバイスはどれですか?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "{appName} での取引は、他の DEX での取引とどう違うのですか?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "各アトミック スワップにはどのくらいの時間がかかりますか?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "スワップ中はオンラインである必要がありますか?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "{appName} の料金はどのように計算されますか?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "ユーザーサポートは提供していますか？",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "国の制限はありますか？",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "{appName} の背後にいるのは誰ですか?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "{appName} で独自のホワイトラベル取引所を開発することは可能ですか?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "新しい時代です！ 「AtomicDEX」から「Komodo Wallet」に正式に名前を変更しました",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "受け取る",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "受け取る",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "オフラインで保存することをお勧めします。",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "無効にする",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "依頼された取引",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "クリア",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "フォームをリセット",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "戻す",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "すべてのコインの有効化を再試行しています...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "すべてのアクティブ化を再試行",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "報酬を受け取る",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "キャンセル",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "エラーが発生しました。後でもう一度やり直してください。",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "取引が進行中です",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "処理",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXOの金額が10KMD未満",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "まだ1時間が経過していない",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1時間",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "Ok",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "報酬ステータス:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "KMDアクティブユーザー特典について詳しく見る",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "受け取る",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "成功！ {amount} KMD を受け取りました。",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "フィアット",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "リワード、KMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "状態",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "残り時間",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "特典情報:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO金額、KMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} 日",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}時 {minutes}分",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}分",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "特典情報",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "ロシア",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "結合して保存",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "続行するには一番下までスクロールします...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "コインを探す",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "すべての Avax トークンを選択",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "すべての BEP トークンを選択",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "すべて選択 コスモネットワーク",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "すべてのERCトークンを選択",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "すべてのETCトークンを選択",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "すべてのファントムトークンを選択",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "すべての HecoChain トークンを選択",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "すべてのハーモニートークンを選択",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "アイリスネットワークをすべて選択",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "すべての Kucoin トークンを選択",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "ムーンリバートークンをすべて選択",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "すべてのポリゴン トークンを選択する",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "すべての QRC トークンを選択",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "すべての SmartBCH トークンを選択",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "すべての SLP トークンを選択します",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "すべての SmartChain を選択",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "すべてのテスト アセットを選択",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "すべての Ubiq コインを選択",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "すべてのUTXOコインを選択",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "すべての ZHTLC コインを選択します",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "ティッカーを検索",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "安全",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "シードフレーズ",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "あなたの新しいシードフレーズ",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "クリックして {amount} 件の注文を表示",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "取引履歴を見る",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "コインを選択",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "ポートフォリオに追加するコインを選択します。",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "コインを有効にする:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "購入したいコインを選択",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "売りたいコインを選択",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "選択した注文:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "ファイルを選ぶ",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "言語を選択する",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "お支払い方法を選択してください",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "売る",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "警告、実際の価値のないテスト コインを販売しても構わないと思っています。",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "送信",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "消去してもよろしいですか",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "財布？",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "もしそうなら、あなたを確認してください",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "シード フレーズを記録します。",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "将来的にウォレットを復元するため。",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "言語",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "設定",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "パスワードを設定する",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "シェア",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "私の {coinName} アドレス: \n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "住所を表示",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "詳細を表示",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "{maxCount} 件中 {count} 件の注文を表示しています。",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "私の注文を表示",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "パスワードでサインイン",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "パスワードをお忘れですか？シードからウォレットを復元する",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "単純",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "活性化",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "購入する{coin}の金額を入力してください",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "買う",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "近い",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "アクティブなコインの最大数は {maxCoins} です。いくつか無効にしてください。",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} はアクティブではありません!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "受け取る",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "売却する{coin}の金額を入力してください",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "売る",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "送信",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "表示を減らす",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "もっと見せる",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "{coin} をアクティベートできません",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "スキップ",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "解散",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "音",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "mp3またはwavファイルを選択してください。 {description} になったら再生します。",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "{description} の場合にプレイ",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "サウンド",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "了解しました もう表示しないでください",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "音",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "サウンド設定",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "スワップ プロセス中、およびアクティブなメーカー注文が行われると、サウンド通知が聞こえます。アトミック スワップ プロトコルでは、取引を成功させるには参加者がオンラインである必要があり、サウンド通知はそれを達成するのに役立ちます。",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "アプリケーション設定でカスタムサウンドを設定できることに注意してください。",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "スペイン語",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "スワップの開始",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "ステップ",
-    "@step": {
-        "type": "text"
-    },
-    "success": "成功！",
-    "@success": {
-        "type": "text"
-    },
-    "support": "サポート",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "ご不明な点がある場合、または {appName} アプリで技術的な問題を発見したと思われる場合は、報告してチームからサポートを受けることができます。",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "スワップ",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "現時点の",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "交換の詳細を確認する",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "見積もり",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "スワップに失敗しました",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "最初に {coin} を有効にして残高をチャージしてください",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "{coin} の残高は、取引手数料を支払うのに十分ではありません。",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "{coin} の残高は、取引手数料を支払うのに十分ではありません。{coin} {amount} が必要です。",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "スワップ進行中",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "進捗詳細",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "開始",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "スワップ成功",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "合計",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "UUIDを入れ替える",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "テーマを切り替える",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "テイカー",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "テイカーオーダー",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "タイムアウト",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "パスワードを作成",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "注文が選択されました",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "に",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "対処するには:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "あなたが持っている",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "アセットが有効になっています。有効なアセットの上限は",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ".新しいものを追加する前に、いくつかを無効にしてください。",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "有効なアセットが多すぎます",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "合計料金:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "トレード",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "スワップ完了！",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "取引詳細",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "取引手数料の計算に失敗しました",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "取引手数料:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "取引モード:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "取引アドレス",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "非表示のトランザクション",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "このトランザクションはフィッシングの可能性があるため非表示になりました。",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "それでも一部のコインが有効化されない場合は、アプリを再起動してみてください。",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "トルコ語",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "ブロック",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "確認",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "確認済み",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "費用",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "取引手数料：",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "取引ID",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "残りのトランザクション: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "リクエストが多すぎます。トランザクション履歴リクエストの制限を超えました。後でもう一度やり直してください。",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "未確認",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "ウクライナ語",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "ロックを解除",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "資金のロックを解除",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "{amnt} 資金のロックを解除しました - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "使えない",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "新しいバージョンが利用可能",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "アップデートの確認...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "バージョン {version} を使用しています",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "新しいバージョンが利用可能です。更新してください。",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "バージョン {version} が利用可能です。更新してください。",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "利用可能なアップデート",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "今のところスキップ",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "{appName} の更新",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "アップデート",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "すでに最新",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "スキャンするのに十分な残高がありません",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "支払い要求。",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "残高不足",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "価値：",
-    "@value": {
-        "type": "text"
-    },
-    "version": "バージョン",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "冒険者",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "シードと秘密鍵",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "ボリューム",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "ウォレット名はすでに使用されています",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "ウォレット名は最大 40 文字にする必要があります",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "ウォレットのみ",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "警告！",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Ok",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "警告 - 特殊なケースでは、このログ データには機密情報が含まれており、失敗したスワップからのコインの使用に使用できる可能性があります。",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "{coinAbbr} をアクティベートできませんでした",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "{coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} モバイルは、ネイティブの第 3 世代 DEX 機能などを備えた次世代のマルチコイン ウォレットです。",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "セットアップしましょう！",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "ようこそ",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "財布",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "完了すると、ポートフォリオ ページにリダイレクトされます。",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "これには時間がかかるため、アプリをフォアグラウンドに維持する必要があります。\nアクティベーションの進行中にアプリを終了すると、問題が発生する可能性があります。",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "撤退",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "以前にカメラへの {appName} アクセスを拒否しました。 QR コードのスキャンを続行するには、電話の設定でカメラの許可を手動で変更してください。",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "アクセスが拒否されました",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "出金確認",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "エラーが発生しました。あとでもう一度試してみてください。",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "WITHDRAW {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "の支払い QR コードをスキャンしようとしています",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "しかし、あなたは上にいます",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "画面を撤回",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "間違ったコイン",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "パスワードが一致しません。もう一度やり直してください。",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "はい",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "あなたが送っているもの:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "既存の注文と一致させようとしている新しい注文があります",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "アクティブなスワップが進行中です",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "新しい注文と一致する注文があります",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "あなたの財布",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "{amount} {coin} を受け取ります",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "受け取るもの:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "ja",
+  "accepteula": "EULA に同意する",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "利用規約に同意する",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "生体認証保護を有効にする",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "PIN 保護を有効にする",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "{protocolName} コインをアクティブにしますか?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "{coinName}をアクティブ化しています",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName} のアクティベーション",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} のアクティベーションが進行中です",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "アクティブ",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "コインを有効にする",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} の有効化に成功しました!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "住所を追加",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "住所録",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "アドレス帳が空です",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "{title} 住所の連絡先のみを表示",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "住所録",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "{abbr} が有効化されていないため、{abbr} アドレスに送金できません。ポートフォリオへどうぞ。",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "何も見つかりません",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "コインを選択",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "受取人住所",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "高度",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "全て",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "カスタム シードを許可する",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "ウォレットには過去の取引が表示されます。すべてのブロックがダウンロードされてスキャンされるため、これにはかなりのストレージと時間がかかります。",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "もう存在している",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "額",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "売却金額",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "いいえ！ {appName} は非親権者です。秘密鍵、シード フレーズ、PIN などの機密データを保存することはありません。このデータはユーザーのデバイスにのみ保存され、デバイスから離れることはありません。あなたは自分の資産を完全に管理しています。",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} は、モバイルでは Android と iPhone の両方で利用でき、デスクトップでは <a href=\"https://komodoplatform.com/\">Windows、Mac、Linux オペレーティング システム</a> で利用できます。",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "他の DEX では通常、単一のブロックチェーン ネットワークに基づく資産の取引のみが許可され、プロキシ トークンが使用され、同じ資金で単一の注文のみが許可されます。 {appName} を使用すると、プロキシ トークンを使用せずに、2 つの異なるブロックチェーン ネットワーク間でネイティブに取引できます。同じ資金で複数の注文を出すこともできます。たとえば、KMD、QTUM、または VRSC で 0.1 BTC を販売できます。最初に約定した注文は、他のすべての注文を自動的にキャンセルします。",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "各スワップの処理時間は、いくつかの要因によって決まります。取引された資産のブロック時間は、各ネットワークによって異なります (通常、ビットコインが最も遅いです)。さらに、ユーザーはセキュリティ設定をカスタマイズできます。たとえば、{appName} に、わずか 3 回の確認後に KMD トランザクションを最終と見なすように依頼できます。これにより、<a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">公証</a>。",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "はい。各アトミック スワップを正常に完了するには、インターネットへの接続を維持し、アプリを実行している必要があります (通常、接続が非常に短時間中断しても問題ありません)。そうしないと、Maker の場合は取引キャンセルのリスクがあり、Taker の場合は資金を失うリスクがあります。アトミック スワップ プロトコルでは、両方の参加者がオンライン状態を維持し、関与するブロックチェーンを監視して、プロセスがアトミック状態を維持する必要があります。",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "{appName} で取引する際に考慮すべき 2 つの手数料カテゴリがあります。 1. {appName} は、テイカー オーダーの取引手数料として約 0.13% (取引量の 1/777、ただし 0.0001 以上) を請求し、メイカー オーダーの手数料はゼロです。 2. メーカーとテイカーの両方が、アトミック スワップ トランザクションを行う際に、関連するブロックチェーンに通常のネットワーク料金を支払う必要があります。ネットワーク手数料は、選択した取引ペアによって大きく異なります。",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "はい！ {appName} は、<a href=\"{link}\">{appCompanyShort} {name}</a> を通じてサポートを提供しています。チームとコミュニティはいつでも喜んでお手伝いします!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "いいえ！ {appName} は完全に分散化されています。第三者によるユーザー アクセスを制限することはできません。",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} は {appCompanyShort} チームによって開発されました。 {appCompanyShort} は、アトミック スワップ、Delayed Proof of Work、相互運用可能なマルチチェーン アーキテクチャなどの革新的なソリューションに取り組んでいる、最も確立されたブロックチェーン プロジェクトの 1 つです。",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "絶対！詳細については、<a href=\"https://developers.komodoplatform.com/\">開発者向けドキュメント</a>をご覧いただくか、パートナーシップに関するお問い合わせでご連絡ください。特定の技術的な質問がありますか? {appName} 開発者コミュニティはいつでもお手伝いいたします。",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "拍手",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "本気ですか？",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "スワップが失敗する",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "スワップは完了するまで実行されます",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "認証する",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "アクティベーションの再試行プロセスが完了すると、ポートフォリオ ページに自動的にリダイレクトされます。",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "最大ボリューム",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "戻る",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "バックアップ",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "{coinName1}/{coinName2} に基づく",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "交換を安全に行うには、バッテリーの充電が重要です ({batteryLevelCritical}%)。充電してからもう一度お試しください。",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "バッテリーの充電が {batteryLevelLow}% 未満です。電話の充電を検討してください。",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "お使いの携帯電話はバッテリー節約モードになっています。このモードを無効にするか、アプリケーションをバックグラウンドにしないでください。そうしないと、アプリが OS によって強制終了され、スワップが失敗する可能性があります。",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "為替レート",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "コモドに建てられた",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "コモドに建てられた",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "買う",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "一致しない場合はMakerに変換",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "スワップが発行されました。お待ちください!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "オーダーマッチが進行中です。{seconde} 秒お待ちください!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "警告、本当の価値のないテスト コインを購入しても構わないと思っています。",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "カモフラージュ PIN とバイオ プロテクションを同時に有効にすることはできません。",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Camo PIN と Bio 保護の競合。",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "カモフラージュ PIN の変更",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "カモフラージュ PIN の作成",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "カモフラージュ PIN でアプリのロックを解除すると、偽の LOW 残高が表示され、カモフラージュ PIN 構成オプションは設定に表示されません。",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "カモフラージュ PIN が無効です",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "カモフラージュ PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "カモフラージュ PIN が見つかりません",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "オフ",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "の上",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "カモフラージュ PIN を保存しました",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "カモフラージュ PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "新しいカモフラージュ PIN を入力してください",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "カモフラージュ PIN の設定",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "カモフラージュ PIN の設定",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "キャンセル",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "アクティベーションのキャンセル",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "アクティベーションをキャンセルしてもよろしいですか?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "キャンセル",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "注文をキャンセルする",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "エラーが発生しました。あとでもう一度試してみてください。",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ok",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "デフォルトのコインです。デフォルトのコインを無効にすることはできません。",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "無効にできません",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "それは再生できません",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEX為替レート",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "CEXデータ",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "このアイコンでマークされた市場データ (価格、チャートなど) は、サードパーティのソース (<a href=\"https://www.coingecko.com/\">coingecko.com</a>、<a href=\" https://openrates.io/\">openrates.io</a>)。",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "CEXレート",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "PIN コードの変更",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "アップデートを確認",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "チェックアウト",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "シード フレーズを確認する",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "継続する",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "戻ってもう一度確認する",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "{index}単語を入力してください",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "シード フレーズは重要です。そのため、正確であることを確認したいと考えています。いつでも簡単にウォレットを復元できるように、シード フレーズについて 3 つの異なる質問をします。",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "シード フレーズの {index} 単語は何ですか?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "シードフレーズを再確認しましょう",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "中国語",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "請求",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "KMD 報酬を受け取りますか？",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "クリックしてご覧ください",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "クリップボードにコピーしました",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "クリップボードにコピー",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "近い",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "エラーメッセージを閉じる",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "プレビューを閉じる",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "コード：",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "アクティベーションをキャンセルしてもよろしいですか?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "アセットの最大数を選択しました",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "{protocolName} コインが有効化されました",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} コインが正常に有効化されました",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "{protocolName} コインは有効化されていません",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "クリア",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "アクティブなコインはありません",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "コインを選択",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "近日公開...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "TXの詳細は近日公開！",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "詳細は近日公開！",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "手数料",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "平均と比較して。 24時間CEX価格",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "CEXとの比較",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "ウォレットを設定しています。お待ちください...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "確認",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "カモフラージュ PIN の確認",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "注文をキャンセルしてもよろしいですか",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "下のボタンをクリックすることで、「EULA」と「利用規約」を読んだことを確認し、これらに同意したことになります",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "パスワードを認証する",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "PIN コードの確認",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "シード フレーズの確認",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "接続中...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "キャンセル",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "連絡先を削除",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "消去",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "連絡先 {name} を削除してもよろしいですか?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "破棄",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "編集",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "出口",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "変更を破棄しますか?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "連絡先が見つかりません",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "保存",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "連絡先の詳細",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "名前",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "契約",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "変換",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "URLを起動できませんでした",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "インポートできませんでした:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "トレード",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "ウォレットを作成する",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "連絡先の作成",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "PIN の作成",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "通貨",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "通貨",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "現在の価値：",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "カスタム料金",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "あなたが何をしているのかを知っている場合にのみ、カスタム料金を使用してください!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "カスタム シード フレーズは、生成された BIP39 準拠のシード フレーズまたは秘密鍵 (WIF) よりも安全性が低く、クラックされやすい可能性があります。リスクを理解し、自分が何をしているかを理解していることを確認するには、下のボックスに「{iUnderstand}」と入力してください。",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "日にち",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "ウォレットの復号化",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "消去",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "非アクティブ化の確認",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "削除しますか",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "ポートフォリオから？一致しない注文はすべてキャンセルされます。",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " も無効化されます",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "ウォレットの削除",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "ウォレットを削除しています...",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "{coinName} の取引手数料を受け取る",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "{coinName} の取引手数料を送信します",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "送信取引手数料 取引手数料",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "取引手数料",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "詳細",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "ドイツ語",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "デベロッパー",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "デックス",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "このコインではDEXは利用できません",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "スクリーンショット/プレビューを無効にする",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "免責事項と利用規約",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "終わり",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "アプリを閉じないでください。詳細についてはタップしてください...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "二度と聞かない",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "パスワードはいらない",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo dPoW セキュリティ",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "間隔",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "連絡先を編集",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "入力 {abbr} アドレス",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "暗号化パスワードを空にすることはできません",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "パスワードを空にすることはできません",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "連絡先の名前を空にすることはできません",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "ウォレット名を空にすることはできません",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "{remains} を引き続き有効にすることができます。選択済み: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "アクティベーションの進行状況に関する最新情報を取得するには、通知を有効にしてください。",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "テストコインを有効にする",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "あなたが持っている",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "アセットが有効になっており、有効にしようとしています",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "もっと。有効なアセットの上限は",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": ".新しいものを追加する前に、いくつかを無効にしてください。",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "あまりにも多くのアセットを有効にしようとしています",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "暗号化ウォレット",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "英語",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "新しい PIN を入力してください",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "古い PIN を入力してください",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "続行するには、パスワードを入力してください。",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "PINコードを入力してください",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "シードフレーズを入力してください",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "最初に販売金額を入力する必要があります",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "バランスが足りない",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "有効な住所ではありません",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Segwit アドレスはサポートされていません (まだ)",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "ガスが不足しています - 少なくとも {gas} Gwei を使用してください",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "エラーです。もう一度お試しください",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "エラーです。後で試してください",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "値が高すぎるか低すぎる",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "データを入力してください",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "推定合計値",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "例: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "都合のよい",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "高い",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "CEXと同じ",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "為替レート：",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "両替",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "書き出す",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "連絡先",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "暗号化ファイルにエクスポートするアイテムを選択してください。",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "書き出す",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "ノート",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "アイテムは正常にエクスポートされました:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "スワップ",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "書き出す",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "失敗した",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "偽の残高:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "よくある質問",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "エラー",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "{coin} フォーセットにリクエストを送信しています...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "蛇口",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "成功",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "要求がタイムアウトしました",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "ログファイルの共有",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "ニュース",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "ここには何もない",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} ニュース",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "続きを読む...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "餌",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "ニュースフィード",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "ニュースの更新を続行できません",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "ニュースの更新を取得できません",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "ニュースフィードが更新されました",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "すでに最新",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "料金は {value} までである必要があります",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "全て",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "フィルター",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "すべてのフィルターをクリア",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "失敗した",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "開始日",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "メーカー",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "コインを受け取る",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "コインを売る",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "状態",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "成功",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "テイカー",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "現在まで",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "テイカー/メーカー",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "指紋",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "完了しました、お待ちください",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "QRコードが見つかりました",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "フランス語",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "から",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "公開キーに関連付けられたアクティベーション後に行われる今後のトランザクションは同期されます。これは最も迅速なオプションであり、必要なストレージの量も最小限です。",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} 手数料",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "ガスリミット",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "{coin}をアクティベートしてください。",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "ガス料金",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "一般的な PIN 保護はアクティブではありません。カモフラージュモードは利用できません。 PIN 保護を有効にしてください。",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "重要: 続行する前に、シード フレーズをバックアップしてください。",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "トランザクションを取得しています。お待ちください",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "ポートフォリオに移動",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "グウェイは {value} までである必要があります",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "ヘルプ",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "ヘルプとサポート",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "残高を非表示",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "パスワードを認証する",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "パスワードの作成",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "現在のパスワード",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "パスワードを入力してください",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "シード フレーズを入力してください",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "ウォレットに名前を付ける",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "パスワード",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "歴史",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "時間",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "ハンガリー語",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "輸入",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "無効なパスワードまたは破損したデータ",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "輸入する品目:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "ファイルが見つかりません",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "無効なスワップ データです。有効なスワップ ステータス JSON ファイルを提供してください。",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "輸入",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "インポートする暗号化ファイルを選択してください。",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "開いています...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "インポートするプレーン テキスト スワップ ファイルを選択してください。",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "キャンセル",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Ok",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "パスワード",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "シングル スワップのインポート",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "輸入スワップ",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "一部のアイテムがスキップされました",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "アイテムが正常にインポートされました:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "スワップのインポートに失敗しました",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "json ファイルのデコード中にエラーが発生しました",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "輸入",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "受信 {coinName} txs 保護設定",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "安全なパスワードを使用し、同じデバイスに保存しないでください",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "スワップリクエストは元に戻すことができず、最終イベントです!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "スワップには最大 60 分かかる場合があります。このアプリケーションを閉じないでください！",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "セキュリティ上の理由から、ウォレット暗号化用のパスワードを提供する必要があります。",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} 取引手数料を支払うのに十分な残高がありません",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "この注文に必要な最小ボリュームは",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "ボリューム不足",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "リフレッシュ",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "インターネット接続が回復しました",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "無効な {coin} アドレスです",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "スワップを続行できません",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "詳細",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} は利用できません:(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "理解します",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "日本",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "韓国語",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "言語",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "最新の取引",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "法的",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "以下",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗注意！ {coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "制限は最大 {value} である必要があります",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "読み込んでいます...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "オーダーブックを読み込んでいます...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "画面がロックされています",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "認証してください！",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "ログインする",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "ログアウト",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "終了時にログアウト",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "ログアウト設定",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "今すぐログアウトしてもよろしいですか?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "分",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "注文する",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "メーカー",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "注文をキャンセルする",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "で作成",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "受け取る",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "オーダーID",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "この注文で開始されたスワップはありません",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "価格",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "売る",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "この注文で開始されたスワップ",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "メーカー注文内容",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "メーカー注文",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "市場",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "チャート",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "深さ",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "質問が見つかりません",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "入札が見つかりませんでした",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "オーダーブック",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "注文詳細",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "価格",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "コインを選択してください",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "マーケット",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "市場",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "パスワードが一致する必要があります",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "変化する",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "一般暗証番号とカモフラージュ暗証番号は同じです。カモフラージュモードは利用できません。カモフラージュ PIN を変更してください。",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "無効な PIN",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "最大",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "最大注文量:",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "ニュース",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "ブラウズ",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "フィードを閲覧します",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "に",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "保存した記事はありません",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "保存しました",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "メモ",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "マージ",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "マージされた値:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "MS",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "最小",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "警告: iOS でアプリを最小化すると、アクティベーション プロセスが終了します。",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "最小注文量:",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "メートル",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "最低販売額は {number} {coinName} です",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "最低購入金額は {number} {coinName} です",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "注文の最小額は {buyAmount} {buyCoin} ({sellAmount} {sellCoin}) です",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "最低販売額は {number} {coinName} です",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "{minValue} {coin} より大きくなければなりません",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "販売額より低くなければなりません",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "必要な最小ボリューム",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "カスタム最小ボリュームを使用",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "現在、携帯データ ネットワークを使用しており、{appName} P2P ネットワークに参加すると、インターネット トラフィックが消費されることに注意してください。携帯電話のデータ プランが高額な場合は、WiFi ネットワークを使用することをお勧めします。",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "より詳しい情報",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "もっと",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "最初に {coin} を有効にして、残高をチャージしてください",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "額",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "コイン",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "売る",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "キャンセル",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "確認",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "{number} オーダーを作成:",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "作成",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "注文",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "注文",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "費用",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "キャンセル",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "受け取る金額を入力してください:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "オートフィル",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "続行する前にすべてのエラーを修正してください",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "金額が無効です",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "販売金額が無効です",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "料金を支払うのに十分な {coin} がありません。 MIN 残高は {fee} {coin} です",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin} の残高が少なすぎます",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "最大販売額は",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "最小受け取り金額は",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "最小販売額は",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "受け取る：",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "売る：",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "マルチ",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "金額を受け取ります。",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "価格/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "ネットワーク料金",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "新しいアカウント",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "新しいアカウント",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "ニュースフィード",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "新しい値:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "次",
+  "@next": {
+    "type": "text"
+  },
+  "no": "いいえ",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "ニュースはありません。後でもう一度確認してください。",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "コインが見つかりません",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "資金がない",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "資金がありません - 入金してください。",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "インターネット接続なし",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "項目が選択されていません",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "項目が選択されていません",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "一致する注文が見つかりません",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "なし",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "値は数値でなければなりません",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "{coinName} の金額を入力してください。",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "クリックして注文を作成",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "注文はありません。取引に行ってください。",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "請求可能な報酬はありません",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "報酬は請求できません - 1 時間後にもう一度お試しください。",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "そのようなコインはありません",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "履歴はありません。",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "取引に十分な {coin} がありません!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "手数料に十分な残高がありません - 少額で取引してください",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "注: 一致した注文は再度キャンセルできません",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "メモを追加",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "ノート",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "何も見つかりません",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "{sell}/{buy} スワップが正常に完了しました",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "スワップ完了",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} スワップに失敗しました",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "スワップに失敗しました",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} スワップ開始",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "新しいスワップが開始されました",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "スワップ ステータスが変更されました",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} スワップがタイムアウトしました",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "スワップ タイムアウト",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "{coin} のトランザクションを受け取りました!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "着信トランザクション",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "取引なし",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} アセット",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "公式プレスリリース",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Ok",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "消去",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "古いログ",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "使用スペース",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "エラーメッセージを開く",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "オプション",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "少ない",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "もっと",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "{coin} の注文はすべてキャンセルされます。",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "オーダーが作成されました",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "注文が正常に作成されました",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "住所",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "キャンセル",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "便宜: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "高価: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "為に",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "CEXと同じ",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "分。",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "価格",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "受け取る",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "選択する",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "売る",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "シングルタップで詳細を開き、ロングタップで注文を選択します",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "費やす",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "詳細",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% 埋められました",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "一致した注文",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "オーダーマッチング",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "注文",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "アクティブ",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "歴史",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "金額 ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "価格 ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "合計 ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "注文",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "不明な型順",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "上書き",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "これはあなた自身の注文です！",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "残高から支払われる:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "受け取ったボリュームから支払われる:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "で支払った",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "パスワードには、小文字 1 つ、大文字 1 つ、特殊記号 1 つを含む 12 文字以上を含める必要があります。",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "ウォレットには、指定した日付以降に行われた過去の取引が表示されます。",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "支払い",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "この取引を受け入れますか？",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "住所へ",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "額：",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "コイン：",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "キャンセル",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "支払いが要求されました",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} はアクティブではありません。有効にしてからもう一度お試しください。",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "ご注文",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "フルボリュームで再生",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "コインを追加してください",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "アプリを再起動してもう一度試すか、下のボタンを押してください。",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "ポートフォリオ",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "コモドによって供給",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "価格",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "秘密鍵",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "秘密鍵",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "確認",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "カスタム保護設定を使用する",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "オフ",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "オン",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "警告、このアトミック スワップは dPoW で保護されていません。",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "公開鍵",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "QRコードスキャナー",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "私の秘密鍵を保管しますか?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "{appName} を使用できるデバイスはどれですか?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "{appName} での取引は、他の DEX での取引とどう違うのですか?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "各アトミック スワップにはどのくらいの時間がかかりますか?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "スワップ中はオンラインである必要がありますか?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "{appName} の料金はどのように計算されますか?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "ユーザーサポートは提供していますか？",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "国の制限はありますか？",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "{appName} の背後にいるのは誰ですか?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "{appName} で独自のホワイトラベル取引所を開発することは可能ですか?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "新しい時代です！ 「AtomicDEX」から「Komodo Wallet」に正式に名前を変更しました",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "受け取る",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "受け取る",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "オフラインで保存することをお勧めします。",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "無効にする",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "依頼された取引",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "クリア",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "フォームをリセット",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "戻す",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "すべてのコインの有効化を再試行しています...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "すべてのアクティブ化を再試行",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "報酬を受け取る",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "キャンセル",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "エラーが発生しました。後でもう一度やり直してください。",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "取引が進行中です",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "処理",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXOの金額が10KMD未満",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "まだ1時間が経過していない",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1時間",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "Ok",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "報酬ステータス:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "KMDアクティブユーザー特典について詳しく見る",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "受け取る",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "成功！ {amount} KMD を受け取りました。",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "フィアット",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "リワード、KMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "状態",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "残り時間",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "特典情報:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO金額、KMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} 日",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}時 {minutes}分",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}分",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "特典情報",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "ロシア",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "結合して保存",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "続行するには一番下までスクロールします...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "コインを探す",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "すべての Avax トークンを選択",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "すべての BEP トークンを選択",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "すべて選択 コスモネットワーク",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "すべてのERCトークンを選択",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "すべてのETCトークンを選択",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "すべてのファントムトークンを選択",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "すべての HecoChain トークンを選択",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "すべてのハーモニートークンを選択",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "アイリスネットワークをすべて選択",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "すべての Kucoin トークンを選択",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "ムーンリバートークンをすべて選択",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "すべてのポリゴン トークンを選択する",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "すべての QRC トークンを選択",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "すべての SmartBCH トークンを選択",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "すべての SLP トークンを選択します",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "すべての SmartChain を選択",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "すべてのテスト アセットを選択",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "すべての Ubiq コインを選択",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "すべてのUTXOコインを選択",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "すべての ZHTLC コインを選択します",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "ティッカーを検索",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "安全",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "シードフレーズ",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "あなたの新しいシードフレーズ",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "クリックして {amount} 件の注文を表示",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "取引履歴を見る",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "コインを選択",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "ポートフォリオに追加するコインを選択します。",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "コインを有効にする:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "購入したいコインを選択",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "売りたいコインを選択",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "日付を選択してください",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "選択した注文:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "ファイルを選ぶ",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "言語を選択する",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "お支払い方法を選択してください",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "売る",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "警告、実際の価値のないテスト コインを販売しても構わないと思っています。",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "送信",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "消去してもよろしいですか",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "財布？",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "もしそうなら、あなたを確認してください",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "シード フレーズを記録します。",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "将来的にウォレットを復元するため。",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "言語",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "設定",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "パスワードを設定する",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "シェア",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "私の {coinName} アドレス: \n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "過去の {coin} 取引をスキャンしますか?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "住所を表示",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "詳細を表示",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "{maxCount} 件中 {count} 件の注文を表示しています。",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "私の注文を表示",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "パスワードでサインイン",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "パスワードをお忘れですか？シードからウォレットを復元する",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "単純",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "活性化",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "購入する{coin}の金額を入力してください",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "買う",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "近い",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "アクティブなコインの最大数は {maxCoins} です。いくつか無効にしてください。",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} はアクティブではありません!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "受け取る",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "売却する{coin}の金額を入力してください",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "売る",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "送信",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "表示を減らす",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "もっと見せる",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "{coin} をアクティベートできません",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "スキップ",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "解散",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "音",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "mp3またはwavファイルを選択してください。 {description} になったら再生します。",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "{description} の場合にプレイ",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "サウンド",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "了解しました もう表示しないでください",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "音",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "サウンド設定",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "スワップ プロセス中、およびアクティブなメーカー注文が行われると、サウンド通知が聞こえます。アトミック スワップ プロトコルでは、取引を成功させるには参加者がオンラインである必要があり、サウンド通知はそれを達成するのに役立ちます。",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "アプリケーション設定でカスタムサウンドを設定できることに注意してください。",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "スペイン語",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "開始日",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "スワップの開始",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "ステップ",
+  "@step": {
+    "type": "text"
+  },
+  "success": "成功！",
+  "@success": {
+    "type": "text"
+  },
+  "support": "サポート",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "ご不明な点がある場合、または {appName} アプリで技術的な問題を発見したと思われる場合は、報告してチームからサポートを受けることができます。",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "スワップ",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "現時点の",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "交換の詳細を確認する",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "見積もり",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "スワップに失敗しました",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "最初に {coin} を有効にして残高をチャージしてください",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "{coin} の残高は、取引手数料を支払うのに十分ではありません。",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "{coin} の残高は、取引手数料を支払うのに十分ではありません。{coin} {amount} が必要です。",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "スワップ進行中",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "進捗詳細",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "開始",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "スワップ成功",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "合計",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "UUIDを入れ替える",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "テーマを切り替える",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "指定した日付から同期",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "苗木アクティベーションからの同期",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "新しいトランザクションを同期する",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "どの {name} トランザクションを同期しますか?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "テイカー",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "テイカーオーダー",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "タイムアウト",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "パスワードを作成",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "注文が選択されました",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "に",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "対処するには:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "あなたが持っている",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "アセットが有効になっています。有効なアセットの上限は",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ".新しいものを追加する前に、いくつかを無効にしてください。",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "有効なアセットが多すぎます",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "合計料金:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "トレード",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "スワップ完了！",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "取引詳細",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "取引手数料の計算に失敗しました",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "取引手数料:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "取引モード:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "取引アドレス",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "非表示のトランザクション",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "このトランザクションはフィッシングの可能性があるため非表示になりました。",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "それでも一部のコインが有効化されない場合は、アプリを再起動してみてください。",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "トルコ語",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "ブロック",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "確認",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "確認済み",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "費用",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "取引手数料：",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "取引ID",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "残りのトランザクション: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "リクエストが多すぎます。トランザクション履歴リクエストの制限を超えました。後でもう一度やり直してください。",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "未確認",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "ウクライナ語",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "ロックを解除",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "資金のロックを解除",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "{amnt} 資金のロックを解除しました - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "使えない",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "新しいバージョンが利用可能",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "アップデートの確認...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "バージョン {version} を使用しています",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "新しいバージョンが利用可能です。更新してください。",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "バージョン {version} が利用可能です。更新してください。",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "利用可能なアップデート",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "今のところスキップ",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "{appName} の更新",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "アップデート",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "すでに最新",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "スキャンするのに十分な残高がありません",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "支払い要求。",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "残高不足",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "価値：",
+  "@value": {
+    "type": "text"
+  },
+  "version": "バージョン",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "冒険者",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "シードと秘密鍵",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "ボリューム",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "ウォレット名はすでに使用されています",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "ウォレット名は最大 40 文字にする必要があります",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "ウォレットのみ",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "警告！",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Ok",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "警告 - 特殊なケースでは、このログ データには機密情報が含まれており、失敗したスワップからのコインの使用に使用できる可能性があります。",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "{coinAbbr} をアクティベートできませんでした",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "{coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} モバイルは、ネイティブの第 3 世代 DEX 機能などを備えた次世代のマルチコイン ウォレットです。",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "セットアップしましょう！",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "ようこそ",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "財布",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "完了すると、ポートフォリオ ページにリダイレクトされます。",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "これには時間がかかるため、アプリをフォアグラウンドに維持する必要があります。\nアクティベーションの進行中にアプリを終了すると、問題が発生する可能性があります。",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "撤退",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "以前にカメラへの {appName} アクセスを拒否しました。 QR コードのスキャンを続行するには、電話の設定でカメラの許可を手動で変更してください。",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "アクセスが拒否されました",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "出金確認",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "エラーが発生しました。あとでもう一度試してみてください。",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "WITHDRAW {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "の支払い QR コードをスキャンしようとしています",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "しかし、あなたは上にいます",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "画面を撤回",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "間違ったコイン",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "パスワードが一致しません。もう一度やり直してください。",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "はい",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "あなたが送っているもの:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "既存の注文と一致させようとしている新しい注文があります",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "アクティブなスワップが進行中です",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "新しい注文と一致する注文があります",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "あなたの財布",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "{amount} {coin} を受け取ります",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "受け取るもの:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,3660 +1,3726 @@
 {
-    "accepteula": "EULA 동의",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "이용약관 동의",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "생체보안 활성화",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "비밀번호 보호 활성화",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "{protocolName} 코인을 활성화하시겠습니까?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "{coinName} 활성화 중",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName} 활성화",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} 활성화 진행 중",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "활성화",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "코인 활성화",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "성공적으로 {name} 활성화!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "주소 추가",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "주소록",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "주소록이 비어 있습니다",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "{title} 주소를 가진 연락처만 보여지고 있습니다",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "주소록",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "{abbr}의 주소로 펀드를 보낼수 없습니다, 왜냐하면 {abbr}는 활성화가 되어있지 않습니다. 포티폴리오로 가주세요.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "찾을 수 없음",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "코인 선택",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "수신자 선택",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "고급",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "모두",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "커스텀 시드 허용",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "벌서 존재합니다",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "양",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "판매 할 양",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "아니요! {appName}은 정보를 보관하지 않습니다. 키, 시드 문구, 비밀번호 등 기밀 데이터는 저장되지 않습니다. 이 데이터는 사용자의 장치에만 저장되며, 시스템에는 저장되지 않습니다. 당신은 자산을 완전히 관리하고 있습니다.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName}은(는) Android 및 iPhone의 모바일과 <a href=\"https://komodoplatform.com/\">Windows, Mac 및 Linux 운영 체제</a>의 데스크톱에서 사용할 수 있습니다.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "다른 DEX는 일반적으로 단일 블록체인 네트워크를 기반으로 하는 자산 거래, 프록시 토큰 사용, 같은 펀드에서 단일 주문만 가능합니다.\n\n{appName}을 사용하면 프록시 토큰 없이 두 개의 다른 블록체인 네트워크 간에 기본적으로 교환할 수 있습니다. 같은 자금으로 여러 개를 주문할 수도 있습니다. 예를 들어, KMD, QTUM 또는 VRSC으로 0.1 BTC를 판매할 수 있습니다. 첫 주문이 가득 차면 다른 모든 주문이 자동으로 취소됩니다.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "각 스왑의 처리 시간은 몇 가지 요인에 의해 결정됩니다. 거래되는 자산의 블록 시간은 네트워크마다 다릅니다(보통 비트코인이 가장 느립니다). 게다가 사용자는 보안 설정을 커스터마이징 할 수 있습니다. 예를 들어 3번의 확인 후 {appName}에게 KMD 트랜잭션을 최종적으로 고려하도록 요구할 수 있습니다, 이는 <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">공증</a>을 기다리는 것보다 스와프 시간이 짧아집니다.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "네. 각 아토믹 스왑을 정상적으로 완료하려면 인터넷에 접속한 채로 애플리케이션을 실행해 두어야 합니다(보통 연결이 매우 짧은 상태도 문제 없습니다). 그렇지 않으면 제조업자의 경우 거래가 취소되고 인수업자의 경우 자금 손실 위험이 있습니다. 애트믹스와프 프로토콜을 사용하려면 두 참가자가 온라인으로 남아 프로세스가 아토믹 상태를 유지하기 위해 관련 블록체인을 감시해야 합니다.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "{appName}에서 거래할 때 고려해야 할 두 가지 수수료 카테고리가 있습니다.\n\n1. {appName}은 수주자의 거래 수수료로 약 0.13%으로(거래량의 1/777 이상 0.0001 이하)를 청구하며 제조사의 주문은 수수료가 제로입니다.\n\n2. 원자력 스와프 거래를 할 때는 제조사와 수험자 모두 관련된 블록체인에 정상적인 네트워크 요금을 지불해야 합니다.\n\n네트워크 요금은 선택한 거래 쌍에 따라 크게 다를 수 있습니다.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "네! {appName}은 <a href=\"{link}\">{appCompanyShort} {name}</a>을 통해서 서포트를 지원합니다. 저희 팀과 커뮤니티는 항상 돕고 싶습니다!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "아니요! {appName}은 완전한 분권화가 되어있습니다. 유저를 제3자 파티를 통해서 제한하는 것은 불가능합니다.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName}은 {appCompanyShort} 팁에서 개발되었습니다. {appCompanyShort}는 원자력 스왑, 지연 작업 증명, 상호 운용 가능한 멀티체인 아키텍처 등의 혁신적인 솔루션을 추진하고 있는 가장 확립된 블록체인 프로젝트 중 하나입니다.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "전적으로! 자세한 내용은 <a href=\"https://developers.komodoplatform.com/\">개발자 문서</a>를 참조하거나 파트너십 문의 사항이 있는 경우 문의해 주세요. 특정 기술 질문이 있습니까? {appName} 개발자 커뮤니티는 항상 도울 준비가 되어 있습니다!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "박수",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "확실하신가요?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "바꾸기 실패",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "바꾸기 완료 중",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "증명하기",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "활성화 재시도가 완료되면 당신은 자동으로 포티폴리오 페이지로 리디랙션이 될 것 입니다.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "최대 볼륨",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "뒤로",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "백업",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "{coinName1}/{coinName2} 기준",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "스왑을 안전하게 실행하려면 배터리 충전양 ({batteryLevelCritical}%)은 매우 중요합니다. 충전을 하고 다시 시도해 주십시오.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "배터리 충전량이 {batteryLevelLow}%보다 낮습니다. 휴대폰 충전을 부탁드립니다.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "전화기가 배터리 절약 모드로 되어 있습니다. 이 모드를 비활성화하거나 애플리케이션을 백그라운드에 두지 마세요. 그렇지 않으면 OS에 의해 애플리케이션이 중지되고 스왑에 실패할 수 있습니다.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "비율 바꾸기",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Komodo로 만들어짐",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Komodo로 만들어짐",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "구매",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "일치하지 않을 경우 제조사로 변환",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "스와프가 발행되었습니다. 잠시만 기다려주세요!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "주문이 진행 중입니다. {seconde}초를 기다려 주세요!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "경고합니다, 당신은 실제 가치가 없는 테스트 코인을 구매하는 것입니다!",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "위장 비밀번호와 바이오인증 보호를 동시에 활성화할 수 없습니다.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "위장 비밀번호와 바이오인증 보호 문제.",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "위장 비밀번호 바꾸기",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "위장 비밀번호 만들기",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "위장 비밀번호로 앱을 잠금해제 하면 가짜인 낮은 잔액이 표시되고, 위장 비밀번호 설정 옵션은 설정에 표시되지 않습니다.",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "잘못된 위장 비밀번호",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "위장 비밀번호",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "위장 비밀번호를 찾을 수 없습니다",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "끄기",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "켜기",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "위장 비밀번호 저장됨",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "위장 비밀번호",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "새로운 위장 비밀번호 입력하기",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "위장 비밀번호 셋업",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "위장 비밀번호 셋업",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "취소",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "취소",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "주문 취소",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "무언가 잘못되었습니다. 나중에 다시 시도해주세요.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "네",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "기본 코인입니다. 기본 코인은 비활성화 될 수 없습니다.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "비활성화 불가능",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "그것은 할 수 없습니다",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEX 변환 비율",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "CEX 데이터",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "이 아이콘이 표시된 시장 데이터(가격, 차트 등)는, 서드 파티(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>)에서 받아왔습니다.",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "CEX 비율",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "비밀번호 바꾸기",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "업데이트 확인하기",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "확인하기",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "시드 문구 확인하기",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "계속하기",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "다시가서 확인하기",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "{index} 단어 입력",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "당신의 시드 문구는 중요합니다 - 그래서 저희는 이것이 맞는지 확인하고 싶습니다. 필요할 때 언제든지 쉽게 지갑을 복원할 수 있도록 시드 문구에 대해 세 가지 다른 질문을 합니다.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "당신의 시드 문구 안에 있는 {index} 단어는 무엇입니까?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "다시 한번 당신의 시드 문구를 확인해봅시다",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "중국인",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "받기",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "KMD 보상을 받으시겠습니까?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "눌러서 보기",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "클립보드에 복사됨",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "클립보드 복사",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "닫기",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "에러 메시지 닫기",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "프리뷰 닫기",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "코드:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "최대 저작물 수를 선택했습니다.",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "{protocolName} 코인이 활성화되었습니다",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName} 코인이 성공적으로 활성화되었습니다.",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "{protocolName} 코인이 활성화되지 않았습니다.",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "클리어",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "활성화된 코인 없음",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "코인 선택",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "곳 옵니다...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "TX 디테일이 곳 옵니다!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "디테일이 곳 옵니다!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "수수료",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "평균에 비해. 24시간 CEX 가격",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "CEX에게 비교하기",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "지갑을 설정하고 있습니다, 기다려주세요...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "확인",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "위장 비밀번호 확인",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "주문을 취소하는 것을 확인하시겠습니까?",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "아래 버튼을 클릭하면 'EULA'와 '이용약관'을 읽고 이러한 버튼에 동의할 수 있습니다.",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "비밀번호 확인",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "핀 코드 확인",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "시드 문구 확인하기",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "연결중...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "취소",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "연락처 삭제",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "삭제",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "{name}을 연락처를 삭제하는 것을 확인하십니까?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "버리기",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "편집",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "종료",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "변경을 파기하시겠습니까?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "연락처를 찾을 수 없습니다",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "저장",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "연락처 상세",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "이름",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "계약",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "바꾸기",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "URL을 시작할 수 없습니다.",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "가져올 수 없습니다:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "바꾸기",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "지갑 만들기",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "연락처 만들기",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "핀 만들기",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "화폐",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "화폐",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "현제 가치:",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "통관 수수료",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "당신이 무엇을 하고 있는지 알고 있는 경우에만 관세비용을 사용하세요!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "커스텀 시드 문구는 생성된 BIP39 준거 시드 문구 또는 개인 키(WIF)보다 안전성이 낮고 크랙되기 쉬운 경우가 있습니다. 위험을 이해하고 무엇을 하고 있는지 확인하려면 아래 상자에 \"{iUnderstand}\"라고 입력해주세요.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "날짜",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "지갑 해석 중",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "삭제",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "비활성화 확인",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "지우시고 싶으십니까",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "당신의 포티폴리오에서? 일치되지 않은 주문들은 모두 취소됩니다.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " 비활성화도 됩니다",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "지갑 삭제",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "지갑 삭제 중...",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "{coinName} 거래 수수료를 받습니다",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "{coinName} 거래 수수료 보내기",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "거래 수수료 거래 수수료 보내기",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "거래 수수료",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "상세",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "독일어",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "개발자",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX은 이 코인에서 사용 불가합니다",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "스크린샷/미리보기 비활성화",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "부인서명 & ToS",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "완료",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "앱을 닫지 마세요. 자세한 내용을 보려면 탭하세요...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "다시 물어보지 마세요",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "전 비밀번호를 원지 않습니다",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo dPoW 보안",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "지속시간",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "연락처 편집",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "{abbr} 주소 입력",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "암호화 암호는 공백으로 둘 수 없습니다",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "비밀번호를 공백으로 둘 수 없습니다",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "연락처 이름은 공백으로 둘 수 없습니다",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "지갑 이름은 절대로 공백으로 둘 수 없습니다",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "여전히 {remains}을(를) 활성화할 수 있습니다. 선택됨: {selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "활성화 진행 상황에 대한 업데이트를 받으려면 알림을 활성화하세요.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "실험 코인 활성화",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "당신의 소유",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "활성화되어 있는 자산과 활성화하려고 하는 자산",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "활성화된 최대 한계치 자산은",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": "새로운 것을 추가하기 전에 먼저 다른 것들을 비활성화 해주세요.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "너무 많은 자산을 활성화 할려고 하고 있습니다",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "지갑 암호화 하는 중",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "영어",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "새로운 핀을 입력하세요",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "옛날 핀을 입력하세요",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "계속하기 위해서 비밀번호를 먼저 입력해주세요.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "핀 코드를 입력하세요",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "시드 문구를 입력하세요",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "판매 양을 먼저 입력하세요",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "잔고가 충분하지 않습니다",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "유효한 주소가 없습니다",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "세그윗 주소가 (아직) 지원되지 않습니다",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "가스가 충분하지 않습니다 - 최소 {gas}양의 가스를 사용하세요",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "에러, 다시 하세요",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "에러, 나중에 다시 하세요",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "값이 너무 높거나 낮습니다",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "데이터를 입력해주세요",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "예상된 합계치",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "예시: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "편리",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "비싼",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "CEX와 똑같음",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "변환 비율:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "변환",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "수출",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "연락처",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "함호화된 파일로 내보낼 항목을 선택하세요.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "수출",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "노트",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "아이템이 성공적으로 내보냈습니다:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "바꾸기",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "수출",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "실패",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "가짜 잔고 잔액:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "자주 묻는 질문들",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "에러",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "{coin} 호수에게 요청 보내는 중...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "호수",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "성공",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "요청 시간 초과",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "로그 파일 공유",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "뉴스",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "아무것도 없습니다",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} 뉴스",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "더 읽기...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "피드",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "뉴스 피드",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "뉴스 업데이트를 진행 할 수 없습니다",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "뉴스 업데이트를 받을 수 없습니다",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "뉴스 피드가 업데이트 됬습니다",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "벌서 최신화 되어 있습니다",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "수수료는 최대 {value}이어야 합니다.",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "모두",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "필터",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "모든 필터 지우기",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "실패",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "날짜부터",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "마커",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "코인 받기",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "코인 판매",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "상태",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "성공적",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "테이커",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "날짜까지",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "테이커/메이커",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "지문",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "마무리 중이니 잠시만 기다려주세요",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "QR코드 발견",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "프랑스 국민",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "에서부터",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} 수수료",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "가스 제한",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "{coin}을 활성화하세요.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "가스 가격",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "일반 핀 보호가 활성화되어 있지 않습니다.\n위장 모드를 사용 할 수 없습니다.\n핀 보호를 활성화 시켜주세요.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "중요: 계속하기 전에 시드 문구를 백업해두세요!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "거래를 받는 중입니다. 잠시 기다려 주세요.",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "포티폴리오로 가기",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Gwei는 최대 {value}이어야 합니다.",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "도움",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "도움 및 서포트",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "잔고 숨기기",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "비밀번호 확인",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "비밀번호 만들기",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "현제 비밀번호",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "당신의 비밀번호 입력하기",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "당신의 시드 문구 입력하기",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "지갑 이름 정하기",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "비밀번호",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "히스토리",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "h",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "헝가리 인",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "불러오기",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "불일치한 비밀번호 또는 망가진 데이터",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "불러올 아이템들:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "파일을 찾을 수 없음",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "틀린 데이터 바꾸기. 알맞은 상태의 JSON 파일을 주세요.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "불러오기",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "불러올 암호화된 파일을 선택하세요.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "열람 중...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "불러올 일반 텍스트 바꾸기 파일을 선택하세요.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "취소",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "네",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "비밀번호",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "싱글 스왑 불러오기",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "스왑 불러오기",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "어떤 아이템들을 건너뛌습니다",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "아이템을 성공적으로 불러왔습니다:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "스왑 불러오기를 실패했습니다",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "json파일 읽기에 에러가 났습니다",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "불러오기",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "수신되는 {coinName} txs 보호 설정",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "보안 비밀번호를 사용하고 똑같은 장치에 저장해두지 마세요",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "스왑 요청은 되돌릴수 없고 이는 최종 이벤트입니다!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "스왑은 60분까지 걸릴 수 있습니다. 이 앱플리케이션을 종료하지 마세요!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "보안 이유상 지갑 암호활를 위해 비밀번호를 입력해야 합니다",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "이 주문을 하기 위한 최소 볼륨은",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "볼륨 부족",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "새로 고침",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "인터넷 연결 복구됨",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "스왑 진행 불가능",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "상세",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} 이 사용불가합니다 :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "전 이해합니다",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "일본어",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "한국인",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "언어",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "마지막 거래",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "법적",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "덜",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗주의! {coinName} 시장의 24시간 거래량이 $10,000 미만입니다!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "한도는 최대 {value}이어야 합니다.",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "로딩 중...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "주문책 로딩 중...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "스크린이 잠겼습니다",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "인증 해주세요!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "로그인",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "로그아웃",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "종료 후 로그아웃",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "로그아웃 설정",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "지금 로그아웃 하고 싶으신게 맞나요?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "분",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "주문 만들기",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "메이커",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "주문 취소",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "에서 만들어짐",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "받기",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "주문 ID",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "이 주문에서 스왑이 실행되지 않았습니다",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "가격",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "판매",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "이 주문으로 스왑이 시작되었습니다",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "주문 디테일 메이커",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "메이커 주문",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "마켓플레이스",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "차트",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "깊이",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "질문을 찾을 수 없음",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "입찰을 찾을 수 없음",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "책 주문",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "주문 디테일",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "가격",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "코인을 선택해 주세요",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "마켓",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "마켓",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "비밀번호가 알맞아합니다",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "바꾸기",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "당신의 일반 핀과 위장 핀이 같습니다.\n위장 모드 사용이 불가능 할 것 입니다.\n위장 핀을 바꿔주세요.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "틀린 핀",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "최대",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "최대 주문 볼륨",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "뉴스",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "브라우즈",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "브라우즈 피드",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "작성",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "당신은 저장된 기사가 없습니다",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "저장",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "메모",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "합체",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "합한 갑어치:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "ms",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "최소",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "경고: iOS에서 앱을 최소화하면 활성화 프로세스가 종료됩니다.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "최소 주문 볼륨",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "m",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "최소 판매 양은 {number} {coinName}입니다",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "최소 구매 양은 {number} {coinName}입니다",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "최소 주문 양은 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})입니다",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "최소 판매 양은 {number} {coinName}입니다",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "값은 {minValue} {coin}보다 커야합니다",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "판매 양보다 적어야 합니다",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "필요된 최소 볼륨",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "커스텀 최소 볼륨 사용",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "이제 셀룰러 데이터를 사용하고 {appName} P2P 네트워크에 참여하여 인터넷 트래픽을 소비합니다. 셀룰러 데이터 요금제가 비싸다면 WiFi 네트워크를 사용하는 것이 좋습니다.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "더 많은 정보",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "더",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "{coin} 활성화하고 먼저 가장 높은 잔고로",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "양",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "코인",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "판매",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "취소",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "확인",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "{number} 주문들 생성:",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "생성",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "주문",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "주문들",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "수수료",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "취소",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "받을 명령 양을 입력하세요:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "자동 채우기",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "계속하기 전에 모든 에러를 고치세요",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "잘못된 양",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "잘못된 판매 양",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "수수료를 지불할 {coin}이 부족합니다. 최소 잔고는 {fee} {coin}입니다",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin} 잔고가 너무 낮습니다",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "최대 판매 양은",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "최소 받는 양은",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "최소 판매 양은",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "받기:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "판매:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "멀티",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Amt 받기",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "가격/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "네트워크 수수료",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "새로운 계정",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "새로운 계정",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "뉴스 피드",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "새로운 값:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "다음",
-    "@next": {
-        "type": "text"
-    },
-    "no": "아니요",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "뉴스 없음 - 나중에 다시 확인하세요!",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "코인을 찾을 수 없음",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "펀드 없음",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "가능한 펀드 없음 -  ㅂ",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "인터넷 연결 없음",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "선택된 아이템 없음",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "선택된 아이템 없음",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "알맞는 주문 없음",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "없음",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "값은 숫자여야 합니다",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "{coinName} 양을 입력해 주세요.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "주문을 만들기 위해서 눌러주세요",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "주문 없음, 가서 거래하세요.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "받을 수 있는 보상 없음",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "받을 수 있는 보상 없음 - 1시간 뒤에 다시하세요",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "그런 코인은 없습니다",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "히스토리 없음.",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "거래를 위한 {coin} 부족합니다!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "수수료를 위한 잔고 부족 - 더 작은 양을 거래하세요",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "노트: 매치 주문은 다시 취소 될 수 없습니다",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "노트 추가",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "노트",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "찾을 수 없습니다",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "{sell}/{buy} 가 성공적으로 바꿔었습니다",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "스와프 완료됨",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} 를 바꾸기 실패했습니다",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "스와프 실패됨",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} 스와프가 시작되었습니다",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "새로운 스와프가 시작되었습니다",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "스와프 상태가 바꿨습니다",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} 스왑 시간이 초과되었습니다",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "스왑 시간 초과됨",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "당신은 {coin} 거래를 받았습니다!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "들어오는 거래",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "거래내역 없음",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} 자산",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "공식 보도 자료",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "네",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "삭제",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "오래된 로그",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "사용된 용양",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "에러 메세지 열기",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "선택 과목",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "더 적은",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "더",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "모든 {coin} 주문이 취소될것 입니다.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "주문 생성됨",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "주문이 성공적으로 생성됬습니다",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "주소",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "취소",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "편함: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "편함: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "위한",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "똑같은 CEX",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "분.",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "가격",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "받기",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "선택",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "판매",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "한개 탭에서 상세를 열고 긴 탭에서 주문을 선택하세요",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "소비",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "세부 사항",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% 채워짐",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "주문 매칭됨",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "주문 매칭",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "주문",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "활성화",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "히스토리",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "Amt. ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "가격 ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "총값 ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "주문",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "알수 없는 주문 종류",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "덮어쓰기",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "이것은 당신만의 주문입니다!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "잔액에서 지불:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "받은 볼륨에서 지불:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "으로 지불",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "비밀번호는 최서 12자 이상이어여 하고, 소문자, 대문자 및 특수 기호가 하나씩 있어야합니다.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "지불",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "거래를 수락하시겠습니까?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "주소 지정",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "양:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "코인:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "취소",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "지불 요청",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "당신의 주문을 넣으세요",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "최대 소리로 틀기",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "코인을 더해 주세요",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "다시하기 위해서 앱을 다시 시작하거나, 밑에 버튼을 눌러 주세요.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "포티폴리오",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Komodo의해 구동됨",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "가격",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "개인 키",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "개인 키들",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "확인 사향",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "커스텀 보호 설정 사용",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "끄기",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "켜기",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "경고, 이 아토믹 스왑은 dPoW 보호가 않되어 있습니다.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "펍키",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "QR 코드 스캐너",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "제 개인 키를 보관하나요?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "어떤 기기에서 {appName}을 사용할 수 있나요?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "다른 DEX들에서 거래하는 것 보다 {appName}에서 하는 것이 무엇이 다른가요?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "각각의 아토믹 스왑을 얼마나 걸리나요?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "스왑을 하는 동안 온라인에 있어야 하나요?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "{appName}에서 수수료는 어떻게 계산되나요?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "유저 지원을 공급하나요?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "나라 제한이 있나요?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "{appName} 뒤에는 누가 있나요?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "{appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "새로운 시대입니다! 'AtomicDEX'에서 'Komodo Wallet'으로 공식 명칭을 변경하였습니다.",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "받기",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "받기",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "저희는 오프라인에 저장하는 것을 추천합니다.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "비활성화",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "요청된 거래",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "클리어",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "폼 리셋",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "복구",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "다시 모든 코인 활성화 중...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "다시 모두 활성화 중",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "당신의 보상을 받으세요",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "취소",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "거래가 진행되고 있습니다",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "진행중",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXO 양이 10 KMD에 이하입니다",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "한 시간이 지나지 않았습니다",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 시간",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "네",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "보상 상태:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "KMD 활성화 유저 보상에 대해서 더 읽어 보기",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "받기",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "성공! {amount} KMD를 받았습니다.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "피아트",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "보상,\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "상태",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "남은 시간",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "보상 정보:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO amt,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} 날(들)",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}h {minutes}m",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}분",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "보상 정보",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "러시아인",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "병함 저장",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "계속하려면 아래로 스크롤하세요...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "코인 찾기",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Avax 토큰 모두 선택",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "BEP 토큰 모두 선택",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "코스모스 네트워크 모두 선택",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "ERC 토큰 모두 선택",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "ETC 토큰 모두 선택",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Fantom 토큰 모두 선택",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "HecoChain 토큰 모두 선택",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Harmony 토큰 모두 선택",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "홍채 네트워크 모두 선택",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Kucoin 토큰 모두 선택",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Moonriver 토큰 모두 선택",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Polygon 토큰 모두 선택",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "QRC 토큰 모두 선택",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "SmartBCH 토큰 모두 선택",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "모든 SLP 토큰 선택",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "SmartChains 토큰 모두 선택",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "테스트 자산 토큰 모두 선택",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Ubiq 코인 모두 선택",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "UTXO 코인 모두 선택",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "모든 ZHTLC 코인을 선택하세요",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Ticker 찾기",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "보안",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "시드 문구",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "당신의 새로운 시드 문구",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "{amount} 주문을 보기 위해 클릭하세요",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "거래 내역 보기",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "코인 선택",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "당신의 포티폴리오에 추가하고 싶은 코인 선택하기",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "활성화 코인:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "구매하고 싶은 코인 선택",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "판매하고 싶은 코인 선택",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "선택된 주문:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "파일 선택",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "언어 선택",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "지불 방법 선택",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "판매",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "경고, 진정한 값어치가 없는 테스트 코인을 판매하고 있습니다!",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "보내기",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "이걸 지우시길 원하십니까",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "지갑?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "그렇다면, 확실하게 하세요",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "당신의 시드 문구를 기록하세요/",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "미래에 당신의 지갑을 복구하기 위해서.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "언어",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "설정",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "비밀번호 만들기",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "공유",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "나의 {coinName} 주소:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "주소 표시",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "상세 보기",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "{maxCount}개 주문 중 {count}개를 표시 중입니다.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "나의 주문 보기",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "비밀번호로 로그인하기",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "비밀번호를 까먹으셨나요? 지갑을 시드로부터 복구하세요",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "심플",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "활성화",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "구매할 {coin} 양을 입력하세요",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "구매",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "거이",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "최대 활성화 코인 양은 {maxCoins}입니다. 조금 비활성화 해주세요.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin}이 활성화 되어 있지 않습니다!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "받기",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "판매 할 {coin} 양을 입력하세요",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "판매",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "보내기",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "덜 보기",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "더 보기",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "{coin}을 활성화 할 수 없습니다",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "스킵",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "해제",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "소리",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "mp3 또는 wav 파일을 골라주세요. 저희가 {description}때 들려드리겠습니다.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "{description}일때 들려주기",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "소리들",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "알겠습니다, 더 이상 보여주지 마세요",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "소리",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "소리 성정",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "스왑 진행 중 및 활성 제조업체 주문이 있을 때 사운드 알림이 들립니다.\n아토믹 교환 프로토콜은 성공적인 거래를 위해 참여자들이 온라인에 있어야 하며, 사운드 알림은 이를 달성하는 데 도움이 됩니다.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "앱플리케이션 성정에서 커스텀 소리를 설정 할 수 있다는 것을 알아두세요.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "스페인의",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "스왑 시작",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "방법",
-    "@step": {
-        "type": "text"
-    },
-    "success": "성공!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "지원",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "궁금한 점이 있거나, {appName} 앱의 기술적인 문제를 발견하셨다고 생각하시면, 보고하고 팀의 지원을 받으실 수 있습니다.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "스왑",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "현재",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "변환 상세 확인",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "견적",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "스왑 실패",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "{coin} 활성화와 최고 잔고를 먼저 해주세요",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다. {coin} {amount}가 필요합니다.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "스왑이 진행되고 있습니다",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "진행 상세",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "시작됨",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "성공적으로 스왑",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "전체",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "UUID 스왑",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "테마 전환",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "테이커",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "테어커 주문",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "시간 초과",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "비밀번호 생성",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "주문 선택됨",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "에게",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "주소로:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "당신의 소유",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "자산이 활성화 됬습니다. 활성화된 자산 최대치는",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ". 새로운 것을 추가하기 전에 비활성화를 해주세요.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "너무 많은 자산이 활성화 되어있습니다",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "총 수수료:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "거래",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "스왑 완료됨!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "거래 상세",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "거래 수수료 계산 실패",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "거래 수수료:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "거래 모드:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "거래 주소",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "숨겨진 거래",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "피싱 시도 가능성으로 인해 이 거래가 숨겨졌습니다.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "그래도 일부 코인이 활성화되어 있지 않다면, 앱을 재부팅해 보세요.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "터키어",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "블록",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "확인",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "확인됨",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "수수료",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "거래 수수료:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "거래 ID",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "남은 거래: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "요청이 너무 많습니다.\n거래 이력 요구 제한을 초과했습니다.\n나중에 다시 시도해주세요.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "미확인",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "우크라이나 인",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "열기",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "펀드 열기",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "성공적으로 {amnt} 펀드를 열었습니다 - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "사용 불가능",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "새로운 버전 사용 가능",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "업데이트 확인중...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "당신은 {version} 사용 중 입니다",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "새로운 버전이 있습니다. 업데이트를 하세요.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "버전 {version}이 있습니다. 업데이트를 하세요.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "업데이트가 있습니다",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "지금은 스킵",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "{appName} 업데이트",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "업데이트",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "벌서 업데이트 되어있습니다",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "스캔된 것을 위한 잔고가 부족합니다",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "지불 요청.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "부족한 잔고",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "값:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "버전",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "익스플로어",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "시드 & 개인 키",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "볼륨",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "지갑 이름이 벌서 사용 중 입니다",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "지갑 이름은 최대 40자가 있어야 합니다",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "오직 지갑만",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "경고!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "네",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "경고 - 특별한 경우 이 로그 데이터에는 스왑에 실패한 코인을 사용하는 데 사용할 수 있는 중요한 정보가 포함되어 있습니다!",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다.\n앱을 다시 시작하고 다시 해주세요.",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} 모바일은 3세대 DEX 기능과 더 많은 기능 등을 탑재한 차세대 멀티코인 지갑입니다.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "이걸 준비해 봅시다!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "환영합니다",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "지갑",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "완료 후 포티폴리오 페이지로 리디렉트 됩니다.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "이 작업은 시간이 걸리며 앱이 포그라운드에 유지되어야 합니다.\n활성화가 진행되는 동안 앱을 종료하면 문제가 발생할 수 있습니다.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "인출",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "카메라에 대한 {appName} 액세스를 이전에 거부했습니다.\nQR코드 스캔을 실시하려면 전화기의 설정에서 카메라의 허가를 수동으로 변경해 주세요.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "액세스 거부",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "인출 확인",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "{amount} {coinName} 인출",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "당신은 지불 QR 코드를 스캔 할려고 합니다",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "하지만 당신은",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "인출 화면에 있습니다",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "잘못된 코인",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "비밀번화가 일치하지 않습니다. 다시 시도해주세요.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "네",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "당신은 보냅니다:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "당신은 이미 있는 주문과 일치한 새로운 주문을 찾고 있습니다",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "당신은 진행되고 있는 활성화 스왑이 있습니다",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "당신은 새로운 주문을 맞출수 있는 주문이 있습니다",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "당신의 지갑",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "당신은 {amount} {coin}을 받습니다",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "당신은 받습니다:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "ko",
+  "accepteula": "EULA 동의",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "이용약관 동의",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "생체보안 활성화",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "비밀번호 보호 활성화",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "{protocolName} 코인을 활성화하시겠습니까?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "{coinName} 활성화 중",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName} 활성화",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} 활성화 진행 중",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "활성화",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "코인 활성화",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "성공적으로 {name} 활성화!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "주소 추가",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "주소록",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "주소록이 비어 있습니다",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "{title} 주소를 가진 연락처만 보여지고 있습니다",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "주소록",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "{abbr}의 주소로 펀드를 보낼수 없습니다, 왜냐하면 {abbr}는 활성화가 되어있지 않습니다. 포티폴리오로 가주세요.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "찾을 수 없음",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "코인 선택",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "수신자 선택",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "고급",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "모두",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "커스텀 시드 허용",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "지갑에는 과거 거래가 표시됩니다. 모든 블록이 다운로드되고 스캔되므로 상당한 저장 공간과 시간이 소요됩니다.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "벌서 존재합니다",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "양",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "판매 할 양",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "아니요! {appName}은 정보를 보관하지 않습니다. 키, 시드 문구, 비밀번호 등 기밀 데이터는 저장되지 않습니다. 이 데이터는 사용자의 장치에만 저장되며, 시스템에는 저장되지 않습니다. 당신은 자산을 완전히 관리하고 있습니다.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName}은(는) Android 및 iPhone의 모바일과 <a href=\"https://komodoplatform.com/\">Windows, Mac 및 Linux 운영 체제</a>의 데스크톱에서 사용할 수 있습니다.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "다른 DEX는 일반적으로 단일 블록체인 네트워크를 기반으로 하는 자산 거래, 프록시 토큰 사용, 같은 펀드에서 단일 주문만 가능합니다.\n\n{appName}을 사용하면 프록시 토큰 없이 두 개의 다른 블록체인 네트워크 간에 기본적으로 교환할 수 있습니다. 같은 자금으로 여러 개를 주문할 수도 있습니다. 예를 들어, KMD, QTUM 또는 VRSC으로 0.1 BTC를 판매할 수 있습니다. 첫 주문이 가득 차면 다른 모든 주문이 자동으로 취소됩니다.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "각 스왑의 처리 시간은 몇 가지 요인에 의해 결정됩니다. 거래되는 자산의 블록 시간은 네트워크마다 다릅니다(보통 비트코인이 가장 느립니다). 게다가 사용자는 보안 설정을 커스터마이징 할 수 있습니다. 예를 들어 3번의 확인 후 {appName}에게 KMD 트랜잭션을 최종적으로 고려하도록 요구할 수 있습니다, 이는 <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">공증</a>을 기다리는 것보다 스와프 시간이 짧아집니다.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "네. 각 아토믹 스왑을 정상적으로 완료하려면 인터넷에 접속한 채로 애플리케이션을 실행해 두어야 합니다(보통 연결이 매우 짧은 상태도 문제 없습니다). 그렇지 않으면 제조업자의 경우 거래가 취소되고 인수업자의 경우 자금 손실 위험이 있습니다. 애트믹스와프 프로토콜을 사용하려면 두 참가자가 온라인으로 남아 프로세스가 아토믹 상태를 유지하기 위해 관련 블록체인을 감시해야 합니다.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "{appName}에서 거래할 때 고려해야 할 두 가지 수수료 카테고리가 있습니다.\n\n1. {appName}은 수주자의 거래 수수료로 약 0.13%으로(거래량의 1/777 이상 0.0001 이하)를 청구하며 제조사의 주문은 수수료가 제로입니다.\n\n2. 원자력 스와프 거래를 할 때는 제조사와 수험자 모두 관련된 블록체인에 정상적인 네트워크 요금을 지불해야 합니다.\n\n네트워크 요금은 선택한 거래 쌍에 따라 크게 다를 수 있습니다.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "네! {appName}은 <a href=\"{link}\">{appCompanyShort} {name}</a>을 통해서 서포트를 지원합니다. 저희 팀과 커뮤니티는 항상 돕고 싶습니다!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "아니요! {appName}은 완전한 분권화가 되어있습니다. 유저를 제3자 파티를 통해서 제한하는 것은 불가능합니다.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName}은 {appCompanyShort} 팁에서 개발되었습니다. {appCompanyShort}는 원자력 스왑, 지연 작업 증명, 상호 운용 가능한 멀티체인 아키텍처 등의 혁신적인 솔루션을 추진하고 있는 가장 확립된 블록체인 프로젝트 중 하나입니다.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "전적으로! 자세한 내용은 <a href=\"https://developers.komodoplatform.com/\">개발자 문서</a>를 참조하거나 파트너십 문의 사항이 있는 경우 문의해 주세요. 특정 기술 질문이 있습니까? {appName} 개발자 커뮤니티는 항상 도울 준비가 되어 있습니다!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "박수",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "확실하신가요?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "바꾸기 실패",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "바꾸기 완료 중",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "증명하기",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "활성화 재시도가 완료되면 당신은 자동으로 포티폴리오 페이지로 리디랙션이 될 것 입니다.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "최대 볼륨",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "뒤로",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "백업",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "{coinName1}/{coinName2} 기준",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "스왑을 안전하게 실행하려면 배터리 충전양 ({batteryLevelCritical}%)은 매우 중요합니다. 충전을 하고 다시 시도해 주십시오.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "배터리 충전량이 {batteryLevelLow}%보다 낮습니다. 휴대폰 충전을 부탁드립니다.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "전화기가 배터리 절약 모드로 되어 있습니다. 이 모드를 비활성화하거나 애플리케이션을 백그라운드에 두지 마세요. 그렇지 않으면 OS에 의해 애플리케이션이 중지되고 스왑에 실패할 수 있습니다.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "비율 바꾸기",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Komodo로 만들어짐",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Komodo로 만들어짐",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "구매",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "일치하지 않을 경우 제조사로 변환",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "스와프가 발행되었습니다. 잠시만 기다려주세요!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "주문이 진행 중입니다. {seconde}초를 기다려 주세요!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "경고합니다, 당신은 실제 가치가 없는 테스트 코인을 구매하는 것입니다!",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "위장 비밀번호와 바이오인증 보호를 동시에 활성화할 수 없습니다.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "위장 비밀번호와 바이오인증 보호 문제.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "위장 비밀번호 바꾸기",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "위장 비밀번호 만들기",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "위장 비밀번호로 앱을 잠금해제 하면 가짜인 낮은 잔액이 표시되고, 위장 비밀번호 설정 옵션은 설정에 표시되지 않습니다.",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "잘못된 위장 비밀번호",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "위장 비밀번호",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "위장 비밀번호를 찾을 수 없습니다",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "끄기",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "켜기",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "위장 비밀번호 저장됨",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "위장 비밀번호",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "새로운 위장 비밀번호 입력하기",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "위장 비밀번호 셋업",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "위장 비밀번호 셋업",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "취소",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "활성화 취소",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "활성화를 취소하시겠습니까?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "취소",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "주문 취소",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "무언가 잘못되었습니다. 나중에 다시 시도해주세요.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "네",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "기본 코인입니다. 기본 코인은 비활성화 될 수 없습니다.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "비활성화 불가능",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "그것은 할 수 없습니다",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEX 변환 비율",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "CEX 데이터",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "이 아이콘이 표시된 시장 데이터(가격, 차트 등)는, 서드 파티(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>)에서 받아왔습니다.",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "CEX 비율",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "비밀번호 바꾸기",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "업데이트 확인하기",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "확인하기",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "시드 문구 확인하기",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "계속하기",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "다시가서 확인하기",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "{index} 단어 입력",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "당신의 시드 문구는 중요합니다 - 그래서 저희는 이것이 맞는지 확인하고 싶습니다. 필요할 때 언제든지 쉽게 지갑을 복원할 수 있도록 시드 문구에 대해 세 가지 다른 질문을 합니다.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "당신의 시드 문구 안에 있는 {index} 단어는 무엇입니까?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "다시 한번 당신의 시드 문구를 확인해봅시다",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "중국인",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "받기",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "KMD 보상을 받으시겠습니까?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "눌러서 보기",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "클립보드에 복사됨",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "클립보드 복사",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "닫기",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "에러 메시지 닫기",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "프리뷰 닫기",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "코드:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "활성화를 취소하시겠습니까?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "최대 저작물 수를 선택했습니다.",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "{protocolName} 코인이 활성화되었습니다",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} 코인이 성공적으로 활성화되었습니다.",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "{protocolName} 코인이 활성화되지 않았습니다.",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "클리어",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "활성화된 코인 없음",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "코인 선택",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "곳 옵니다...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "TX 디테일이 곳 옵니다!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "디테일이 곳 옵니다!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "수수료",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "평균에 비해. 24시간 CEX 가격",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "CEX에게 비교하기",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "지갑을 설정하고 있습니다, 기다려주세요...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "확인",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "위장 비밀번호 확인",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "주문을 취소하는 것을 확인하시겠습니까?",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "아래 버튼을 클릭하면 'EULA'와 '이용약관'을 읽고 이러한 버튼에 동의할 수 있습니다.",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "비밀번호 확인",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "핀 코드 확인",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "시드 문구 확인하기",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "연결중...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "취소",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "연락처 삭제",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "삭제",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "{name}을 연락처를 삭제하는 것을 확인하십니까?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "버리기",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "편집",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "종료",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "변경을 파기하시겠습니까?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "연락처를 찾을 수 없습니다",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "저장",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "연락처 상세",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "이름",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "계약",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "바꾸기",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "URL을 시작할 수 없습니다.",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "가져올 수 없습니다:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "바꾸기",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "지갑 만들기",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "연락처 만들기",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "핀 만들기",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "화폐",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "화폐",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "현제 가치:",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "통관 수수료",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "당신이 무엇을 하고 있는지 알고 있는 경우에만 관세비용을 사용하세요!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "커스텀 시드 문구는 생성된 BIP39 준거 시드 문구 또는 개인 키(WIF)보다 안전성이 낮고 크랙되기 쉬운 경우가 있습니다. 위험을 이해하고 무엇을 하고 있는지 확인하려면 아래 상자에 \"{iUnderstand}\"라고 입력해주세요.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "날짜",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "지갑 해석 중",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "삭제",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "비활성화 확인",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "지우시고 싶으십니까",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "당신의 포티폴리오에서? 일치되지 않은 주문들은 모두 취소됩니다.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " 비활성화도 됩니다",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "지갑 삭제",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "지갑 삭제 중...",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "{coinName} 거래 수수료를 받습니다",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "{coinName} 거래 수수료 보내기",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "거래 수수료 거래 수수료 보내기",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "거래 수수료",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "상세",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "독일어",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "개발자",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX은 이 코인에서 사용 불가합니다",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "스크린샷/미리보기 비활성화",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "부인서명 & ToS",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "완료",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "앱을 닫지 마세요. 자세한 내용을 보려면 탭하세요...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "다시 물어보지 마세요",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "전 비밀번호를 원지 않습니다",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo dPoW 보안",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "지속시간",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "연락처 편집",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "{abbr} 주소 입력",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "암호화 암호는 공백으로 둘 수 없습니다",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "비밀번호를 공백으로 둘 수 없습니다",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "연락처 이름은 공백으로 둘 수 없습니다",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "지갑 이름은 절대로 공백으로 둘 수 없습니다",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "여전히 {remains}을(를) 활성화할 수 있습니다. 선택됨: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "활성화 진행 상황에 대한 업데이트를 받으려면 알림을 활성화하세요.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "실험 코인 활성화",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "당신의 소유",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "활성화되어 있는 자산과 활성화하려고 하는 자산",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "활성화된 최대 한계치 자산은",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": "새로운 것을 추가하기 전에 먼저 다른 것들을 비활성화 해주세요.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "너무 많은 자산을 활성화 할려고 하고 있습니다",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "지갑 암호화 하는 중",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "영어",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "새로운 핀을 입력하세요",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "옛날 핀을 입력하세요",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "계속하기 위해서 비밀번호를 먼저 입력해주세요.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "핀 코드를 입력하세요",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "시드 문구를 입력하세요",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "판매 양을 먼저 입력하세요",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "잔고가 충분하지 않습니다",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "유효한 주소가 없습니다",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "세그윗 주소가 (아직) 지원되지 않습니다",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "가스가 충분하지 않습니다 - 최소 {gas}양의 가스를 사용하세요",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "에러, 다시 하세요",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "에러, 나중에 다시 하세요",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "값이 너무 높거나 낮습니다",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "데이터를 입력해주세요",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "예상된 합계치",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "예시: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "편리",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "비싼",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "CEX와 똑같음",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "변환 비율:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "변환",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "수출",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "연락처",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "함호화된 파일로 내보낼 항목을 선택하세요.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "수출",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "노트",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "아이템이 성공적으로 내보냈습니다:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "바꾸기",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "수출",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "실패",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "가짜 잔고 잔액:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "자주 묻는 질문들",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "에러",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "{coin} 호수에게 요청 보내는 중...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "호수",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "성공",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "요청 시간 초과",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "로그 파일 공유",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "뉴스",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "아무것도 없습니다",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} 뉴스",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "더 읽기...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "피드",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "뉴스 피드",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "뉴스 업데이트를 진행 할 수 없습니다",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "뉴스 업데이트를 받을 수 없습니다",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "뉴스 피드가 업데이트 됬습니다",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "벌서 최신화 되어 있습니다",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "수수료는 최대 {value}이어야 합니다.",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "모두",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "필터",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "모든 필터 지우기",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "실패",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "날짜부터",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "마커",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "코인 받기",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "코인 판매",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "상태",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "성공적",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "테이커",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "날짜까지",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "테이커/메이커",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "지문",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "마무리 중이니 잠시만 기다려주세요",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "QR코드 발견",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "프랑스 국민",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "에서부터",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "공개 키와 관련된 활성화 후 향후 거래가 동기화됩니다. 이는 가장 빠른 옵션이며 저장 공간을 가장 적게 차지합니다.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} 수수료",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "가스 제한",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "{coin}을 활성화하세요.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "가스 가격",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "일반 핀 보호가 활성화되어 있지 않습니다.\n위장 모드를 사용 할 수 없습니다.\n핀 보호를 활성화 시켜주세요.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "중요: 계속하기 전에 시드 문구를 백업해두세요!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "거래를 받는 중입니다. 잠시 기다려 주세요.",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "포티폴리오로 가기",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei는 최대 {value}이어야 합니다.",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "도움",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "도움 및 서포트",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "잔고 숨기기",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "비밀번호 확인",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "비밀번호 만들기",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "현제 비밀번호",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "당신의 비밀번호 입력하기",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "당신의 시드 문구 입력하기",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "지갑 이름 정하기",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "비밀번호",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "히스토리",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "h",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "헝가리 인",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "불러오기",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "불일치한 비밀번호 또는 망가진 데이터",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "불러올 아이템들:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "파일을 찾을 수 없음",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "틀린 데이터 바꾸기. 알맞은 상태의 JSON 파일을 주세요.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "불러오기",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "불러올 암호화된 파일을 선택하세요.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "열람 중...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "불러올 일반 텍스트 바꾸기 파일을 선택하세요.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "취소",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "네",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "비밀번호",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "싱글 스왑 불러오기",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "스왑 불러오기",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "어떤 아이템들을 건너뛌습니다",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "아이템을 성공적으로 불러왔습니다:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "스왑 불러오기를 실패했습니다",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "json파일 읽기에 에러가 났습니다",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "불러오기",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "수신되는 {coinName} txs 보호 설정",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "보안 비밀번호를 사용하고 똑같은 장치에 저장해두지 마세요",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "스왑 요청은 되돌릴수 없고 이는 최종 이벤트입니다!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "스왑은 60분까지 걸릴 수 있습니다. 이 앱플리케이션을 종료하지 마세요!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "보안 이유상 지갑 암호활를 위해 비밀번호를 입력해야 합니다",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "이 주문을 하기 위한 최소 볼륨은",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "볼륨 부족",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "새로 고침",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "인터넷 연결 복구됨",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "잘못된 {coin} 주소",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "스왑 진행 불가능",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "상세",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} 이 사용불가합니다 :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "전 이해합니다",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "일본어",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "한국인",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "언어",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "마지막 거래",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "법적",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "덜",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗주의! {coinName} 시장의 24시간 거래량이 $10,000 미만입니다!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "한도는 최대 {value}이어야 합니다.",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "로딩 중...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "주문책 로딩 중...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "스크린이 잠겼습니다",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "인증 해주세요!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "로그인",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "로그아웃",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "종료 후 로그아웃",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "로그아웃 설정",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "지금 로그아웃 하고 싶으신게 맞나요?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "분",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "주문 만들기",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "메이커",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "주문 취소",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "에서 만들어짐",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "받기",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "주문 ID",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "이 주문에서 스왑이 실행되지 않았습니다",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "가격",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "판매",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "이 주문으로 스왑이 시작되었습니다",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "주문 디테일 메이커",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "메이커 주문",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "마켓플레이스",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "차트",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "깊이",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "질문을 찾을 수 없음",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "입찰을 찾을 수 없음",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "책 주문",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "주문 디테일",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "가격",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "코인을 선택해 주세요",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "마켓",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "마켓",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "비밀번호가 알맞아합니다",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "바꾸기",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "당신의 일반 핀과 위장 핀이 같습니다.\n위장 모드 사용이 불가능 할 것 입니다.\n위장 핀을 바꿔주세요.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "틀린 핀",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "최대",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "최대 주문 볼륨",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "뉴스",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "브라우즈",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "브라우즈 피드",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "작성",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "당신은 저장된 기사가 없습니다",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "저장",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "메모",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "합체",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "합한 갑어치:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "ms",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "최소",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "경고: iOS에서 앱을 최소화하면 활성화 프로세스가 종료됩니다.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "최소 주문 볼륨",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "m",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "최소 판매 양은 {number} {coinName}입니다",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "최소 구매 양은 {number} {coinName}입니다",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "최소 주문 양은 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})입니다",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "최소 판매 양은 {number} {coinName}입니다",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "값은 {minValue} {coin}보다 커야합니다",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "판매 양보다 적어야 합니다",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "필요된 최소 볼륨",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "커스텀 최소 볼륨 사용",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "이제 셀룰러 데이터를 사용하고 {appName} P2P 네트워크에 참여하여 인터넷 트래픽을 소비합니다. 셀룰러 데이터 요금제가 비싸다면 WiFi 네트워크를 사용하는 것이 좋습니다.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "더 많은 정보",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "더",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "{coin} 활성화하고 먼저 가장 높은 잔고로",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "양",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "코인",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "판매",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "취소",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "확인",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "{number} 주문들 생성:",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "생성",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "주문",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "주문들",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "수수료",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "취소",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "받을 명령 양을 입력하세요:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "자동 채우기",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "계속하기 전에 모든 에러를 고치세요",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "잘못된 양",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "잘못된 판매 양",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "수수료를 지불할 {coin}이 부족합니다. 최소 잔고는 {fee} {coin}입니다",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin} 잔고가 너무 낮습니다",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "최대 판매 양은",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "최소 받는 양은",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "최소 판매 양은",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "받기:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "판매:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "멀티",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Amt 받기",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "가격/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "네트워크 수수료",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "새로운 계정",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "새로운 계정",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "뉴스 피드",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "새로운 값:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "다음",
+  "@next": {
+    "type": "text"
+  },
+  "no": "아니요",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "뉴스 없음 - 나중에 다시 확인하세요!",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "코인을 찾을 수 없음",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "펀드 없음",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "가능한 펀드 없음 -  ㅂ",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "인터넷 연결 없음",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "선택된 아이템 없음",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "선택된 아이템 없음",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "알맞는 주문 없음",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "없음",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "값은 숫자여야 합니다",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "{coinName} 양을 입력해 주세요.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "주문을 만들기 위해서 눌러주세요",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "주문 없음, 가서 거래하세요.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "받을 수 있는 보상 없음",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "받을 수 있는 보상 없음 - 1시간 뒤에 다시하세요",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "그런 코인은 없습니다",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "히스토리 없음.",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "거래를 위한 {coin} 부족합니다!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "수수료를 위한 잔고 부족 - 더 작은 양을 거래하세요",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "노트: 매치 주문은 다시 취소 될 수 없습니다",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "노트 추가",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "노트",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "찾을 수 없습니다",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "{sell}/{buy} 가 성공적으로 바꿔었습니다",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "스와프 완료됨",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} 를 바꾸기 실패했습니다",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "스와프 실패됨",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} 스와프가 시작되었습니다",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "새로운 스와프가 시작되었습니다",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "스와프 상태가 바꿨습니다",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} 스왑 시간이 초과되었습니다",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "스왑 시간 초과됨",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "당신은 {coin} 거래를 받았습니다!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "들어오는 거래",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "거래내역 없음",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} 자산",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "공식 보도 자료",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "네",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "삭제",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "오래된 로그",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "사용된 용양",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "에러 메세지 열기",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "선택 과목",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "더 적은",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "더",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "모든 {coin} 주문이 취소될것 입니다.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "주문 생성됨",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "주문이 성공적으로 생성됬습니다",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "주소",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "취소",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "편함: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "편함: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "위한",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "똑같은 CEX",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "분.",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "가격",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "받기",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "선택",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "판매",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "한개 탭에서 상세를 열고 긴 탭에서 주문을 선택하세요",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "소비",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "세부 사항",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% 채워짐",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "주문 매칭됨",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "주문 매칭",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "주문",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "활성화",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "히스토리",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "Amt. ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "가격 ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "총값 ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "주문",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "알수 없는 주문 종류",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "덮어쓰기",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "이것은 당신만의 주문입니다!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "잔액에서 지불:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "받은 볼륨에서 지불:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "으로 지불",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "비밀번호는 최서 12자 이상이어여 하고, 소문자, 대문자 및 특수 기호가 하나씩 있어야합니다.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "귀하의 지갑에는 지정된 날짜 이후에 이루어진 과거 거래가 표시됩니다.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "지불",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "거래를 수락하시겠습니까?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "주소 지정",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "양:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "코인:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "취소",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "지불 요청",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "당신의 주문을 넣으세요",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "최대 소리로 틀기",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "코인을 더해 주세요",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "다시하기 위해서 앱을 다시 시작하거나, 밑에 버튼을 눌러 주세요.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "포티폴리오",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Komodo의해 구동됨",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "가격",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "개인 키",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "개인 키들",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "확인 사향",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "커스텀 보호 설정 사용",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "끄기",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "켜기",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "경고, 이 아토믹 스왑은 dPoW 보호가 않되어 있습니다.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "펍키",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "QR 코드 스캐너",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "제 개인 키를 보관하나요?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "어떤 기기에서 {appName}을 사용할 수 있나요?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "다른 DEX들에서 거래하는 것 보다 {appName}에서 하는 것이 무엇이 다른가요?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "각각의 아토믹 스왑을 얼마나 걸리나요?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "스왑을 하는 동안 온라인에 있어야 하나요?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "{appName}에서 수수료는 어떻게 계산되나요?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "유저 지원을 공급하나요?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "나라 제한이 있나요?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "{appName} 뒤에는 누가 있나요?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "{appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "새로운 시대입니다! 'AtomicDEX'에서 'Komodo Wallet'으로 공식 명칭을 변경하였습니다.",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "받기",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "받기",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "저희는 오프라인에 저장하는 것을 추천합니다.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "비활성화",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "요청된 거래",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "클리어",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "폼 리셋",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "복구",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "다시 모든 코인 활성화 중...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "다시 모두 활성화 중",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "당신의 보상을 받으세요",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "취소",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "거래가 진행되고 있습니다",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "진행중",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXO 양이 10 KMD에 이하입니다",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "한 시간이 지나지 않았습니다",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 시간",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "네",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "보상 상태:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "KMD 활성화 유저 보상에 대해서 더 읽어 보기",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "받기",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "성공! {amount} KMD를 받았습니다.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "피아트",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "보상,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "상태",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "남은 시간",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "보상 정보:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO amt,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} 날(들)",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}h {minutes}m",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}분",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "보상 정보",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "러시아인",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "병함 저장",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "계속하려면 아래로 스크롤하세요...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "코인 찾기",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Avax 토큰 모두 선택",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "BEP 토큰 모두 선택",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "코스모스 네트워크 모두 선택",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "ERC 토큰 모두 선택",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "ETC 토큰 모두 선택",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Fantom 토큰 모두 선택",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "HecoChain 토큰 모두 선택",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Harmony 토큰 모두 선택",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "홍채 네트워크 모두 선택",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Kucoin 토큰 모두 선택",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Moonriver 토큰 모두 선택",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Polygon 토큰 모두 선택",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "QRC 토큰 모두 선택",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "SmartBCH 토큰 모두 선택",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "모든 SLP 토큰 선택",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "SmartChains 토큰 모두 선택",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "테스트 자산 토큰 모두 선택",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Ubiq 코인 모두 선택",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "UTXO 코인 모두 선택",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "모든 ZHTLC 코인을 선택하세요",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Ticker 찾기",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "보안",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "시드 문구",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "당신의 새로운 시드 문구",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "{amount} 주문을 보기 위해 클릭하세요",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "거래 내역 보기",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "코인 선택",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "당신의 포티폴리오에 추가하고 싶은 코인 선택하기",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "활성화 코인:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "구매하고 싶은 코인 선택",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "판매하고 싶은 코인 선택",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "날짜를 선택하세요",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "선택된 주문:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "파일 선택",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "언어 선택",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "지불 방법 선택",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "판매",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "경고, 진정한 값어치가 없는 테스트 코인을 판매하고 있습니다!",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "보내기",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "이걸 지우시길 원하십니까",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "지갑?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "그렇다면, 확실하게 하세요",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "당신의 시드 문구를 기록하세요/",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "미래에 당신의 지갑을 복구하기 위해서.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "언어",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "설정",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "비밀번호 만들기",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "공유",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "나의 {coinName} 주소:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "과거 {coin} 거래를 검색하시겠습니까?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "주소 표시",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "상세 보기",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "{maxCount}개 주문 중 {count}개를 표시 중입니다.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "나의 주문 보기",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "비밀번호로 로그인하기",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "비밀번호를 까먹으셨나요? 지갑을 시드로부터 복구하세요",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "심플",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "활성화",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "구매할 {coin} 양을 입력하세요",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "구매",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "거이",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "최대 활성화 코인 양은 {maxCoins}입니다. 조금 비활성화 해주세요.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin}이 활성화 되어 있지 않습니다!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "받기",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "판매 할 {coin} 양을 입력하세요",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "판매",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "보내기",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "덜 보기",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "더 보기",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "{coin}을 활성화 할 수 없습니다",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "스킵",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "해제",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "소리",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "mp3 또는 wav 파일을 골라주세요. 저희가 {description}때 들려드리겠습니다.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "{description}일때 들려주기",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "소리들",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "알겠습니다, 더 이상 보여주지 마세요",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "소리",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "소리 성정",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "스왑 진행 중 및 활성 제조업체 주문이 있을 때 사운드 알림이 들립니다.\n아토믹 교환 프로토콜은 성공적인 거래를 위해 참여자들이 온라인에 있어야 하며, 사운드 알림은 이를 달성하는 데 도움이 됩니다.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "앱플리케이션 성정에서 커스텀 소리를 설정 할 수 있다는 것을 알아두세요.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "스페인의",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "시작일",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "스왑 시작",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "방법",
+  "@step": {
+    "type": "text"
+  },
+  "success": "성공!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "지원",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "궁금한 점이 있거나, {appName} 앱의 기술적인 문제를 발견하셨다고 생각하시면, 보고하고 팀의 지원을 받으실 수 있습니다.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "스왑",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "현재",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "변환 상세 확인",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "견적",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "스왑 실패",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "{coin} 활성화와 최고 잔고를 먼저 해주세요",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다. {coin} {amount}가 필요합니다.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "스왑이 진행되고 있습니다",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "진행 상세",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "시작됨",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "성공적으로 스왑",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "전체",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "UUID 스왑",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "테마 전환",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "지정된 날짜부터 동기화",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "묘목 활성화에서 동기화",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "새 거래 동기화",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "어떤 {name} 거래를 동기화하시겠습니까?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "테이커",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "테어커 주문",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "시간 초과",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "비밀번호 생성",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "주문 선택됨",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "에게",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "주소로:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "당신의 소유",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "자산이 활성화 됬습니다. 활성화된 자산 최대치는",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ". 새로운 것을 추가하기 전에 비활성화를 해주세요.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "너무 많은 자산이 활성화 되어있습니다",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "총 수수료:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "거래",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "스왑 완료됨!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "거래 상세",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "거래 수수료 계산 실패",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "거래 수수료:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "거래 모드:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "거래 주소",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "숨겨진 거래",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "피싱 시도 가능성으로 인해 이 거래가 숨겨졌습니다.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "그래도 일부 코인이 활성화되어 있지 않다면, 앱을 재부팅해 보세요.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "터키어",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "블록",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "확인",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "확인됨",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "수수료",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "거래 수수료:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "거래 ID",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "남은 거래: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "요청이 너무 많습니다.\n거래 이력 요구 제한을 초과했습니다.\n나중에 다시 시도해주세요.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "미확인",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "우크라이나 인",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "열기",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "펀드 열기",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "성공적으로 {amnt} 펀드를 열었습니다 - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "사용 불가능",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "새로운 버전 사용 가능",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "업데이트 확인중...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "당신은 {version} 사용 중 입니다",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "새로운 버전이 있습니다. 업데이트를 하세요.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "버전 {version}이 있습니다. 업데이트를 하세요.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "업데이트가 있습니다",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "지금은 스킵",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "{appName} 업데이트",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "업데이트",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "벌서 업데이트 되어있습니다",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "스캔된 것을 위한 잔고가 부족합니다",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "지불 요청.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "부족한 잔고",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "값:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "버전",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "익스플로어",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "시드 & 개인 키",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "볼륨",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "지갑 이름이 벌서 사용 중 입니다",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "지갑 이름은 최대 40자가 있어야 합니다",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "오직 지갑만",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "경고!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "네",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "경고 - 특별한 경우 이 로그 데이터에는 스왑에 실패한 코인을 사용하는 데 사용할 수 있는 중요한 정보가 포함되어 있습니다!",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다.\n앱을 다시 시작하고 다시 해주세요.",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} 모바일은 3세대 DEX 기능과 더 많은 기능 등을 탑재한 차세대 멀티코인 지갑입니다.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "이걸 준비해 봅시다!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "환영합니다",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "지갑",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "완료 후 포티폴리오 페이지로 리디렉트 됩니다.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "이 작업은 시간이 걸리며 앱이 포그라운드에 유지되어야 합니다.\n활성화가 진행되는 동안 앱을 종료하면 문제가 발생할 수 있습니다.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "인출",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "카메라에 대한 {appName} 액세스를 이전에 거부했습니다.\nQR코드 스캔을 실시하려면 전화기의 설정에서 카메라의 허가를 수동으로 변경해 주세요.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "액세스 거부",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "인출 확인",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "{amount} {coinName} 인출",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "당신은 지불 QR 코드를 스캔 할려고 합니다",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "하지만 당신은",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "인출 화면에 있습니다",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "잘못된 코인",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "비밀번화가 일치하지 않습니다. 다시 시도해주세요.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "네",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "당신은 보냅니다:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "당신은 이미 있는 주문과 일치한 새로운 주문을 찾고 있습니다",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "당신은 진행되고 있는 활성화 스왑이 있습니다",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "당신은 새로운 주문을 맞출수 있는 주문이 있습니다",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "당신의 지갑",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "당신은 {amount} {coin}을 받습니다",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "당신은 받습니다:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,3726 +1,5540 @@
 {
-  "@@locale": "ko",
-  "accepteula": "EULA 동의",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "이용약관 동의",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "생체보안 활성화",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "비밀번호 보호 활성화",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "{protocolName} 코인을 활성화하시겠습니까?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "이제 셀룰러 데이터를 사용하고 {appName} P2P 네트워크에 참여하여 인터넷 트래픽을 소비합니다. 셀룰러 데이터 요금제가 비싸다면 WiFi 네트워크를 사용하는 것이 좋습니다.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "액세스 거부",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "카메라에 대한 {appName} 액세스를 이전에 거부했습니다.\nQR코드 스캔을 실시하려면 전화기의 설정에서 카메라의 허가를 수동으로 변경해 주세요.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "환영합니다",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "지갑",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} 모바일은 3세대 DEX 기능과 더 많은 기능 등을 탑재한 차세대 멀티코인 지갑입니다.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "이걸 준비해 봅시다!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "{appName} 업데이트",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "당신은 {version} 사용 중 입니다",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "업데이트 확인중...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "벌서 업데이트 되어있습니다",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "새로운 버전 사용 가능",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "업데이트",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "지금은 스킵",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "업데이트가 있습니다",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "새로운 버전이 있습니다. 업데이트를 하세요.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "버전 {version}이 있습니다. 업데이트를 하세요.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "도움",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "도움 및 서포트",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "자주 묻는 질문들",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "지원",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "궁금한 점이 있거나, {appName} 앱의 기술적인 문제를 발견하셨다고 생각하시면, 보고하고 팀의 지원을 받으실 수 있습니다.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "제 개인 키를 보관하나요?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "아니요! {appName}은 정보를 보관하지 않습니다. 키, 시드 문구, 비밀번호 등 기밀 데이터는 저장되지 않습니다. 이 데이터는 사용자의 장치에만 저장되며, 시스템에는 저장되지 않습니다. 당신은 자산을 완전히 관리하고 있습니다.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "다른 DEX들에서 거래하는 것 보다 {appName}에서 하는 것이 무엇이 다른가요?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "다른 DEX는 일반적으로 단일 블록체인 네트워크를 기반으로 하는 자산 거래, 프록시 토큰 사용, 같은 펀드에서 단일 주문만 가능합니다.\n\n{appName}을 사용하면 프록시 토큰 없이 두 개의 다른 블록체인 네트워크 간에 기본적으로 교환할 수 있습니다. 같은 자금으로 여러 개를 주문할 수도 있습니다. 예를 들어, KMD, QTUM 또는 VRSC으로 0.1 BTC를 판매할 수 있습니다. 첫 주문이 가득 차면 다른 모든 주문이 자동으로 취소됩니다.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "각각의 아토믹 스왑을 얼마나 걸리나요?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "각 스왑의 처리 시간은 몇 가지 요인에 의해 결정됩니다. 거래되는 자산의 블록 시간은 네트워크마다 다릅니다(보통 비트코인이 가장 느립니다). 게다가 사용자는 보안 설정을 커스터마이징 할 수 있습니다. 예를 들어 3번의 확인 후 {appName}에게 KMD 트랜잭션을 최종적으로 고려하도록 요구할 수 있습니다, 이는 <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">공증</a>을 기다리는 것보다 스와프 시간이 짧아집니다.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "스왑을 하는 동안 온라인에 있어야 하나요?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "네. 각 아토믹 스왑을 정상적으로 완료하려면 인터넷에 접속한 채로 애플리케이션을 실행해 두어야 합니다(보통 연결이 매우 짧은 상태도 문제 없습니다). 그렇지 않으면 제조업자의 경우 거래가 취소되고 인수업자의 경우 자금 손실 위험이 있습니다. 애트믹스와프 프로토콜을 사용하려면 두 참가자가 온라인으로 남아 프로세스가 아토믹 상태를 유지하기 위해 관련 블록체인을 감시해야 합니다.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "{appName}에서 수수료는 어떻게 계산되나요?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "{appName}에서 거래할 때 고려해야 할 두 가지 수수료 카테고리가 있습니다.\n\n1. {appName}은 수주자의 거래 수수료로 약 0.13%으로(거래량의 1/777 이상 0.0001 이하)를 청구하며 제조사의 주문은 수수료가 제로입니다.\n\n2. 원자력 스와프 거래를 할 때는 제조사와 수험자 모두 관련된 블록체인에 정상적인 네트워크 요금을 지불해야 합니다.\n\n네트워크 요금은 선택한 거래 쌍에 따라 크게 다를 수 있습니다.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "유저 지원을 공급하나요?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "네! {appName}은 <a href=\"{link}\">{appCompanyShort} {name}</a>을 통해서 서포트를 지원합니다. 저희 팀과 커뮤니티는 항상 돕고 싶습니다!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "나라 제한이 있나요?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "아니요! {appName}은 완전한 분권화가 되어있습니다. 유저를 제3자 파티를 통해서 제한하는 것은 불가능합니다.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "{appName} 뒤에는 누가 있나요?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName}은 {appCompanyShort} 팁에서 개발되었습니다. {appCompanyShort}는 원자력 스왑, 지연 작업 증명, 상호 운용 가능한 멀티체인 아키텍처 등의 혁신적인 솔루션을 추진하고 있는 가장 확립된 블록체인 프로젝트 중 하나입니다.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "{appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "전적으로! 자세한 내용은 <a href=\"https://developers.komodoplatform.com/\">개발자 문서</a>를 참조하거나 파트너십 문의 사항이 있는 경우 문의해 주세요. 특정 기술 질문이 있습니까? {appName} 개발자 커뮤니티는 항상 도울 준비가 되어 있습니다!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "어떤 기기에서 {appName}을 사용할 수 있나요?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName}은(는) Android 및 iPhone의 모바일과 <a href=\"https://komodoplatform.com/\">Windows, Mac 및 Linux 운영 체제</a>의 데스크톱에서 사용할 수 있습니다.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "피드",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "뉴스 피드",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "더 읽기...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "아무것도 없습니다",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "뉴스 피드가 업데이트 됬습니다",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "해제",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "뉴스",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "지속시간",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "뉴스 업데이트를 받을 수 없습니다",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "뉴스 업데이트를 진행 할 수 없습니다",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "벌서 최신화 되어 있습니다",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "날짜",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} 뉴스",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "핀 만들기",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "핀 코드를 입력하세요",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "로그인",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "새로운 계정",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "새로운 계정",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "성공적으로 {name} 활성화!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "연결중...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "코인 활성화",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} 자산",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "시드 문구를 입력하세요",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "예시: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "확인",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "경고합니다, 당신은 실제 가치가 없는 테스트 코인을 구매하는 것입니다!",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "스왑을 안전하게 실행하려면 배터리 충전양 ({batteryLevelCritical}%)은 매우 중요합니다. 충전을 하고 다시 시도해 주십시오.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "배터리 충전량이 {batteryLevelLow}%보다 낮습니다. 휴대폰 충전을 부탁드립니다.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "전화기가 배터리 절약 모드로 되어 있습니다. 이 모드를 비활성화하거나 애플리케이션을 백그라운드에 두지 마세요. 그렇지 않으면 OS에 의해 애플리케이션이 중지되고 스왑에 실패할 수 있습니다.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "경고, 진정한 값어치가 없는 테스트 코인을 판매하고 있습니다!",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "구매",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "판매",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "나의 {coinName} 주소:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "인출",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "값이 너무 높거나 낮습니다",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "양",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "수신자 선택",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "{amount} {coinName} 인출",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "인출 확인",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "닫기",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "시드 문구 확인하기",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "당신의 새로운 시드 문구",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "중요: 계속하기 전에 시드 문구를 백업해두세요!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "저희는 오프라인에 저장하는 것을 추천합니다.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "다음",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "핀 코드 확인",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "위장 비밀번호 셋업",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "위장 비밀번호 확인",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "에러, 다시 하세요",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "설정",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "보안",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "비밀번호 보호 활성화",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "스크린샷/미리보기 비활성화",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "스크린이 잠겼습니다",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "비밀번호 바꾸기",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "로그아웃",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "최대",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "최소",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "총 수수료:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "잔액에서 지불:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "거래 모드:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "스킵",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "합체",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "덮어쓰기",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "현제 가치:",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "새로운 값:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "합한 갑어치:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "병함 저장",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "벌서 존재합니다",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "심플",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "고급",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "받은 볼륨에서 지불:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "판매 할 양",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "당신은 받습니다:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "판매하고 싶은 코인 선택",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "구매하고 싶은 코인 선택",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "스왑",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "스와프가 발행되었습니다. 잠시만 기다려주세요!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "주문이 진행 중입니다. {seconde}초를 기다려 주세요!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "네트워크 수수료",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "수수료",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "포티폴리오",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "확인하기",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "예상된 합계치",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "지불 방법 선택",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "볼륨",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "당신의 주문을 넣으세요",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "곳 옵니다...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "마켓플레이스",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "당신은 보냅니다:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "코드:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "값:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "으로 지불",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "데이터를 입력해주세요",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "잔고가 충분하지 않습니다",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Gwei는 최대 {value}이어야 합니다.",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "수수료는 최대 {value}이어야 합니다.",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "한도는 최대 {value}이어야 합니다.",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "유효한 주소가 없습니다",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "세그윗 주소가 (아직) 지원되지 않습니다",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "주소로:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "받기",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "보내기",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "펍키",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "뒤로",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "취소",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "상세",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "네",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "아니요",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "노트: 매치 주문은 다시 취소 될 수 없습니다",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "다시 물어보지 마세요",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "주문 취소",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "주문을 취소하는 것을 확인하시겠습니까?",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "사용 불가능",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "TX 디테일이 곳 옵니다!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "히스토리",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "바꾸기",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "디테일이 곳 옵니다!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "주문 매칭",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "주문 매칭됨",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "스왑이 진행되고 있습니다",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "성공적으로 스왑",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "시간 초과",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "바꾸기",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "스왑 실패",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "에러, 나중에 다시 하세요",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "마지막 거래",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "거래를 받는 중입니다. 잠시 기다려 주세요.",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "마무리 중이니 잠시만 기다려주세요",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "로그 파일 공유",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "주문책 로딩 중...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "받기",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "KMD 보상을 받으시겠습니까?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "성공!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "받을 수 있는 보상 없음 - 1시간 뒤에 다시하세요",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "로딩 중...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "남은 거래: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "뉴스",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "뉴스 피드",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "클립보드에 복사됨",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "에서부터",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "에게",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "확인됨",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "미확인",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "블록",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "확인",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "수수료",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "거래 ID",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "메모",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "히스토리 없음.",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "거래",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "클리어",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "폼 리셋",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "스왑 완료됨!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "방법",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "거래 상세",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "요청된 거래",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "UUID 스왑",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "브라우즈",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "저장",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "여전히 {remains}을(를) 활성화할 수 있습니다. 선택됨: {selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "당신은 저장된 기사가 없습니다",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "브라우즈 피드",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "작성",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "인증 해주세요!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "거래내역 없음",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "완료",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "활성화 코인:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "당신의 포티폴리오에 추가하고 싶은 코인 선택하기",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "뉴스 없음 - 나중에 다시 확인하세요!",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "스왑 요청은 되돌릴수 없고 이는 최종 이벤트입니다!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "스왑은 60분까지 걸릴 수 있습니다. 이 앱플리케이션을 종료하지 마세요!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "변환 상세 확인",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "필요된 최소 볼륨",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "커스텀 최소 볼륨 사용",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "값은 숫자여야 합니다",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "판매 양보다 적어야 합니다",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "값은 {minValue} {coin}보다 커야합니다",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "시드 문구 확인하기",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "다시 한번 당신의 시드 문구를 확인해봅시다",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "당신의 시드 문구는 중요합니다 - 그래서 저희는 이것이 맞는지 확인하고 싶습니다. 필요할 때 언제든지 쉽게 지갑을 복원할 수 있도록 시드 문구에 대해 세 가지 다른 질문을 합니다.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "당신의 시드 문구 안에 있는 {index} 단어는 무엇입니까?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "{index} 단어 입력",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "계속하기",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "다시가서 확인하기",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "익스플로어",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "생체보안 활성화",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "커스텀 시드 허용",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "경고!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "전 이해합니다",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "커스텀 시드 문구는 생성된 BIP39 준거 시드 문구 또는 개인 키(WIF)보다 안전성이 낮고 크랙되기 쉬운 경우가 있습니다. 위험을 이해하고 무엇을 하고 있는지 확인하려면 아래 상자에 \"{iUnderstand}\"라고 입력해주세요.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "당신의 비밀번호 입력하기",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "당신의 지갑",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "비밀번호를 까먹으셨나요? 지갑을 시드로부터 복구하세요",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "비밀번호로 로그인하기",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "당신의 시드 문구 입력하기",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "비밀번화가 일치하지 않습니다. 다시 시도해주세요.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "지갑 이름 정하기",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "보안 이유상 지갑 암호활를 위해 비밀번호를 입력해야 합니다",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "비밀번호 확인",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "전 비밀번호를 원지 않습니다",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "확실하신가요?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "보안 비밀번호를 사용하고 똑같은 장치에 저장해두지 마세요",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "비밀번호 만들기",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "지갑 만들기",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "복구",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "비밀번호",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "비밀번호는 최서 12자 이상이어여 하고, 소문자, 대문자 및 특수 기호가 하나씩 있어야합니다.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "비밀번호 만들기",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "비밀번호 확인",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "현제 비밀번호",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "로그아웃 설정",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "종료 후 로그아웃",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "지갑 삭제",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "삭제",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "이걸 지우시길 원하십니까",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "지갑?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "그렇다면, 확실하게 하세요",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "당신의 시드 문구를 기록하세요/",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "미래에 당신의 지갑을 복구하기 위해서.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "백업",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "버전",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "시드 & 개인 키",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "시드 문구",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "개인 키들",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "개인 키",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "계속하기 위해서 비밀번호를 먼저 입력해주세요.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "클립보드 복사",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "열기",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "성공적으로 {amnt} 펀드를 열었습니다 - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "펀드 열기",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "주문 없음, 가서 거래하세요.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "{coinName} 양을 입력해 주세요.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "비율 바꾸기",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "받기",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "주문 만들기",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "변환",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "주문",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "코인 선택",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗주의! {coinName} 시장의 24시간 거래량이 $10,000 미만입니다!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "언어 선택",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "펀드 없음",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "가능한 펀드 없음 -  ㅂ",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "포티폴리오로 가기",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "주문을 만들기 위해서 눌러주세요",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "볼륨 부족",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "이 주문을 하기 위한 최소 볼륨은",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "주문 생성됨",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "주문이 성공적으로 생성됬습니다",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "나의 주문 보기",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "최소 판매 양은 {number} {coinName}입니다",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "비밀번호 생성",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "최소 구매 양은 {number} {coinName}입니다",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "최소 판매 양은 {number} {coinName}입니다",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "최소 주문 양은 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})입니다",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "판매 양을 먼저 입력하세요",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "지갑 암호화 하는 중",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "지갑 해석 중",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "수수료를 위한 잔고 부족 - 더 작은 양을 거래하세요",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "인터넷 연결 없음",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Komodo로 만들어짐",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "코인을 더해 주세요",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "인터넷 연결 복구됨",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "새로 고침",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "법적",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "부인서명 & ToS",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "EULA 동의",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "이용약관 동의",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "아래 버튼을 클릭하면 'EULA'와 '이용약관'을 읽고 이러한 버튼에 동의할 수 있습니다.",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} 수수료",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "거래를 위한 {coin} 부족합니다!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "{coin}을 활성화하세요.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "당신은 {amount} {coin}을 받습니다",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "{amount} 주문을 보기 위해 클릭하세요",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "눌러서 보기",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "가격",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "최대 볼륨",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "지갑을 설정하고 있습니다, 기다려주세요...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "주문 선택됨",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "거래 수수료:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "거래 수수료:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다. {coin} {amount}가 필요합니다.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "스왑 진행 불가능",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "상세 보기",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "변환 비율:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "선택된 주문:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "최소 주문 볼륨",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "최대 주문 볼륨",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "상세",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "{coin} 활성화와 최고 잔고를 먼저 해주세요",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "거래 수수료 계산 실패",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "비활성화",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "오직 지갑만",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "지갑 이름은 절대로 공백으로 둘 수 없습니다",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "지갑 이름은 최대 40자가 있어야 합니다",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "지갑 이름이 벌서 사용 중 입니다",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX은 이 코인에서 사용 불가합니다",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "코인 찾기",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "SmartChains 토큰 모두 선택",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "테스트 자산 토큰 모두 선택",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "ERC 토큰 모두 선택",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "모든 SLP 토큰 선택",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "코스모스 네트워크 모두 선택",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "홍채 네트워크 모두 선택",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Kucoin 토큰 모두 선택",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Harmony 토큰 모두 선택",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "ETC 토큰 모두 선택",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "SmartBCH 토큰 모두 선택",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Avax 토큰 모두 선택",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Ubiq 코인 모두 선택",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "BEP 토큰 모두 선택",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Polygon 토큰 모두 선택",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "QRC 토큰 모두 선택",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "HecoChain 토큰 모두 선택",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "모든 ZHTLC 코인을 선택하세요",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Fantom 토큰 모두 선택",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Moonriver 토큰 모두 선택",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "통관 수수료",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "가스 제한",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "가스 가격",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "당신이 무엇을 하고 있는지 알고 있는 경우에만 관세비용을 사용하세요!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "UTXO 코인 모두 선택",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Komodo로 만들어짐",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Komodo의해 구동됨",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "가스가 충분하지 않습니다 - 최소 {gas}양의 가스를 사용하세요",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "모든 {coin} 주문이 취소될것 입니다.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "비활성화 확인",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "지우시고 싶으십니까",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "당신의 포티폴리오에서? 일치되지 않은 주문들은 모두 취소됩니다.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " 비활성화도 됩니다",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "비활성화 불가능",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "기본 코인입니다. 기본 코인은 비활성화 될 수 없습니다.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "네",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "공유",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "경고 - 특별한 경우 이 로그 데이터에는 스왑에 실패한 코인을 사용하는 데 사용할 수 있는 중요한 정보가 포함되어 있습니다!",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "옛날 핀을 입력하세요",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "새로운 핀을 입력하세요",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "증명하기",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "언어",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "영어",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "프랑스 국민",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "독일어",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "중국인",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "러시아인",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "일본어",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "터키어",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "헝가리 인",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "스페인의",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "한국인",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "우크라이나 인",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "호수",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "성공",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "에러",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "요청 시간 초과",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "{coin} 호수에게 요청 보내는 중...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "선택 과목",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "소리",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "최대 소리로 틀기",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "테이커",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "당신은 이미 있는 주문과 일치한 새로운 주문을 찾고 있습니다",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "메이커",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "당신은 새로운 주문을 맞출수 있는 주문이 있습니다",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "활성화",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "당신은 진행되고 있는 활성화 스왑이 있습니다",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "실패",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "바꾸기 실패",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "박수",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "바꾸기 완료 중",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "그것은 할 수 없습니다",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "mp3 또는 wav 파일을 골라주세요. 저희가 {description}때 들려드리겠습니다.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "{description}일때 들려주기",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "소리들",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "스왑 진행 중 및 활성 제조업체 주문이 있을 때 사운드 알림이 들립니다.\n아토믹 교환 프로토콜은 성공적인 거래를 위해 참여자들이 온라인에 있어야 하며, 사운드 알림은 이를 달성하는 데 도움이 됩니다.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "앱플리케이션 성정에서 커스텀 소리를 설정 할 수 있다는 것을 알아두세요.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "알겠습니다, 더 이상 보여주지 마세요",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "소리 성정",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "소리",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "마켓",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "마켓",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "가격",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "책 주문",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "차트",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "깊이",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "가격",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "판매",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "위한",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "분.",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "주소",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "편함: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "편함: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "똑같은 CEX",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "받기",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "소비",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "이것은 당신만의 주문입니다!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "코인을 선택해 주세요",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "코인 선택",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "활성화된 코인 없음",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "클리어",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "가격 ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "Amt. ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "총값 ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "입찰을 찾을 수 없음",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "질문을 찾을 수 없음",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "주문 디테일",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "무언가 잘못되었습니다. 나중에 다시 시도해주세요.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "보상 정보",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "KMD 활성화 유저 보상에 대해서 더 읽어 보기",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "취소",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "받기",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "받을 수 있는 보상 없음",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "보상 정보:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO amt,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "보상,\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "피아트",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "남은 시간",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "상태",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "보상 상태:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "네",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} 날(들)",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}h {minutes}m",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}분",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "성공! {amount} KMD를 받았습니다.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXO 양이 10 KMD에 이하입니다",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "진행중",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "거래가 진행되고 있습니다",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 시간",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "한 시간이 지나지 않았습니다",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "당신의 보상을 받으세요",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "거래 내역 보기",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "다시 모든 코인 활성화 중...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "완료 후 포티폴리오 페이지로 리디렉트 됩니다.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "그래도 일부 코인이 활성화되어 있지 않다면, 앱을 재부팅해 보세요.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "다시하기 위해서 앱을 다시 시작하거나, 밑에 버튼을 눌러 주세요.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "다시 모두 활성화 중",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "활성화 재시도가 완료되면 당신은 자동으로 포티폴리오 페이지로 리디랙션이 될 것 입니다.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다.\n앱을 다시 시작하고 다시 해주세요.",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} 이 사용불가합니다 :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "멀티",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "계속하기 전에 모든 에러를 고치세요",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "생성",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "주문",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "주문들",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "코인",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "판매:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "판매",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "양",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "받기:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "가격/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Amt 받기",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "받을 명령 양을 입력하세요:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "취소",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "자동 채우기",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "수수료",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "수수료를 지불할 {coin}이 부족합니다. 최소 잔고는 {fee} {coin}입니다",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "{number} 주문들 생성:",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "취소",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "확인",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "잘못된 판매 양",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "최대 판매 양은",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "최소 판매 양은",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "잘못된 양",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "잘못된 {coin} 주소",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "{coin} 활성화하고 먼저 가장 높은 잔고로",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin} 잔고가 너무 낮습니다",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "최소 받는 양은",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "주소록",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "주소록",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "연락처 상세",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "주소록이 비어 있습니다",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "{title} 주소를 가진 연락처만 보여지고 있습니다",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "연락처 만들기",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "이름",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "연락처 편집",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "취소",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "저장",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "버리기",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "종료",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "변경을 파기하시겠습니까?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "주소 추가",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "코인 선택",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Ticker 찾기",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "연락처 삭제",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "{name}을 연락처를 삭제하는 것을 확인하십니까?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "삭제",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "연락처를 찾을 수 없습니다",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "편집",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "찾을 수 없음",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "그런 코인은 없습니다",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "{abbr}의 주소로 펀드를 보낼수 없습니다, 왜냐하면 {abbr}는 활성화가 되어있지 않습니다. 포티폴리오로 가주세요.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "네",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "연락처 이름은 공백으로 둘 수 없습니다",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "{abbr} 주소 입력",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "위장 비밀번호",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "위장 비밀번호",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "켜기",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "끄기",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "틀린 핀",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "바꾸기",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "위장 비밀번호로 앱을 잠금해제 하면 가짜인 낮은 잔액이 표시되고, 위장 비밀번호 설정 옵션은 설정에 표시되지 않습니다.",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "당신의 일반 핀과 위장 핀이 같습니다.\n위장 모드 사용이 불가능 할 것 입니다.\n위장 핀을 바꿔주세요.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "위장 비밀번호와 바이오인증 보호를 동시에 활성화할 수 없습니다.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "위장 비밀번호와 바이오인증 보호 문제.",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "일반 핀 보호가 활성화되어 있지 않습니다.\n위장 모드를 사용 할 수 없습니다.\n핀 보호를 활성화 시켜주세요.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "가짜 잔고 잔액:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "위장 비밀번호를 찾을 수 없습니다",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "위장 비밀번호 만들기",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "위장 비밀번호 저장됨",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "잘못된 위장 비밀번호",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "위장 비밀번호 바꾸기",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "위장 비밀번호 셋업",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "새로운 위장 비밀번호 입력하기",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "켜기",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "끄기",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "확인 사향",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo dPoW 보안",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "커스텀 보호 설정 사용",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "경고, 이 아토믹 스왑은 dPoW 보호가 않되어 있습니다.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "일치하지 않을 경우 제조사로 변환",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEX 변환 비율",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "편리",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "비싼",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "CEX와 똑같음",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "CEX에게 비교하기",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "평균에 비해. 24시간 CEX 가격",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "활성화",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "히스토리",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "세부 사항",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "한개 탭에서 상세를 열고 긴 탭에서 주문을 선택하세요",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "취소",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "선택",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "알맞는 주문 없음",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "메이커 주문",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "테어커 주문",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "현재",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "견적",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "시작됨",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "전체",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "진행 상세",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "에러 메시지 닫기",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "에러 메세지 열기",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "들어오는 거래",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "당신은 {coin} 거래를 받았습니다!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "스와프 완료됨",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "{sell}/{buy} 가 성공적으로 바꿔었습니다",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "스와프 실패됨",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} 를 바꾸기 실패했습니다",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "스왑 시간 초과됨",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} 스왑 시간이 초과되었습니다",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "스와프 상태가 바꿨습니다",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "새로운 스와프가 시작되었습니다",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} 스와프가 시작되었습니다",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "언어",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "화폐",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "잔고 숨기기",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "테마 전환",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "CEX 데이터",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "이 아이콘이 표시된 시장 데이터(가격, 차트 등)는, 서드 파티(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>)에서 받아왔습니다.",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "업데이트 확인하기",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "지금 로그아웃 하고 싶으신게 맞나요?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "화폐",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "요청이 너무 많습니다.\n거래 이력 요구 제한을 초과했습니다.\n나중에 다시 시도해주세요.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "ms",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "m",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "분",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "h",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "더",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "덜",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "오래된 로그",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "삭제",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "지갑 삭제 중...",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "사용된 용양",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "네",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "프리뷰 닫기",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "취소",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "계속하려면 아래로 스크롤하세요...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "개발자",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "실험 코인 활성화",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "주문 디테일 메이커",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "판매",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "받기",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "가격",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "주문 취소",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "주문 ID",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "에서 만들어짐",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "이 주문에서 스왑이 실행되지 않았습니다",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "이 주문으로 스왑이 시작되었습니다",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% 채워짐",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "노트",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "노트 추가",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "불러오기",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "싱글 스왑 불러오기",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "수출",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "불러오기",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "스왑 불러오기",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "수출",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "함호화된 파일로 내보낼 항목을 선택하세요.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "불러올 암호화된 파일을 선택하세요.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "불러올 일반 텍스트 바꾸기 파일을 선택하세요.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "열람 중...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "불러올 아이템들:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "노트",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "연락처",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "바꾸기",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "찾을 수 없습니다",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "수출",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "불러오기",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "암호화 암호는 공백으로 둘 수 없습니다",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "비밀번호를 공백으로 둘 수 없습니다",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "비밀번호가 알맞아합니다",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "선택된 아이템 없음",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "선택된 아이템 없음",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "파일 선택",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "파일을 찾을 수 없음",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "지문",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "비밀번호",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "취소",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "네",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "아이템이 성공적으로 내보냈습니다:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "아이템을 성공적으로 불러왔습니다:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "불일치한 비밀번호 또는 망가진 데이터",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "json파일 읽기에 에러가 났습니다",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "주문",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "알수 없는 주문 종류",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "가져올 수 없습니다:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "어떤 아이템들을 건너뛌습니다",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "스왑 불러오기를 실패했습니다",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "틀린 데이터 바꾸기. 알맞은 상태의 JSON 파일을 주세요.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "{coinName} 활성화 중",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "앱을 닫지 마세요. 자세한 내용을 보려면 탭하세요...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName} 활성화",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "{protocolName} 코인이 활성화되었습니다",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "{protocolName} 코인이 활성화되지 않았습니다.",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName} 코인이 성공적으로 활성화되었습니다.",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} 활성화 진행 중",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "{protocolName} 코인을 활성화하시겠습니까?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "더 많은 정보",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "주소 표시",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "피싱 시도 가능성으로 인해 이 거래가 숨겨졌습니다.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "거래 주소",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "숨겨진 거래",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "URL을 시작할 수 없습니다.",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "이 작업은 시간이 걸리며 앱이 포그라운드에 유지되어야 합니다.\n활성화가 진행되는 동안 앱을 종료하면 문제가 발생할 수 있습니다.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "경고: iOS에서 앱을 최소화하면 활성화 프로세스가 종료됩니다.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "활성화 진행 상황에 대한 업데이트를 받으려면 알림을 활성화하세요.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "QR 코드 스캐너",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "QR코드 발견",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "계약",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "스왑 시작",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "없음",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "CEX 비율",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "수신되는 {coinName} txs 보호 설정",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "{maxCount}개 주문 중 {count}개를 표시 중입니다.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "더 적은",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "더",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "{coinName1}/{coinName2} 기준",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "거래 수수료 거래 수수료 보내기",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "거래 수수료",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "{coinName} 거래 수수료 보내기",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "{coinName} 거래 수수료를 받습니다",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "필터",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "상태",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "모두",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "성공적",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "실패",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "날짜부터",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "날짜까지",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "테이커/메이커",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "마커",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "모두",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "테이커",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "코인 판매",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "코인 받기",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "모든 필터 지우기",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "부족한 잔고",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "스캔된 것을 위한 잔고가 부족합니다",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "지불 요청.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "너무 많은 자산을 활성화 할려고 하고 있습니다",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "당신의 소유",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "활성화되어 있는 자산과 활성화하려고 하는 자산",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "활성화된 최대 한계치 자산은",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": "새로운 것을 추가하기 전에 먼저 다른 것들을 비활성화 해주세요.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "최대 저작물 수를 선택했습니다.",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "너무 많은 자산이 활성화 되어있습니다",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "당신의 소유",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "자산이 활성화 됬습니다. 활성화된 자산 최대치는",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ". 새로운 것을 추가하기 전에 비활성화를 해주세요.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "지불 요청",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "코인:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "주소 지정",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "양:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "거래를 수락하시겠습니까?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "지불",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "취소",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "잘못된 코인",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "당신은 지불 QR 코드를 스캔 할려고 합니다",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "하지만 당신은",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "인출 화면에 있습니다",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "판매",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "구매",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "받기",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "보내기",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "거이",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "활성화",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "최대 활성화 코인 양은 {maxCoins}입니다. 조금 비활성화 해주세요.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "{coin}을 활성화 할 수 없습니다",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin}이 활성화 되어 있지 않습니다!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "구매할 {coin} 양을 입력하세요",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "판매 할 {coin} 양을 입력하세요",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "덜 보기",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "더 보기",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "코인을 찾을 수 없음",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "새로운 시대입니다! 'AtomicDEX'에서 'Komodo Wallet'으로 공식 명칭을 변경하였습니다.",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "공식 보도 자료",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "과거 {coin} 거래를 검색하시겠습니까?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "활성화 취소",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "활성화를 취소하시겠습니까?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "활성화를 취소하시겠습니까?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "어떤 {name} 거래를 동기화하시겠습니까?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "새 거래 동기화",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "지정된 날짜부터 동기화",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "묘목 활성화에서 동기화",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "날짜를 선택하세요",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "시작일",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "공개 키와 관련된 활성화 후 향후 거래가 동기화됩니다. 이는 가장 빠른 옵션이며 저장 공간을 가장 적게 차지합니다.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "지갑에는 과거 거래가 표시됩니다. 모든 블록이 다운로드되고 스캔되므로 상당한 저장 공간과 시간이 소요됩니다.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "귀하의 지갑에는 지정된 날짜 이후에 이루어진 과거 거래가 표시됩니다.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "{coinName} 활성화 중",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} 활성화",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} 활성화 진행 중",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "활성화",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "코인 활성화",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "성공적으로 {name} 활성화!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "주소 추가",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "주소록",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "주소록이 비어 있습니다",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "{title} 주소를 가진 연락처만 보여지고 있습니다",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "주소록",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "{abbr}의 주소로 펀드를 보낼수 없습니다, 왜냐하면 {abbr}는 활성화가 되어있지 않습니다. 포티폴리오로 가주세요.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "찾을 수 없음",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "코인 선택",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "수신자 선택",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "고급",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "모두",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "커스텀 시드 허용",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "지갑에는 과거 거래가 표시됩니다. 모든 블록이 다운로드되고 스캔되므로 상당한 저장 공간과 시간이 소요됩니다.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "벌서 존재합니다",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "양",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "판매 할 양",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "아니요! {appName}은 정보를 보관하지 않습니다. 키, 시드 문구, 비밀번호 등 기밀 데이터는 저장되지 않습니다. 이 데이터는 사용자의 장치에만 저장되며, 시스템에는 저장되지 않습니다. 당신은 자산을 완전히 관리하고 있습니다.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName}은(는) Android 및 iPhone의 모바일과 <a href=\"https://komodoplatform.com/\">Windows, Mac 및 Linux 운영 체제</a>의 데스크톱에서 사용할 수 있습니다.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "다른 DEX는 일반적으로 단일 블록체인 네트워크를 기반으로 하는 자산 거래, 프록시 토큰 사용, 같은 펀드에서 단일 주문만 가능합니다.\n\n{appName}을 사용하면 프록시 토큰 없이 두 개의 다른 블록체인 네트워크 간에 기본적으로 교환할 수 있습니다. 같은 자금으로 여러 개를 주문할 수도 있습니다. 예를 들어, KMD, QTUM 또는 VRSC으로 0.1 BTC를 판매할 수 있습니다. 첫 주문이 가득 차면 다른 모든 주문이 자동으로 취소됩니다.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "각 스왑의 처리 시간은 몇 가지 요인에 의해 결정됩니다. 거래되는 자산의 블록 시간은 네트워크마다 다릅니다(보통 비트코인이 가장 느립니다). 게다가 사용자는 보안 설정을 커스터마이징 할 수 있습니다. 예를 들어 3번의 확인 후 {appName}에게 KMD 트랜잭션을 최종적으로 고려하도록 요구할 수 있습니다, 이는 <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">공증</a>을 기다리는 것보다 스와프 시간이 짧아집니다.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "네. 각 아토믹 스왑을 정상적으로 완료하려면 인터넷에 접속한 채로 애플리케이션을 실행해 두어야 합니다(보통 연결이 매우 짧은 상태도 문제 없습니다). 그렇지 않으면 제조업자의 경우 거래가 취소되고 인수업자의 경우 자금 손실 위험이 있습니다. 애트믹스와프 프로토콜을 사용하려면 두 참가자가 온라인으로 남아 프로세스가 아토믹 상태를 유지하기 위해 관련 블록체인을 감시해야 합니다.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "{appName}에서 거래할 때 고려해야 할 두 가지 수수료 카테고리가 있습니다.\n\n1. {appName}은 수주자의 거래 수수료로 약 0.13%으로(거래량의 1/777 이상 0.0001 이하)를 청구하며 제조사의 주문은 수수료가 제로입니다.\n\n2. 원자력 스와프 거래를 할 때는 제조사와 수험자 모두 관련된 블록체인에 정상적인 네트워크 요금을 지불해야 합니다.\n\n네트워크 요금은 선택한 거래 쌍에 따라 크게 다를 수 있습니다.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "네! {appName}은 <a href=\"{link}\">{appCompanyShort} {name}</a>을 통해서 서포트를 지원합니다. 저희 팀과 커뮤니티는 항상 돕고 싶습니다!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "아니요! {appName}은 완전한 분권화가 되어있습니다. 유저를 제3자 파티를 통해서 제한하는 것은 불가능합니다.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName}은 {appCompanyShort} 팁에서 개발되었습니다. {appCompanyShort}는 원자력 스왑, 지연 작업 증명, 상호 운용 가능한 멀티체인 아키텍처 등의 혁신적인 솔루션을 추진하고 있는 가장 확립된 블록체인 프로젝트 중 하나입니다.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "전적으로! 자세한 내용은 <a href=\"https://developers.komodoplatform.com/\">개발자 문서</a>를 참조하거나 파트너십 문의 사항이 있는 경우 문의해 주세요. 특정 기술 질문이 있습니까? {appName} 개발자 커뮤니티는 항상 도울 준비가 되어 있습니다!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "박수",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "확실하신가요?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "바꾸기 실패",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "바꾸기 완료 중",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "증명하기",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "활성화 재시도가 완료되면 당신은 자동으로 포티폴리오 페이지로 리디랙션이 될 것 입니다.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "최대 볼륨",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "뒤로",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "백업",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "{coinName1}/{coinName2} 기준",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "스왑을 안전하게 실행하려면 배터리 충전양 ({batteryLevelCritical}%)은 매우 중요합니다. 충전을 하고 다시 시도해 주십시오.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "배터리 충전량이 {batteryLevelLow}%보다 낮습니다. 휴대폰 충전을 부탁드립니다.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "전화기가 배터리 절약 모드로 되어 있습니다. 이 모드를 비활성화하거나 애플리케이션을 백그라운드에 두지 마세요. 그렇지 않으면 OS에 의해 애플리케이션이 중지되고 스왑에 실패할 수 있습니다.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "비율 바꾸기",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Komodo로 만들어짐",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Komodo로 만들어짐",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "구매",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "일치하지 않을 경우 제조사로 변환",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "스와프가 발행되었습니다. 잠시만 기다려주세요!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "주문이 진행 중입니다. {seconde}초를 기다려 주세요!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "경고합니다, 당신은 실제 가치가 없는 테스트 코인을 구매하는 것입니다!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "위장 비밀번호와 바이오인증 보호를 동시에 활성화할 수 없습니다.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "위장 비밀번호와 바이오인증 보호 문제.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "위장 비밀번호 바꾸기",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "위장 비밀번호 만들기",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "위장 비밀번호로 앱을 잠금해제 하면 가짜인 낮은 잔액이 표시되고, 위장 비밀번호 설정 옵션은 설정에 표시되지 않습니다.",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "잘못된 위장 비밀번호",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "위장 비밀번호",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "위장 비밀번호를 찾을 수 없습니다",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "끄기",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "켜기",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "위장 비밀번호 저장됨",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "위장 비밀번호",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "새로운 위장 비밀번호 입력하기",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "위장 비밀번호 셋업",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "위장 비밀번호 셋업",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "취소",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "활성화 취소",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "활성화를 취소하시겠습니까?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "취소",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "주문 취소",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "무언가 잘못되었습니다. 나중에 다시 시도해주세요.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "네",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "기본 코인입니다. 기본 코인은 비활성화 될 수 없습니다.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "비활성화 불가능",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "그것은 할 수 없습니다",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEX 변환 비율",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEX 데이터",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "이 아이콘이 표시된 시장 데이터(가격, 차트 등)는, 서드 파티(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>)에서 받아왔습니다.",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEX 비율",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "비밀번호 바꾸기",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "업데이트 확인하기",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "확인하기",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "시드 문구 확인하기",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "계속하기",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "다시가서 확인하기",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "{index} 단어 입력",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "당신의 시드 문구는 중요합니다 - 그래서 저희는 이것이 맞는지 확인하고 싶습니다. 필요할 때 언제든지 쉽게 지갑을 복원할 수 있도록 시드 문구에 대해 세 가지 다른 질문을 합니다.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "당신의 시드 문구 안에 있는 {index} 단어는 무엇입니까?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "다시 한번 당신의 시드 문구를 확인해봅시다",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "중국인",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "받기",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "KMD 보상을 받으시겠습니까?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "눌러서 보기",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "클립보드에 복사됨",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "클립보드 복사",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "닫기",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "에러 메시지 닫기",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "프리뷰 닫기",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "코드:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "활성화를 취소하시겠습니까?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "최대 저작물 수를 선택했습니다.",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName} 코인이 활성화되었습니다",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName} 코인이 성공적으로 활성화되었습니다.",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "{protocolName} 코인이 활성화되지 않았습니다.",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "클리어",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "활성화된 코인 없음",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "코인 선택",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "곳 옵니다...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "TX 디테일이 곳 옵니다!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "디테일이 곳 옵니다!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "수수료",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "평균에 비해. 24시간 CEX 가격",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "CEX에게 비교하기",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "지갑을 설정하고 있습니다, 기다려주세요...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "확인",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "위장 비밀번호 확인",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "주문을 취소하는 것을 확인하시겠습니까?",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "아래 버튼을 클릭하면 'EULA'와 '이용약관'을 읽고 이러한 버튼에 동의할 수 있습니다.",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "비밀번호 확인",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "핀 코드 확인",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "시드 문구 확인하기",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "연결중...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "취소",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "연락처 삭제",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "삭제",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "{name}을 연락처를 삭제하는 것을 확인하십니까?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "버리기",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "편집",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "종료",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "변경을 파기하시겠습니까?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "연락처를 찾을 수 없습니다",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "저장",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "연락처 상세",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "이름",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "계약",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "바꾸기",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "URL을 시작할 수 없습니다.",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "가져올 수 없습니다:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "바꾸기",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "지갑 만들기",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "연락처 만들기",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "핀 만들기",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "화폐",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "화폐",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "현제 가치:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "통관 수수료",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "당신이 무엇을 하고 있는지 알고 있는 경우에만 관세비용을 사용하세요!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "커스텀 시드 문구는 생성된 BIP39 준거 시드 문구 또는 개인 키(WIF)보다 안전성이 낮고 크랙되기 쉬운 경우가 있습니다. 위험을 이해하고 무엇을 하고 있는지 확인하려면 아래 상자에 \"{iUnderstand}\"라고 입력해주세요.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "날짜",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "지갑 해석 중",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "삭제",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "비활성화 확인",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "지우시고 싶으십니까",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "당신의 포티폴리오에서? 일치되지 않은 주문들은 모두 취소됩니다.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " 비활성화도 됩니다",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "지갑 삭제",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "지갑 삭제 중...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "{coinName} 거래 수수료를 받습니다",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "{coinName} 거래 수수료 보내기",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "거래 수수료 거래 수수료 보내기",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "거래 수수료",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "상세",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "독일어",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "개발자",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX은 이 코인에서 사용 불가합니다",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "스크린샷/미리보기 비활성화",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "부인서명 & ToS",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "완료",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "앱을 닫지 마세요. 자세한 내용을 보려면 탭하세요...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "다시 물어보지 마세요",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "전 비밀번호를 원지 않습니다",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW 보안",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "지속시간",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "연락처 편집",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "{abbr} 주소 입력",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "암호화 암호는 공백으로 둘 수 없습니다",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "비밀번호를 공백으로 둘 수 없습니다",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "연락처 이름은 공백으로 둘 수 없습니다",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "지갑 이름은 절대로 공백으로 둘 수 없습니다",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "여전히 {remains}을(를) 활성화할 수 있습니다. 선택됨: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "활성화 진행 상황에 대한 업데이트를 받으려면 알림을 활성화하세요.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "실험 코인 활성화",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "당신의 소유",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "활성화되어 있는 자산과 활성화하려고 하는 자산",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "활성화된 최대 한계치 자산은",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": "새로운 것을 추가하기 전에 먼저 다른 것들을 비활성화 해주세요.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "너무 많은 자산을 활성화 할려고 하고 있습니다",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "지갑 암호화 하는 중",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "영어",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "새로운 핀을 입력하세요",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "옛날 핀을 입력하세요",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "계속하기 위해서 비밀번호를 먼저 입력해주세요.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "핀 코드를 입력하세요",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "시드 문구를 입력하세요",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "판매 양을 먼저 입력하세요",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "잔고가 충분하지 않습니다",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "유효한 주소가 없습니다",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "세그윗 주소가 (아직) 지원되지 않습니다",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "가스가 충분하지 않습니다 - 최소 {gas}양의 가스를 사용하세요",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "에러, 다시 하세요",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "에러, 나중에 다시 하세요",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "값이 너무 높거나 낮습니다",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "데이터를 입력해주세요",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "예상된 합계치",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "예시: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "편리",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "비싼",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "CEX와 똑같음",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "변환 비율:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "변환",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "수출",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "연락처",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "함호화된 파일로 내보낼 항목을 선택하세요.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "수출",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "노트",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "아이템이 성공적으로 내보냈습니다:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "바꾸기",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "수출",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "실패",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "가짜 잔고 잔액:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "자주 묻는 질문들",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "에러",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "{coin} 호수에게 요청 보내는 중...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "호수",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "성공",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "요청 시간 초과",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "로그 파일 공유",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "뉴스",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "아무것도 없습니다",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} 뉴스",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "더 읽기...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "피드",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "뉴스 피드",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "뉴스 업데이트를 진행 할 수 없습니다",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "뉴스 업데이트를 받을 수 없습니다",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "뉴스 피드가 업데이트 됬습니다",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "벌서 최신화 되어 있습니다",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "수수료는 최대 {value}이어야 합니다.",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "모두",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "필터",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "모든 필터 지우기",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "실패",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "날짜부터",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "마커",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "코인 받기",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "코인 판매",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "상태",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "성공적",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "테이커",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "날짜까지",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "테이커/메이커",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "지문",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "마무리 중이니 잠시만 기다려주세요",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "QR코드 발견",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "프랑스 국민",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "에서부터",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "공개 키와 관련된 활성화 후 향후 거래가 동기화됩니다. 이는 가장 빠른 옵션이며 저장 공간을 가장 적게 차지합니다.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} 수수료",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "가스 제한",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "{coin}을 활성화하세요.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "가스 가격",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "일반 핀 보호가 활성화되어 있지 않습니다.\n위장 모드를 사용 할 수 없습니다.\n핀 보호를 활성화 시켜주세요.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "중요: 계속하기 전에 시드 문구를 백업해두세요!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "거래를 받는 중입니다. 잠시 기다려 주세요.",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "포티폴리오로 가기",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei는 최대 {value}이어야 합니다.",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "도움",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "도움 및 서포트",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "잔고 숨기기",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "비밀번호 확인",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "비밀번호 만들기",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "현제 비밀번호",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "당신의 비밀번호 입력하기",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "당신의 시드 문구 입력하기",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "지갑 이름 정하기",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "비밀번호",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "히스토리",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "h",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "헝가리 인",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "불러오기",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "불일치한 비밀번호 또는 망가진 데이터",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "불러올 아이템들:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "파일을 찾을 수 없음",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "틀린 데이터 바꾸기. 알맞은 상태의 JSON 파일을 주세요.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "불러오기",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "불러올 암호화된 파일을 선택하세요.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "열람 중...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "불러올 일반 텍스트 바꾸기 파일을 선택하세요.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "취소",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "네",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "비밀번호",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "싱글 스왑 불러오기",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "스왑 불러오기",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "어떤 아이템들을 건너뛌습니다",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "아이템을 성공적으로 불러왔습니다:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "스왑 불러오기를 실패했습니다",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "json파일 읽기에 에러가 났습니다",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "불러오기",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "수신되는 {coinName} txs 보호 설정",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "보안 비밀번호를 사용하고 똑같은 장치에 저장해두지 마세요",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "스왑 요청은 되돌릴수 없고 이는 최종 이벤트입니다!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "스왑은 60분까지 걸릴 수 있습니다. 이 앱플리케이션을 종료하지 마세요!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "보안 이유상 지갑 암호활를 위해 비밀번호를 입력해야 합니다",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "이 주문을 하기 위한 최소 볼륨은",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "볼륨 부족",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "새로 고침",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "인터넷 연결 복구됨",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "잘못된 {coin} 주소",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "스왑 진행 불가능",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "상세",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} 이 사용불가합니다 :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "전 이해합니다",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "일본어",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "한국인",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "언어",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "마지막 거래",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "법적",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "덜",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗주의! {coinName} 시장의 24시간 거래량이 $10,000 미만입니다!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "한도는 최대 {value}이어야 합니다.",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "로딩 중...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "주문책 로딩 중...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "스크린이 잠겼습니다",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "인증 해주세요!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "로그인",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "로그아웃",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "종료 후 로그아웃",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "로그아웃 설정",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "지금 로그아웃 하고 싶으신게 맞나요?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "분",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "주문 만들기",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "메이커",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "주문 취소",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "에서 만들어짐",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "받기",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "주문 ID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "이 주문에서 스왑이 실행되지 않았습니다",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "가격",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "판매",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "이 주문으로 스왑이 시작되었습니다",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "주문 디테일 메이커",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "메이커 주문",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "마켓플레이스",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "차트",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "깊이",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "질문을 찾을 수 없음",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "입찰을 찾을 수 없음",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "책 주문",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "주문 디테일",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "가격",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "코인을 선택해 주세요",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "마켓",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "마켓",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "비밀번호가 알맞아합니다",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "바꾸기",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "당신의 일반 핀과 위장 핀이 같습니다.\n위장 모드 사용이 불가능 할 것 입니다.\n위장 핀을 바꿔주세요.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "틀린 핀",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "최대",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "최대 주문 볼륨",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "뉴스",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "브라우즈",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "브라우즈 피드",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "작성",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "당신은 저장된 기사가 없습니다",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "저장",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "메모",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "합체",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "합한 갑어치:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "ms",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "최소",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "경고: iOS에서 앱을 최소화하면 활성화 프로세스가 종료됩니다.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "최소 주문 볼륨",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "m",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "최소 판매 양은 {number} {coinName}입니다",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "최소 구매 양은 {number} {coinName}입니다",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "최소 주문 양은 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})입니다",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "최소 판매 양은 {number} {coinName}입니다",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "값은 {minValue} {coin}보다 커야합니다",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "판매 양보다 적어야 합니다",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "필요된 최소 볼륨",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "커스텀 최소 볼륨 사용",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "이제 셀룰러 데이터를 사용하고 {appName} P2P 네트워크에 참여하여 인터넷 트래픽을 소비합니다. 셀룰러 데이터 요금제가 비싸다면 WiFi 네트워크를 사용하는 것이 좋습니다.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "더 많은 정보",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "더",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "{coin} 활성화하고 먼저 가장 높은 잔고로",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "양",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "코인",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "판매",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "취소",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "확인",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "{number} 주문들 생성:",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "생성",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "주문",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "주문들",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "수수료",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "취소",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "받을 명령 양을 입력하세요:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "자동 채우기",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "계속하기 전에 모든 에러를 고치세요",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "잘못된 양",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "잘못된 판매 양",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "수수료를 지불할 {coin}이 부족합니다. 최소 잔고는 {fee} {coin}입니다",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} 잔고가 너무 낮습니다",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "최대 판매 양은",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "최소 받는 양은",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "최소 판매 양은",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "받기:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "판매:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "멀티",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Amt 받기",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "가격/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "네트워크 수수료",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "새로운 계정",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "새로운 계정",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "뉴스 피드",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "새로운 값:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "다음",
-  "@next": {
-    "type": "text"
-  },
-  "no": "아니요",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "뉴스 없음 - 나중에 다시 확인하세요!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "코인을 찾을 수 없음",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "펀드 없음",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "가능한 펀드 없음 -  ㅂ",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "인터넷 연결 없음",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "선택된 아이템 없음",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "선택된 아이템 없음",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "알맞는 주문 없음",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "없음",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "값은 숫자여야 합니다",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "{coinName} 양을 입력해 주세요.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "주문을 만들기 위해서 눌러주세요",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "주문 없음, 가서 거래하세요.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "받을 수 있는 보상 없음",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "받을 수 있는 보상 없음 - 1시간 뒤에 다시하세요",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "그런 코인은 없습니다",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "히스토리 없음.",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "거래를 위한 {coin} 부족합니다!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "수수료를 위한 잔고 부족 - 더 작은 양을 거래하세요",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "노트: 매치 주문은 다시 취소 될 수 없습니다",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "노트 추가",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "노트",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "찾을 수 없습니다",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "{sell}/{buy} 가 성공적으로 바꿔었습니다",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "스와프 완료됨",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} 를 바꾸기 실패했습니다",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "스와프 실패됨",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} 스와프가 시작되었습니다",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "새로운 스와프가 시작되었습니다",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "스와프 상태가 바꿨습니다",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} 스왑 시간이 초과되었습니다",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "스왑 시간 초과됨",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "당신은 {coin} 거래를 받았습니다!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "들어오는 거래",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "거래내역 없음",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} 자산",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "공식 보도 자료",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "네",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "삭제",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "오래된 로그",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "사용된 용양",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "에러 메세지 열기",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "선택 과목",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "더 적은",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "더",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "모든 {coin} 주문이 취소될것 입니다.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "주문 생성됨",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "주문이 성공적으로 생성됬습니다",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "주소",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "취소",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "편함: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "편함: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "위한",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "똑같은 CEX",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "분.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "가격",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "받기",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "선택",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "판매",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "한개 탭에서 상세를 열고 긴 탭에서 주문을 선택하세요",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "소비",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "세부 사항",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% 채워짐",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "주문 매칭됨",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "주문 매칭",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "주문",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "활성화",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "히스토리",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Amt. ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "가격 ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "총값 ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "주문",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "알수 없는 주문 종류",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "덮어쓰기",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "이것은 당신만의 주문입니다!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "잔액에서 지불:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "받은 볼륨에서 지불:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "으로 지불",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "비밀번호는 최서 12자 이상이어여 하고, 소문자, 대문자 및 특수 기호가 하나씩 있어야합니다.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "귀하의 지갑에는 지정된 날짜 이후에 이루어진 과거 거래가 표시됩니다.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "지불",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "거래를 수락하시겠습니까?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "주소 지정",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "양:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "코인:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "취소",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "지불 요청",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "당신의 주문을 넣으세요",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "최대 소리로 틀기",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "코인을 더해 주세요",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "다시하기 위해서 앱을 다시 시작하거나, 밑에 버튼을 눌러 주세요.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "포티폴리오",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Komodo의해 구동됨",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "가격",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "개인 키",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "개인 키들",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "확인 사향",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "커스텀 보호 설정 사용",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "끄기",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "켜기",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "경고, 이 아토믹 스왑은 dPoW 보호가 않되어 있습니다.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "펍키",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "QR 코드 스캐너",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "제 개인 키를 보관하나요?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "어떤 기기에서 {appName}을 사용할 수 있나요?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "다른 DEX들에서 거래하는 것 보다 {appName}에서 하는 것이 무엇이 다른가요?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "각각의 아토믹 스왑을 얼마나 걸리나요?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "스왑을 하는 동안 온라인에 있어야 하나요?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "{appName}에서 수수료는 어떻게 계산되나요?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "유저 지원을 공급하나요?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "나라 제한이 있나요?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "{appName} 뒤에는 누가 있나요?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "{appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "새로운 시대입니다! 'AtomicDEX'에서 'Komodo Wallet'으로 공식 명칭을 변경하였습니다.",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "받기",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "받기",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "저희는 오프라인에 저장하는 것을 추천합니다.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "비활성화",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "요청된 거래",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "클리어",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "폼 리셋",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "복구",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "다시 모든 코인 활성화 중...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "다시 모두 활성화 중",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "당신의 보상을 받으세요",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "취소",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "거래가 진행되고 있습니다",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "진행중",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO 양이 10 KMD에 이하입니다",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "한 시간이 지나지 않았습니다",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 시간",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "네",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "보상 상태:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "KMD 활성화 유저 보상에 대해서 더 읽어 보기",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "받기",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "성공! {amount} KMD를 받았습니다.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "피아트",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "보상,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "상태",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "남은 시간",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "보상 정보:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO amt,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} 날(들)",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}h {minutes}m",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}분",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "보상 정보",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "러시아인",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "병함 저장",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "계속하려면 아래로 스크롤하세요...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "코인 찾기",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Avax 토큰 모두 선택",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "BEP 토큰 모두 선택",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "코스모스 네트워크 모두 선택",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "ERC 토큰 모두 선택",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "ETC 토큰 모두 선택",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Fantom 토큰 모두 선택",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "HecoChain 토큰 모두 선택",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Harmony 토큰 모두 선택",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "홍채 네트워크 모두 선택",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Kucoin 토큰 모두 선택",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Moonriver 토큰 모두 선택",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Polygon 토큰 모두 선택",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "QRC 토큰 모두 선택",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "SmartBCH 토큰 모두 선택",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "모든 SLP 토큰 선택",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "SmartChains 토큰 모두 선택",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "테스트 자산 토큰 모두 선택",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Ubiq 코인 모두 선택",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "UTXO 코인 모두 선택",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "모든 ZHTLC 코인을 선택하세요",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Ticker 찾기",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "보안",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "시드 문구",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "당신의 새로운 시드 문구",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "{amount} 주문을 보기 위해 클릭하세요",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "거래 내역 보기",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "코인 선택",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "당신의 포티폴리오에 추가하고 싶은 코인 선택하기",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "활성화 코인:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "구매하고 싶은 코인 선택",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "판매하고 싶은 코인 선택",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "날짜를 선택하세요",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "선택된 주문:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "파일 선택",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "언어 선택",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "지불 방법 선택",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "판매",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "경고, 진정한 값어치가 없는 테스트 코인을 판매하고 있습니다!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "보내기",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "이걸 지우시길 원하십니까",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "지갑?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "그렇다면, 확실하게 하세요",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "당신의 시드 문구를 기록하세요/",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "미래에 당신의 지갑을 복구하기 위해서.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "언어",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "설정",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "비밀번호 만들기",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "공유",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "나의 {coinName} 주소:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "과거 {coin} 거래를 검색하시겠습니까?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "주소 표시",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "상세 보기",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "{maxCount}개 주문 중 {count}개를 표시 중입니다.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "나의 주문 보기",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "비밀번호로 로그인하기",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "비밀번호를 까먹으셨나요? 지갑을 시드로부터 복구하세요",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "심플",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "활성화",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "구매할 {coin} 양을 입력하세요",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "구매",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "거이",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "최대 활성화 코인 양은 {maxCoins}입니다. 조금 비활성화 해주세요.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin}이 활성화 되어 있지 않습니다!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "받기",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "판매 할 {coin} 양을 입력하세요",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "판매",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "보내기",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "덜 보기",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "더 보기",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "{coin}을 활성화 할 수 없습니다",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "스킵",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "해제",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "소리",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "mp3 또는 wav 파일을 골라주세요. 저희가 {description}때 들려드리겠습니다.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "{description}일때 들려주기",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "소리들",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "알겠습니다, 더 이상 보여주지 마세요",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "소리",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "소리 성정",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "스왑 진행 중 및 활성 제조업체 주문이 있을 때 사운드 알림이 들립니다.\n아토믹 교환 프로토콜은 성공적인 거래를 위해 참여자들이 온라인에 있어야 하며, 사운드 알림은 이를 달성하는 데 도움이 됩니다.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "앱플리케이션 성정에서 커스텀 소리를 설정 할 수 있다는 것을 알아두세요.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "스페인의",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "시작일",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "스왑 시작",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "방법",
-  "@step": {
-    "type": "text"
-  },
-  "success": "성공!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "지원",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "궁금한 점이 있거나, {appName} 앱의 기술적인 문제를 발견하셨다고 생각하시면, 보고하고 팀의 지원을 받으실 수 있습니다.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "스왑",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "현재",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "변환 상세 확인",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "견적",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "스왑 실패",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "{coin} 활성화와 최고 잔고를 먼저 해주세요",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "{coin} 잔고가 거래 수수료를 지불하기 부족합니다. {coin} {amount}가 필요합니다.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "스왑이 진행되고 있습니다",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "진행 상세",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "시작됨",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "성공적으로 스왑",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "전체",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "UUID 스왑",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "테마 전환",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "지정된 날짜부터 동기화",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "묘목 활성화에서 동기화",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "새 거래 동기화",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "어떤 {name} 거래를 동기화하시겠습니까?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "테이커",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "테어커 주문",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "시간 초과",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "비밀번호 생성",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "주문 선택됨",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "에게",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "주소로:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "당신의 소유",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "자산이 활성화 됬습니다. 활성화된 자산 최대치는",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". 새로운 것을 추가하기 전에 비활성화를 해주세요.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "너무 많은 자산이 활성화 되어있습니다",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "총 수수료:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "거래",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "스왑 완료됨!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "거래 상세",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "거래 수수료 계산 실패",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "거래 수수료:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "거래 모드:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "거래 주소",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "숨겨진 거래",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "피싱 시도 가능성으로 인해 이 거래가 숨겨졌습니다.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "그래도 일부 코인이 활성화되어 있지 않다면, 앱을 재부팅해 보세요.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "터키어",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "블록",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "확인",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "확인됨",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "수수료",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "거래 수수료:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "거래 ID",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "남은 거래: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "요청이 너무 많습니다.\n거래 이력 요구 제한을 초과했습니다.\n나중에 다시 시도해주세요.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "미확인",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "우크라이나 인",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "열기",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "펀드 열기",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "성공적으로 {amnt} 펀드를 열었습니다 - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "사용 불가능",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "새로운 버전 사용 가능",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "업데이트 확인중...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "당신은 {version} 사용 중 입니다",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "새로운 버전이 있습니다. 업데이트를 하세요.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "버전 {version}이 있습니다. 업데이트를 하세요.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "업데이트가 있습니다",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "지금은 스킵",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "{appName} 업데이트",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "업데이트",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "벌서 업데이트 되어있습니다",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "스캔된 것을 위한 잔고가 부족합니다",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "지불 요청.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "부족한 잔고",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "값:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "버전",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "익스플로어",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "시드 & 개인 키",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "볼륨",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "지갑 이름이 벌서 사용 중 입니다",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "지갑 이름은 최대 40자가 있어야 합니다",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "오직 지갑만",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "경고!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "네",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "경고 - 특별한 경우 이 로그 데이터에는 스왑에 실패한 코인을 사용하는 데 사용할 수 있는 중요한 정보가 포함되어 있습니다!",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "저희가 {coinAbbr}를 활성화 하는 것을 실패했습니다.\n앱을 다시 시작하고 다시 해주세요.",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} 모바일은 3세대 DEX 기능과 더 많은 기능 등을 탑재한 차세대 멀티코인 지갑입니다.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "이걸 준비해 봅시다!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "환영합니다",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "지갑",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "완료 후 포티폴리오 페이지로 리디렉트 됩니다.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "이 작업은 시간이 걸리며 앱이 포그라운드에 유지되어야 합니다.\n활성화가 진행되는 동안 앱을 종료하면 문제가 발생할 수 있습니다.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "인출",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "카메라에 대한 {appName} 액세스를 이전에 거부했습니다.\nQR코드 스캔을 실시하려면 전화기의 설정에서 카메라의 허가를 수동으로 변경해 주세요.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "액세스 거부",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "인출 확인",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "무언가 잘못 됬습니다. 나중에 다시 시도하세요.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "{amount} {coinName} 인출",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "당신은 지불 QR 코드를 스캔 할려고 합니다",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "하지만 당신은",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "인출 화면에 있습니다",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "잘못된 코인",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "비밀번화가 일치하지 않습니다. 다시 시도해주세요.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "네",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "당신은 보냅니다:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "당신은 이미 있는 주문과 일치한 새로운 주문을 찾고 있습니다",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "당신은 진행되고 있는 활성화 스왑이 있습니다",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "당신은 새로운 주문을 맞출수 있는 주문이 있습니다",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "당신의 지갑",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "당신은 {amount} {coin}을 받습니다",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "당신은 받습니다:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -3621,6 +3621,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "{coinAbbr} 활성화를 취소하지 못했습니다.",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} 이 사용불가합니다 :(",
     "@isUnavailable": {
         "type": "text",
@@ -5460,6 +5470,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "코인 활성화가 취소되었습니다.",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "{coin}을(를) 성공적으로 활성화했습니다",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "{coin} 활성화가 취소되었습니다.",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "모든 특별 코인 활성화 요청을 수락하거나 코인 선택을 취소하세요.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "활성화 취소",
     "@cancelActivation": {

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,1020 +1,190 @@
 {
-  "@@locale": "en",
-  "accepteula": "Accept EULA",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Accept TERMS and CONDITIONS",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Activate Biometric protection",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "Activate PIN protection",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "Activate {protocolName} coins?",
-  "@activateCoins": {
+  "@@last_modified": "2023-10-06T11:55:34.625736",
+  "mobileDataWarning": "Please note that now you're using cellular data and participation in {appName} P2P network consume internet traffic. It's better to use a WiFi network if your cellular data plan is costly.",
+  "@mobileDataWarning": {
     "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "activating": "Activating {coinName}",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} Activation",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} Activation in Progress",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Active",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Add Coin",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "Activated {name} successfully !",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Add Address",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Address book",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "Address book is empty",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Only showing contacts with {title} addresses",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Address Book",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "You can not send funds to {abbr} address, because {abbr} is not activated. Please go to portfolio.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Nothing found",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Select Coin",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Recipients address",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Advanced",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "All",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Allow custom seed",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "alreadyExists": "Already exists",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Amount",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Amount To Sell",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "No! {appName} is non-custodial. We never store any sensitive data, including your private keys, seed phrases, or PIN. This data is only stored on the user’s device and never leaves it. You are in full control of your assets.",
-  "@answer_1": {
-    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
       "appName": {}
     }
   },
-  "answer_10": "{appName} is available for mobile on both Android and iPhone, and for desktop on <a href=\"https://komodoplatform.com/\">Windows, Mac, and Linux operating systems</a>.",
-  "@answer_10": {
+  "withdrawCameraAccessTitle": "Access Denied",
+  "@withdrawCameraAccessTitle": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "withdrawCameraAccessText": "You have previously denied {appName} access to the camera.\nPlease manually change camera permission in your phone settings to proceed with the QR code scan.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
       "appName": {}
     }
   },
-  "answer_2": "Other DEXs generally only allow you to trade assets that are based on a single blockchain network, use proxy tokens, and only allow placing a single order with the same funds.\n\n{appName} enables you to natively trade across two different blockchain networks without proxy tokens. You can also place multiple orders with the same funds. For example, you can sell 0.1 BTC for KMD, QTUM, or VRSC — the first order that fills automatically cancels all other orders.",
-  "@answer_2": {
+  "welcomeTitle": "WELCOME",
+  "@welcomeTitle": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "welcomeWallet": "wallet",
+  "@welcomeWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "welcomeInfo": "{appName} mobile is a next generation multi-coin wallet with native third generation DEX functionality and more.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
       "appName": {}
     }
   },
-  "answer_3": "Several factors determine the processing time for each swap. The block time of the traded assets depends on each network (Bitcoin typically being the slowest) Additionally, the user can customize security preferences. For example, you can ask {appName} to consider a KMD transaction as final after just 3 confirmations which makes the swap time shorter compared to waiting for a <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.",
-  "@answer_3": {
+  "welcomeLetSetUp": "LET'S GET SET UP!",
+  "@welcomeLetSetUp": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
       "appName": {}
     }
   },
-  "answer_4": "Yes. You must remain connected to the internet and have your app running to successfully complete each atomic swap (very short breaks in connectivity are usually fine). Otherwise, there is risk of trade cancellation if you are a maker, and risk of loss of funds if you are a taker. The atomic swap protocol requires both participants to stay online and monitor the involved blockchains for the process to stay atomic.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "There are two fee categories to consider when trading on {appName}.\n\n1. {appName} charges approximately 0.13% (1/777 of trading volume but not lower than 0.0001) as the trading fee for taker orders, and maker orders have zero fees.\n\n2. Both makers and takers will need to pay normal network fees to the involved blockchains when making atomic swap transactions.\n\nNetwork fees can vary greatly depending on your selected trading pair.",
-  "@answer_5": {
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
     "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "answer_6": "Yes! {appName} offers support through the <a href=\"{link}\">{appCompanyShort} {name}</a>. The team and the community are always happy to help!",
-  "@answer_6": {
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER\n\n",
+  "@eulaTitle3": {
     "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "answer_7": "No! {appName} is fully decentralized. It is not possible to limit user access by any third party.",
-  "@answer_7": {
+  "eulaTitle4": "GENERAL USE\n\n",
+  "@eulaTitle4": {
     "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "answer_8": "{appName} is developed by the {appCompanyShort} team. {appCompanyShort} is one of the most established blockchain projects working on innovative solutions like atomic swaps, Delayed Proof of Work, and an interoperable multi-chain architecture.",
-  "@answer_8": {
+  "eulaTitle5": "MODIFICATIONS\n\n",
+  "@eulaTitle5": {
     "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "answer_9": "Absolutely! You can read our <a href=\"https://developers.komodoplatform.com/\">developer documentation</a> for more details or contact us with your partnership inquiries. Have a specific technical question? The {appName} developer community is always ready to help!",
-  "@answer_9": {
+  "eulaTitle6": "LIMITATIONS ON USE\n\n",
+  "@eulaTitle6": {
     "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "Applause": "Applause",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "ARE YOU SURE?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "a swap fails",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "a swap runs to completion",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "authenticate",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "You will be automatically redirected to portfolio page when the retry activation process completes.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "max vol",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "back",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Backup",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "based on {coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP\n\n",
+  "@eulaTitle7": {
     "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "batteryCriticalError": "Your battery charge is critical ({batteryLevelCritical}%) to perform a swap safely. Please put it on charge and try again.",
-  "@batteryCriticalError": {
+  "eulaTitle8": "BACKUPS\n\n",
+  "@eulaTitle8": {
     "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "batteryLowWarning": "Your battery charge is lower than {batteryLevelLow}%. Please consider phone charging.",
-  "@batteryLowWarning": {
+  "eulaTitle9": "GENERAL WARNING\n\n",
+  "@eulaTitle9": {
     "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "batterySavingWarning": "Your phone is in battery saving mode. Please disable this mode or do NOT put the application to the background, otherwise, the app might be killed by OS and swap failed.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Exchange rate",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Built on Komodo",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Built on Komodo",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Buy",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Convert to Maker if not matched",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Swap issued, please wait!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Ordermatch ongoing, please wait {seconde} seconds!",
-  "@buySuccessWaitingError": {
+  "eulaTitle10": "ACCESS AND SECURITY\n\n",
+  "@eulaTitle10": {
     "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "buyTestCoinWarning": "Warning, you're willing to buy test coins WITHOUT real value!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Camouflage PIN and Bio protection can't be enabled at the same time.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Camo PIN and Bio protection conflict.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Change Camouflage PIN",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Create Camouflage PIN",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "If You'll unlock the app with the Camouflage PIN, a fake LOW balance will be shown and the Camouflage PIN config option will NOT be visible in the settings",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "Invalid Camouflage PIN",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Camouflage PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Camouflage PIN not found",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Off",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "On",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Camouflage PIN saved",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Camouflage PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Enter new Camouflage PIN",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Camouflage PIN Setup",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Camouflage PIN Setup",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "Cancel",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelButton": "Cancel",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Cancel Order",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Something went wrong. Try again later.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ok",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": " is a default coin. Default coins can't be disabled.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Can't disable ",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Can't play that",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEXchange rate",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEX data",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Markets data (prices, charts, etc.) marked with this icon originates from third party sources (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEX Rate",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "Change PIN code",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Check for updates",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Check Out",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Check seed phrase",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "CONTINUE",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "GO BACK AND CHECK AGAIN",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "Enter the {index} word",
-  "@checkSeedPhraseHint": {
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS\n\n",
+  "@eulaTitle11": {
     "type": "text",
-    "placeholders": {
-      "index": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "checkSeedPhraseInfo": "Your seed phrase is important - that's why we like to make sure it's correct. We'll ask you three different questions about your seed phrase to make sure you'll be able to easily restore your wallet whenever you want.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "What is the {index} word in your seed phrase?",
-  "@checkSeedPhraseSubtile": {
+  "eulaTitle12": "DISCLAIMER\n\n",
+  "@eulaTitle12": {
     "type": "text",
-    "placeholders": {
-      "index": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "checkSeedPhraseTitle": "LET'S DOUBLE CHECK YOUR SEED PHRASE",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Chinese",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "claim",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "Claim your KMD reward?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Click to see ",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Copied to the clipboard",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Copy to clipboard",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Close",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Close Error Message",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Close preview",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Code: ",
-  "@code": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "You have selected the max number of assets",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName} coins are activated",
-  "@coinsAreActivated": {
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY\n\n",
+  "@eulaTitle13": {
     "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "coinsAreActivatedSuccessfully": "{protocolName} coins activated successfully",
-  "@coinsAreActivatedSuccessfully": {
+  "eulaTitle14": "GENERAL RISK FACTORS\n\n",
+  "@eulaTitle14": {
     "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "coinsAreNotActivated": "{protocolName} coins are not activated",
-  "@coinsAreNotActivated": {
+  "eulaTitle15": "INDEMNIFICATION\n\n",
+  "@eulaTitle15": {
     "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "coinSelectClear": "Clear",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "No active coins",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Select Coin",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Coming soon...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "TX details coming soon!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "Details coming soon!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "commission fee",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "compared to avg. 24h CEX price",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "compared to CEX",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Configuring your wallet, please wait...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Confirm",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Confirm Camouflage PIN",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Are you sure you want to cancel the order",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "By clicking the button below, you confirm to have read and accept the 'EULA' and 'Terms and Conditions'.",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Confirm password",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "Confirm PIN code",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Confirm Seed Phrase",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Connecting...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Cancel",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Delete Contact",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Delete",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "Are you sure you want to delete contact {name}?",
-  "@contactDeleteWarning": {
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET\n\n",
+  "@eulaTitle16": {
     "type": "text",
-    "placeholders": {
-      "name": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "contactDiscardBtn": "Discard",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Edit",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Exit",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Discard your changes?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "No contacts found",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Save",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Contact details",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Name",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Contract",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Convert",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "Could not launch URL",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "Couldn't import: ",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "trade",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "CREATE A WALLET",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Create Contact",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "Create PIN",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Currency",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Currency",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Current value:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Custom fee",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "Only use custom fees if you know what you are doing!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Custom seed phrases might be less secure and easier to crack than a generated BIP39 compliant seed phrase or private key (WIF). To confirm you understand the risk and know what you are doing, type \"{iUnderstand}\" in the box below.",
-  "@customSeedWarning": {
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE\n\n",
+  "@eulaTitle17": {
     "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "date": "Date",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Decrypting wallet",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Delete",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Confirm deactivation",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "Do you want to remove ",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": " from your portfolio? All unmatched orders will be canceled. ",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " will also be deactivated",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Delete Wallet",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Deleting wallet...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "receive {coinName} transaction fee",
-  "@detailedFeesReceiveCoinTransactionFee": {
+  "eulaTitle18": "TERMINATION\n\n",
+  "@eulaTitle18": {
     "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "detailedFeesSendCoinTransactionFee": "send {coinName} transaction fee",
-  "@detailedFeesSendCoinTransactionFee": {
+  "eulaTitle19": "THIRD PARTY RIGHTS\n\n",
+  "@eulaTitle19": {
     "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "detailedFeesSendTradingFeeTransactionFee": "send trading fee transaction fee",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "trading fee",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "details",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Deutsch",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Developer",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX is not available for this coin",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Disable Screenshots/Preview",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Disclaimer & ToS",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Done",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Do not close the app. Tap for more info...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Don’t ask again",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "I don't want a password",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW security",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Duration",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Edit Contact",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Input {abbr} address",
-  "@emptyCoin": {
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS\n\n",
+  "@eulaTitle20": {
     "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "Encryption password can't be empty",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "Password can't be empty",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Contact name cannot be empty",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "Wallet name must not be empty",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "You can still enable {remains}, Selected: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Please enable notifications to get updates on the activation progress.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Enable Test Coins",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "You have ",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": " assets enabled and trying to enable ",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": " more. Enabled assets max limit is ",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ". Please disable some assets before adding more.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Trying to enable too many assets",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Encrypting wallet",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "English",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Enter your new PIN",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Enter your old PIN",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Please enter your password to continue.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Enter your PIN code",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Enter Your Seed Phrase",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "You must enter Sell Amount first",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Not enough balance",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Not a valid address",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Segwit addresses are not supported (yet)",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Not enough gas - use at least {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Error, please try again",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Error, please try later",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "Value is too high or low",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Please input data",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Estimated Total Value",
-  "@estimateValue": {
-    "type": "text"
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020\n\n",
   "@eulaParagraphe1": {
     "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to: \n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors; \n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions; \n(c) the unavailability of the application or any portion of it; \n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application. \n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}. \nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.\n\n",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. \n\n",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020\n\n",
-  "@eulaParagraphe19": {
-    "type": "text",
+    "placeholders_order": [
+      "appName",
+      "appCompanyLong"
+    ],
     "placeholders": {
       "appName": {},
       "appCompanyLong": {}
@@ -1023,6 +193,10 @@
   "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms. \nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam. \nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n",
   "@eulaParagraphe2": {
     "type": "text",
+    "placeholders_order": [
+      "appName",
+      "appCompanyLong"
+    ],
     "placeholders": {
       "appName": {},
       "appCompanyLong": {}
@@ -1030,15 +204,22 @@
   },
   "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time. \n\n",
   "@eulaParagraphe3": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n",
   "@eulaParagraphe4": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n",
   "@eulaParagraphe5": {
     "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
       "appName": {}
     }
@@ -1046,6 +227,10 @@
   "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n",
   "@eulaParagraphe6": {
     "type": "text",
+    "placeholders_order": [
+      "appName",
+      "appCompanyLong"
+    ],
     "placeholders": {
       "appName": {},
       "appCompanyLong": {}
@@ -1053,815 +238,2063 @@
   },
   "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n",
   "@eulaParagraphe7": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n",
   "@eulaParagraphe8": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). \n\n",
   "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile",
-  "@eulaTitle1": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to: \n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors; \n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions; \n(c) the unavailability of the application or any portion of it; \n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application. \n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}. \nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyShort",
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n",
+  "@eulaParagraphe12": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.\n\n",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyShort",
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. \n\n",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020\n\n",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders_order": [
+      "appName",
+      "appCompanyLong"
+    ],
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "updatesTitle": "{appName} update",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
       "appName": {}
     }
   },
-  "eulaTitle10": "ACCESS AND SECURITY\n\n",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS\n\n",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER\n\n",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY\n\n",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS\n\n",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION\n\n",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET\n\n",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE\n\n",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION\n\n",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS\n\n",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS\n\n",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER\n\n",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE\n\n",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS\n\n",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE\n\n",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP\n\n",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS\n\n",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING\n\n",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Example: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Expedient",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Expensive",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Identical to CEX",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Exchange rate:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "EXCHANGE",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Export",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Contacts",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Please select items to export into encrypted file.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Export",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Notes",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Items have been successfully exported:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Swaps",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Export",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Failed",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Fake balance amount:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Frequently Asked Questions",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Error",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Sending request to {coin} faucet...",
-  "@faucetInProgress": {
+  "updatesCurrentVersion": "You are using version {version}",
+  "@updatesCurrentVersion": {
     "type": "text",
+    "placeholders_order": [
+      "version"
+    ],
     "placeholders": {
-      "coin": {}
+      "version": {}
     }
   },
-  "faucetName": "FAUCET",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Success",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "Request timed out",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Share Log File",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "News",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Nothing here",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} news",
-  "@feedNotifTitle": {
+  "updatesChecking": "Checking for updates...",
+  "@updatesChecking": {
     "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "feedReadMore": "Read more...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Feed",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "News Feed",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Unable to proceed news update",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Unable to get news update",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "News feed updated",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Already up to date",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Fees must be up to {value}",
-  "@feesError": {
+  "updatesUpToDate": "Already up to date",
+  "@updatesUpToDate": {
     "type": "text",
-    "placeholders": {
-      "value": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "filtersAll": "All",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Filter",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Clear all filters",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Failed",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "From date",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Maker",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Receive coin",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Sell coin",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Status",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Successful",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Taker",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "To date",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Taker/Maker",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Fingerprint",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Finishing up, please wait",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "Found QR Code",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "French",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "From",
-  "@from": {
-    "type": "text"
-  },
-  "gasFee": "{coin} fee",
-  "@gasFee": {
+  "updatesAvailable": "New version available",
+  "@updatesAvailable": {
     "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "gasLimit": "Gas limit",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Please activate {coin}.",
-  "@gasNotActive": {
+  "updatesUpdate": "Update",
+  "@updatesUpdate": {
     "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "gasPrice": "Gas price",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "General PIN protection is not active.\nCamouflage mode will not be available.\nPlease activate PIN protection.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Important: Back up your seed phrase before proceeding!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "Getting transaction, please wait",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Go to portfolio",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei must be up to {value}",
-  "@gweiError": {
+  "updatesSkip": "Skip for now",
+  "@updatesSkip": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "updatesNotifTitle": "Update available",
+  "@updatesNotifTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "updatesNotifAvailable": "New version available. Please update.",
+  "@updatesNotifAvailable": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "updatesNotifAvailableVersion": "Version {version} available. Please update.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders_order": [
+      "version"
+    ],
     "placeholders": {
-      "value": {}
+      "version": {}
     }
   },
   "helpLink": "Help",
   "@helpLink": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "helpTitle": "Help and Support",
   "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Hide balances",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Confirm Password",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Create Password",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Current password",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Enter your password",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Enter your seed phrase",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Name your wallet",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Password",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "history",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "h",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Hungarian",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Import",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Invalid password or corrupted data",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "Items to be imported:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "File not found",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Invalid swap data. Please provide a valid swap status JSON file.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Import",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Please select encrypted file to import.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Opening...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Please select plain text swap file to import.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Cancel",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ok",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Password",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Import Single Swap",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Import Swap",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Some items have been skipped",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Items have been successfully imported:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Failed to import swap",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Error decoding json file",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Import",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Incoming  {coinName} txs protection settings",
-  "@incomingTransactionsProtectionSettings": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "faqTitle": "Frequently Asked Questions",
+  "@faqTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "support": "Support",
+  "@support": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "supportLinksDesc": "If you have any questions, or think you've found a technical problem with the {appName} app, you can report it and get support from our team.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
     "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_1": "Do you store my private keys?",
+  "@question_1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "answer_1": "No! {appName} is non-custodial. We never store any sensitive data, including your private keys, seed phrases, or PIN. This data is only stored on the user’s device and never leaves it. You are in full control of your assets.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "How is trading on {appName} different from trading on other DEXs?",
+  "@question_2": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Other DEXs generally only allow you to trade assets that are based on a single blockchain network, use proxy tokens, and only allow placing a single order with the same funds.\n\n{appName} enables you to natively trade across two different blockchain networks without proxy tokens. You can also place multiple orders with the same funds. For example, you can sell 0.1 BTC for KMD, QTUM, or VRSC — the first order that fills automatically cancels all other orders.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "How long does each atomic swap take?",
+  "@question_3": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "answer_3": "Several factors determine the processing time for each swap. The block time of the traded assets depends on each network (Bitcoin typically being the slowest) Additionally, the user can customize security preferences. For example, you can ask {appName} to consider a KMD transaction as final after just 3 confirmations which makes the swap time shorter compared to waiting for a <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_4": "Do I need to be online for the duration of the swap?",
+  "@question_4": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "answer_4": "Yes. You must remain connected to the internet and have your app running to successfully complete each atomic swap (very short breaks in connectivity are usually fine). Otherwise, there is risk of trade cancellation if you are a maker, and risk of loss of funds if you are a taker. The atomic swap protocol requires both participants to stay online and monitor the involved blockchains for the process to stay atomic.",
+  "@answer_4": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "question_5": "How are the fees on {appName} calculated?",
+  "@question_5": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_5": "There are two fee categories to consider when trading on {appName}.\n\n1. {appName} charges approximately 0.13% (1/777 of trading volume but not lower than 0.0001) as the trading fee for taker orders, and maker orders have zero fees.\n\n2. Both makers and takers will need to pay normal network fees to the involved blockchains when making atomic swap transactions.\n\nNetwork fees can vary greatly depending on your selected trading pair.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Do you provide user support?",
+  "@question_6": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "answer_6": "Yes! {appName} offers support through the <a href=\"{link}\">{appCompanyShort} {name}</a>. The team and the community are always happy to help!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders_order": [
+      "name",
+      "link",
+      "appName",
+      "appCompanyShort"
+    ],
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "question_7": "Do you have country restrictions?",
+  "@question_7": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "answer_7": "No! {appName} is fully decentralized. It is not possible to limit user access by any third party.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_8": "Who is behind {appName}?",
+  "@question_8": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} is developed by the {appCompanyShort} team. {appCompanyShort} is one of the most established blockchain projects working on innovative solutions like atomic swaps, Delayed Proof of Work, and an interoperable multi-chain architecture.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders_order": [
+      "appName",
+      "appCompanyShort"
+    ],
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "question_9": "Is it possible to develop my own white-label exchange on {appName}?",
+  "@question_9": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_9": "Absolutely! You can read our <a href=\"https://developers.komodoplatform.com/\">developer documentation</a> for more details or contact us with your partnership inquiries. Have a specific technical question? The {appName} developer community is always ready to help!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_10": "Which devices can I use {appName} on?",
+  "@question_10": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} is available for mobile on both Android and iPhone, and for desktop on <a href=\"https://komodoplatform.com/\">Windows, Mac, and Linux operating systems</a>.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders_order": [
+      "appName"
+    ],
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "feedTab": "Feed",
+  "@feedTab": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedTitle": "News Feed",
+  "@feedTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedReadMore": "Read more...",
+  "@feedReadMore": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedNotFound": "Nothing here",
+  "@feedNotFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedUpdated": "News feed updated",
+  "@feedUpdated": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "snackbarDismiss": "Dismiss",
+  "@snackbarDismiss": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedNewsTab": "News",
+  "@feedNewsTab": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "duration": "Duration",
+  "@duration": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedUnableToUpdate": "Unable to get news update",
+  "@feedUnableToUpdate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedUnableToProceed": "Unable to proceed news update",
+  "@feedUnableToProceed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedUpToDate": "Already up to date",
+  "@feedUpToDate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "date": "Date",
+  "@date": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedNotifTitle": "{appCompanyShort} news",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders_order": [
+      "appCompanyShort"
+    ],
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "createPin": "Create PIN",
+  "@createPin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enterPinCode": "Enter your PIN code",
+  "@enterPinCode": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "login": "login",
+  "@login": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "newAccount": "new account",
+  "@newAccount": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "newAccountUpper": "New Account",
+  "@newAccountUpper": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addingCoinSuccess": "Activated {name} successfully !",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders_order": [
+      "name"
+    ],
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "connecting": "Connecting...",
+  "@connecting": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addCoin": "Add Coin",
+  "@addCoin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "numberAssets": "{assets} Assets",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders_order": [
+      "assets"
+    ],
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "enterSeedPhrase": "Enter Your Seed Phrase",
+  "@enterSeedPhrase": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exampleHintSeed": "Example: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirm": "Confirm",
+  "@confirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "buyTestCoinWarning": "Warning, you're willing to buy test coins WITHOUT real value!",
+  "@buyTestCoinWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "batteryCriticalError": "Your battery charge is critical ({batteryLevelCritical}%) to perform a swap safely. Please put it on charge and try again.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders_order": [
+      "batteryLevelCritical"
+    ],
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "Your battery charge is lower than {batteryLevelLow}%. Please consider phone charging.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders_order": [
+      "batteryLevelLow"
+    ],
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Your phone is in battery saving mode. Please disable this mode or do NOT put the application to the background, otherwise, the app might be killed by OS and swap failed.",
+  "@batterySavingWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "sellTestCoinWarning": "Warning, you're willing to sell test coins WITHOUT real value!",
+  "@sellTestCoinWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "buy": "Buy",
+  "@buy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "sell": "Sell",
+  "@sell": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "shareAddress": "My {coinName} address: \n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName",
+      "address"
+    ],
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "withdraw": "Withdraw",
+  "@withdraw": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorValueEmpty": "Value is too high or low",
+  "@errorValueEmpty": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "amount": "Amount",
+  "@amount": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressSend": "Recipients address",
+  "@addressSend": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "withdrawValue": "WITHDRAW {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders_order": [
+      "amount",
+      "coinName"
+    ],
+    "placeholders": {
+      "amount": {},
       "coinName": {}
     }
   },
-  "infoPasswordDialog": "Use a secure password and do not store it on the same device",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "The swap request can not be undone and is a final event!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "The swap can take up to 60 minutes. DONT close this application!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "You have to provide a password for the wallet encryption due to security reasons.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} balance not sufficient to pay trading fee",
-  "@insufficientBalanceToPay": {
+  "withdrawConfirm": "Confirm Withdrawal",
+  "@withdrawConfirm": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "withdrawConfirmError": "Something went wrong. Try again later.",
+  "@withdrawConfirmError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "close": "Close",
+  "@close": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirmSeed": "Confirm Seed Phrase",
+  "@confirmSeed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "seedPhraseTitle": "Your new Seed Phrase",
+  "@seedPhraseTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "getBackupPhrase": "Important: Back up your seed phrase before proceeding!",
+  "@getBackupPhrase": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "recommendSeedMessage": "We recommend storing it offline.",
+  "@recommendSeedMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "next": "next",
+  "@next": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirmPin": "Confirm PIN code",
+  "@confirmPin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camouflageSetup": "Camouflage PIN Setup",
+  "@camouflageSetup": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirmCamouflageSetup": "Confirm Camouflage PIN",
+  "@confirmCamouflageSetup": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorTryAgain": "Error, please try again",
+  "@errorTryAgain": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settings": "Settings",
+  "@settings": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "security": "Security",
+  "@security": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "activateAccessPin": "Activate PIN protection",
+  "@activateAccessPin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "disableScreenshots": "Disable Screenshots/Preview",
+  "@disableScreenshots": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "lockScreen": "Screen is locked",
+  "@lockScreen": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "changePin": "Change PIN code",
+  "@changePin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "logout": "Log Out",
+  "@logout": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "max": "MAX",
+  "@max": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "min": "MIN",
+  "@min": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "totalFees": "Total Fees:",
+  "@totalFees": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paidFromBalance": "Paid from balance:",
+  "@paidFromBalance": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tradingMode": "Trading Mode:",
+  "@tradingMode": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "skip": "Skip",
+  "@skip": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "merge": "Merge",
+  "@merge": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "overwrite": "Overwrite",
+  "@overwrite": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "currentValue": "Current value:",
+  "@currentValue": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "newValue": "New value:",
+  "@newValue": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "mergedValue": "Merged value:",
+  "@mergedValue": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "saveMerged": "Save merged",
+  "@saveMerged": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "alreadyExists": "Already exists",
+  "@alreadyExists": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simple": "Simple",
+  "@simple": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "advanced": "Advanced",
+  "@advanced": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paidFromVolume": "Paid from received volume:",
+  "@paidFromVolume": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "amountToSell": "Amount To Sell",
+  "@amountToSell": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "youWillReceived": "You will receive: ",
+  "@youWillReceived": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectCoinToSell": "Select the coin you want to SELL",
+  "@selectCoinToSell": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectCoinToBuy": "Select the coin you want to BUY",
+  "@selectCoinToBuy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swap": "swap",
+  "@swap": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "buySuccessWaiting": "Swap issued, please wait!",
+  "@buySuccessWaiting": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "buySuccessWaitingError": "Ordermatch ongoing, please wait {seconde} seconds!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders_order": [
+      "seconde"
+    ],
     "placeholders": {
-      "abbr": {}
+      "seconde": {}
     }
   },
-  "insufficientText": "Minumum volume required by this order is",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Insufficient volume",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Refresh",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Internet Connection Restored",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidSwap": "Unable to proceed swap",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Details",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} is unavailable :(",
-  "@isUnavailable": {
+  "networkFee": "Network fee",
+  "@networkFee": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "commissionFee": "commission fee",
+  "@commissionFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "portfolio": "Portfolio",
+  "@portfolio": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "checkOut": "Check Out",
+  "@checkOut": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "estimateValue": "Estimated Total Value",
+  "@estimateValue": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectPaymentMethod": "Select Your Payment Method",
+  "@selectPaymentMethod": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "volumes": "Volumes",
+  "@volumes": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "placeOrder": "Place your order",
+  "@placeOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "comingSoon": "Coming soon...",
+  "@comingSoon": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketplace": "Marketplace",
+  "@marketplace": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "youAreSending": "You are sending:",
+  "@youAreSending": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "code": "Code: ",
+  "@code": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "value": "Value: ",
+  "@value": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paidWith": "Paid with ",
+  "@paidWith": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorValueNotEmpty": "Please input data",
+  "@errorValueNotEmpty": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorAmountBalance": "Not enough balance",
+  "@errorAmountBalance": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "gweiError": "Gwei must be up to {value}",
+  "@gweiError": {
+    "type": "text",
+    "placeholders_order": [
+      "value"
+    ],
     "placeholders": {
-      "coinAbbr": {}
+      "value": {}
     }
   },
-  "iUnderstand": "I understand",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Japanese",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Korean",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Language",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Latest Transactions",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Legal",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Less",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Caution! Market for {coinName} has less than $10k 24h trading-volume!",
-  "@lessThanCaution": {
+  "feesError": "Fees must be up to {value}",
+  "@feesError": {
     "type": "text",
+    "placeholders_order": [
+      "value"
+    ],
     "placeholders": {
-      "coinName": {}
+      "value": {}
     }
   },
   "limitError": "Limit must be up to {value}",
   "@limitError": {
     "type": "text",
+    "placeholders_order": [
+      "value"
+    ],
     "placeholders": {
       "value": {}
     }
   },
-  "loading": "Loading...",
-  "@loading": {
-    "type": "text"
+  "errorNotAValidAddress": "Not a valid address",
+  "@errorNotAValidAddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorNotAValidAddressSegWit": "Segwit addresses are not supported (yet)",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "toAddress": "To address:",
+  "@toAddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "receive": "RECEIVE",
+  "@receive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "send": "SEND",
+  "@send": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pubkey": "Pubkey",
+  "@pubkey": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "back": "back",
+  "@back": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cancel": "Cancel",
+  "@cancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "details": "details",
+  "@details": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "yes": "Yes",
+  "@yes": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "no": "No",
+  "@no": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noteOnOrder": "Note: Matched order cannot be cancelled again",
+  "@noteOnOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "dontAskAgain": "Don’t ask again",
+  "@dontAskAgain": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cancelOrder": "Cancel Order",
+  "@cancelOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirmCancel": "Are you sure you want to cancel the order",
+  "@confirmCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "unspendable": "unspendable",
+  "@unspendable": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "commingsoon": "TX details coming soon!",
+  "@commingsoon": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "history": "history",
+  "@history": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "create": "trade",
+  "@create": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "commingsoonGeneral": "Details coming soon!",
+  "@commingsoonGeneral": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderMatching": "Order matching",
+  "@orderMatching": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderMatched": "Order matched",
+  "@orderMatched": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapOngoing": "Swap ongoing",
+  "@swapOngoing": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapSucceful": "Swap successful",
+  "@swapSucceful": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "timeOut": "Timeout",
+  "@timeOut": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "convert": "Convert",
+  "@convert": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapFailed": "Swap failed",
+  "@swapFailed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorTryLater": "Error, please try later",
+  "@errorTryLater": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "latestTxs": "Latest Transactions",
+  "@latestTxs": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "gettingTxWait": "Getting transaction, please wait",
+  "@gettingTxWait": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "finishingUp": "Finishing up, please wait",
+  "@finishingUp": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "feedback": "Share Log File",
+  "@feedback": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "loadingOrderbook": "Loading orderbook...",
   "@loadingOrderbook": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "lockScreen": "Screen is locked",
-  "@lockScreen": {
-    "type": "text"
+  "claim": "claim",
+  "@claim": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "lockScreenAuth": "Please authenticate!",
-  "@lockScreenAuth": {
-    "type": "text"
+  "claimTitle": "Claim your KMD reward?",
+  "@claimTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "login": "login",
-  "@login": {
-    "type": "text"
+  "success": "Success!",
+  "@success": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "logout": "Log Out",
-  "@logout": {
-    "type": "text"
+  "noRewardYet": "No reward claimable - please try again in 1h.",
+  "@noRewardYet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "logoutOnExit": "Log Out on Exit",
-  "@logoutOnExit": {
-    "type": "text"
+  "loading": "Loading...",
+  "@loading": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "logoutsettings": "Log Out Settings",
-  "@logoutsettings": {
-    "type": "text"
+  "txleft": "Transactions Left: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders_order": [
+      "left"
+    ],
+    "placeholders": {
+      "left": {}
+    }
   },
-  "logoutWarning": "Are you sure you want to logout now?",
-  "@logoutWarning": {
-    "type": "text"
+  "insufficientBalanceToPay": "{abbr} balance not sufficient to pay trading fee",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders_order": [
+      "abbr"
+    ],
+    "placeholders": {
+      "abbr": {}
+    }
   },
-  "longMinutes": "minutes",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "make an order",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Maker",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Cancel order",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Created at",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Receive",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "Order ID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "No swaps were started by this order",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Price",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Sell",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Swaps started by this order",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Maker Order details",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Maker Order",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Marketplace",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Chart",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Depth",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "No asks found",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "No bids found",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "ORDER BOOK",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Order Details",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "PRICE",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Please select coins",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Markets",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "MARKETS",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Passwords must match",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Change",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Your general PIN and Camouflage PIN are the same.\nCamouflage mode will not be available.\nPlease change Camouflage PIN.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "Invalid PIN",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAX",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Max order volume:",
-  "@maxOrder": {
-    "type": "text"
+  "dex": "DEX",
+  "@dex": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "media": "News",
   "@media": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "mediaBrowse": "BROWSE",
-  "@mediaBrowse": {
-    "type": "text"
+  "newsFeed": "News feed",
+  "@newsFeed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "mediaBrowseFeed": "BROWSE FEED",
-  "@mediaBrowseFeed": {
-    "type": "text"
+  "clipboard": "Copied to the clipboard",
+  "@clipboard": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "mediaBy": "By",
-  "@mediaBy": {
-    "type": "text"
+  "from": "From",
+  "@from": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "mediaNotSavedDescription": "YOU HAVE NO SAVED ARTICLES",
-  "@mediaNotSavedDescription": {
-    "type": "text"
+  "to": "To",
+  "@to": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "mediaSaved": "SAVED",
-  "@mediaSaved": {
-    "type": "text"
+  "txConfirmed": "CONFIRMED",
+  "@txConfirmed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txNotConfirmed": "UNCONFIRMED",
+  "@txNotConfirmed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txBlock": "Block",
+  "@txBlock": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txConfirmations": "Confirmations",
+  "@txConfirmations": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txFee": "Fee",
+  "@txFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txHash": "Transaction ID",
+  "@txHash": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "memo": "Memo",
   "@memo": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "merge": "Merge",
-  "@merge": {
-    "type": "text"
+  "noSwaps": "No history.",
+  "@noSwaps": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "mergedValue": "Merged value:",
-  "@mergedValue": {
-    "type": "text"
+  "trade": "TRADE",
+  "@trade": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "milliseconds": "ms",
-  "@milliseconds": {
-    "type": "text"
+  "reset": "CLEAR",
+  "@reset": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "min": "MIN",
-  "@min": {
-    "type": "text"
+  "resetTitle": "Reset form",
+  "@resetTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "minimizingWillTerminate": "Warning: Minimizing the app on iOS will terminate the activation process.",
-  "@minimizingWillTerminate": {
-    "type": "text"
+  "tradeCompleted": "SWAP COMPLETED!",
+  "@tradeCompleted": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "minOrder": "Min order volume:",
-  "@minOrder": {
-    "type": "text"
+  "step": "Step",
+  "@step": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "minutes": "m",
-  "@minutes": {
-    "type": "text"
+  "tradeDetail": "TRADE DETAILS",
+  "@tradeDetail": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "requestedTrade": "Requested Trade",
+  "@requestedTrade": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapUUID": "Swap UUID",
+  "@swapUUID": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "mediaBrowse": "BROWSE",
+  "@mediaBrowse": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "mediaSaved": "SAVED",
+  "@mediaSaved": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enable": "You can still enable {remains}, Selected: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders_order": [
+      "selected",
+      "remains"
+    ],
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "mediaNotSavedDescription": "YOU HAVE NO SAVED ARTICLES",
+  "@mediaNotSavedDescription": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "mediaBrowseFeed": "BROWSE FEED",
+  "@mediaBrowseFeed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "mediaBy": "By",
+  "@mediaBy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "lockScreenAuth": "Please authenticate!",
+  "@lockScreenAuth": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noTxs": "No Transactions",
+  "@noTxs": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "done": "Done",
+  "@done": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectCoinTitle": "Activate coins:",
+  "@selectCoinTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectCoinInfo": "Select the coins you want to add to your portfolio.",
+  "@selectCoinInfo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noArticles": "No news - please check back later!",
+  "@noArticles": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "infoTrade1": "The swap request can not be undone and is a final event!",
+  "@infoTrade1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "infoTrade2": "The swap can take up to 60 minutes. DONT close this application!",
+  "@infoTrade2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapDetailTitle": "CONFIRM EXCHANGE DETAILS",
+  "@swapDetailTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "minVolumeTitle": "Min volume required",
+  "@minVolumeTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "minVolumeToggle": "Use custom min volume",
+  "@minVolumeToggle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "nonNumericInput": "The value must be numeric",
+  "@nonNumericInput": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "minVolumeIsTDH": "Must be lower than sell amount",
+  "@minVolumeIsTDH": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "minVolumeInput": "Must be greater than {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders_order": [
+      "minValue",
+      "coin"
+    ],
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "checkSeedPhrase": "Check seed phrase",
+  "@checkSeedPhrase": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "checkSeedPhraseTitle": "LET'S DOUBLE CHECK YOUR SEED PHRASE",
+  "@checkSeedPhraseTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "checkSeedPhraseInfo": "Your seed phrase is important - that's why we like to make sure it's correct. We'll ask you three different questions about your seed phrase to make sure you'll be able to easily restore your wallet whenever you want.",
+  "@checkSeedPhraseInfo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "checkSeedPhraseSubtile": "What is the {index} word in your seed phrase?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders_order": [
+      "index"
+    ],
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseHint": "Enter the {index} word",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders_order": [
+      "index"
+    ],
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseButton1": "CONTINUE",
+  "@checkSeedPhraseButton1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "checkSeedPhraseButton2": "GO BACK AND CHECK AGAIN",
+  "@checkSeedPhraseButton2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "viewInExplorerButton": "Explorer",
+  "@viewInExplorerButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "activateAccessBiometric": "Activate Biometric protection",
+  "@activateAccessBiometric": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "allowCustomSeed": "Allow custom seed",
+  "@allowCustomSeed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "warning": "Warning!",
+  "@warning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "iUnderstand": "I understand",
+  "@iUnderstand": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "customSeedWarning": "Custom seed phrases might be less secure and easier to crack than a generated BIP39 compliant seed phrase or private key (WIF). To confirm you understand the risk and know what you are doing, type \"{iUnderstand}\" in the box below.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders_order": [
+      "iUnderstand"
+    ],
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "hintEnterPassword": "Enter your password",
+  "@hintEnterPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "yourWallet": "your wallet",
+  "@yourWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "signInWithSeedPhrase": "Forgot the password? Restore wallet from seed",
+  "@signInWithSeedPhrase": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "signInWithPassword": "Sign in with password",
+  "@signInWithPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hintEnterSeedPhrase": "Enter your seed phrase",
+  "@hintEnterSeedPhrase": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "wrongPassword": "The passwords do not match. Please try again.",
+  "@wrongPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hintNameYourWallet": "Name your wallet",
+  "@hintNameYourWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "infoWalletPassword": "You have to provide a password for the wallet encryption due to security reasons.",
+  "@infoWalletPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirmPassword": "Confirm password",
+  "@confirmPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "dontWantPassword": "I don't want a password",
+  "@dontWantPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "areYouSure": "ARE YOU SURE?",
+  "@areYouSure": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "infoPasswordDialog": "Use a secure password and do not store it on the same device",
+  "@infoPasswordDialog": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "setUpPassword": "SET UP A PASSWORD",
+  "@setUpPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "createAWallet": "CREATE A WALLET",
+  "@createAWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "restoreWallet": "RESTORE",
+  "@restoreWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hintPassword": "Password",
+  "@hintPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "passwordRequirement": "Password must contain at least 12 characters, with one lower-case, one upper-case and one special symbol.",
+  "@passwordRequirement": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hintCreatePassword": "Create Password",
+  "@hintCreatePassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hintConfirmPassword": "Confirm Password",
+  "@hintConfirmPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hintCurrentPassword": "Current password",
+  "@hintCurrentPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "logoutsettings": "Log Out Settings",
+  "@logoutsettings": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "logoutOnExit": "Log Out on Exit",
+  "@logoutOnExit": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deleteWallet": "Delete Wallet",
+  "@deleteWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "delete": "Delete",
+  "@delete": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settingDialogSpan1": "Are you sure you want to delete ",
+  "@settingDialogSpan1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settingDialogSpan2": " wallet?",
+  "@settingDialogSpan2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settingDialogSpan3": "If so, make sure you ",
+  "@settingDialogSpan3": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settingDialogSpan4": " record your seed phrase.",
+  "@settingDialogSpan4": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settingDialogSpan5": " In order to restore your wallet in the future.",
+  "@settingDialogSpan5": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "backupTitle": "Backup",
+  "@backupTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "version": "version",
+  "@version": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "viewSeedAndKeys": "Seed & Private Keys",
+  "@viewSeedAndKeys": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "seedPhrase": "Seed Phrase",
+  "@seedPhrase": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "privateKeys": "Private Keys",
+  "@privateKeys": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "privateKey": "Private Key",
+  "@privateKey": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enterpassword": "Please enter your password to continue.",
+  "@enterpassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "clipboardCopy": "Copy to clipboard",
+  "@clipboardCopy": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "unlock": "unlock",
+  "@unlock": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "unlockSuccess": "Successfully unlocked {amnt} funds - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders_order": [
+      "amnt",
+      "hash"
+    ],
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unlockFunds": "Unlock Funds",
+  "@unlockFunds": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noOrders": "No orders, please go to trade.",
+  "@noOrders": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noOrder": "Please enter the {coinName} amount.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "bestAvailableRate": "Exchange rate",
+  "@bestAvailableRate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "receiveLower": "Receive",
+  "@receiveLower": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makeAorder": "make an order",
+  "@makeAorder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exchangeTitle": "EXCHANGE",
+  "@exchangeTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orders": "orders",
+  "@orders": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectCoin": "Select coin",
+  "@selectCoin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "lessThanCaution": "❗Caution! Market for {coinName} has less than $10k 24h trading-volume!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "selectLanguage": "Select Language",
+  "@selectLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noFunds": "No funds",
+  "@noFunds": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noFundsDetected": "No funds available - please deposit.",
+  "@noFundsDetected": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "goToPorfolio": "Go to portfolio",
+  "@goToPorfolio": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noOrderAvailable": "Click to create an order",
+  "@noOrderAvailable": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "insufficientTitle": "Insufficient volume",
+  "@insufficientTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "insufficientText": "Minumum volume required by this order is",
+  "@insufficientText": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderCreated": "Order created",
+  "@orderCreated": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderCreatedInfo": "Order successfully created",
+  "@orderCreatedInfo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "showMyOrders": "Show My Orders",
+  "@showMyOrders": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "minValue": "The minimum amount to sell is {number} {coinName}",
   "@minValue": {
     "type": "text",
+    "placeholders_order": [
+      "coinName",
+      "number"
+    ],
     "placeholders": {
       "coinName": {},
       "number": {}
     }
   },
+  "titleCreatePassword": "CREATE A PASSWORD",
+  "@titleCreatePassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "minValueBuy": "The minimum amount to buy is {number} {coinName}",
   "@minValueBuy": {
     "type": "text",
+    "placeholders_order": [
+      "coinName",
+      "number"
+    ],
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueSell": "The minimum amount to sell is {number} {coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName",
+      "number"
+    ],
     "placeholders": {
       "coinName": {},
       "number": {}
@@ -1870,6 +2303,12 @@
   "minValueOrder": "Order minimum amount is {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
   "@minValueOrder": {
     "type": "text",
+    "placeholders_order": [
+      "buyCoin",
+      "buyAmount",
+      "sellCoin",
+      "sellAmount"
+    ],
     "placeholders": {
       "buyCoin": {},
       "buyAmount": {},
@@ -1877,1203 +2316,840 @@
       "sellAmount": {}
     }
   },
-  "minValueSell": "The minimum amount to sell is {number} {coinName}",
-  "@minValueSell": {
+  "enterSellAmount": "You must enter Sell Amount first",
+  "@enterSellAmount": {
     "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "minVolumeInput": "Must be greater than {minValue} {coin}",
-  "@minVolumeInput": {
+  "encryptingWallet": "Encrypting wallet",
+  "@encryptingWallet": {
     "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "minVolumeIsTDH": "Must be lower than sell amount",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Min volume required",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Use custom min volume",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Please note that now you're using cellular data and participation in {appName} P2P network consume internet traffic. It's better to use a WiFi network if your cellular data plan is costly.",
-  "@mobileDataWarning": {
+  "decryptingWallet": "Decrypting wallet",
+  "@decryptingWallet": {
     "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "moreInfo": "More Info",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "More",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Activate {coin} and top-up balance first",
-  "@multiActivateGas": {
+  "notEnoughtBalanceForFee": "Not enough balance for fees - trade a smaller amount",
+  "@notEnoughtBalanceForFee": {
     "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Amount",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Coin",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Sell",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Cancel",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Confirm",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "Create {number} Order(s):",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Create",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Order",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Orders",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "fee",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Cancel",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Please enter fiat amount to receive:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Autofill",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Please fix all errors before continuing",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Invalid amount",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Invalid sell amount",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "Not enough {coin} to pay fees. MIN balance is {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} balance is too low",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "Max sell amount is",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "Min receive amount is",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "Min sell amount is",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Receive:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Sell:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Multi",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Receive Amt.",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Price/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Network fee",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "new account",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "New Account",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "News feed",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "New value:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "next",
-  "@next": {
-    "type": "text"
-  },
-  "no": "No",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "No news - please check back later!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "No coin found",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "No funds",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "No funds available - please deposit.",
-  "@noFundsDetected": {
-    "type": "text"
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "noInternet": "No Internet Connection",
   "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "No items selected",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "No items selected",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "No matching orders found",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "None",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "The value must be numeric",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Please enter the {coinName} amount.",
-  "@noOrder": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "builtKomodo": "Built on Komodo",
+  "@builtKomodo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pleaseAddCoin": "Please Add A Coin",
+  "@pleaseAddCoin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "internetRestored": "Internet Connection Restored",
+  "@internetRestored": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "internetRefreshButton": "Refresh",
+  "@internetRefreshButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "legalTitle": "Legal",
+  "@legalTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "disclaimerAndTos": "Disclaimer & ToS",
+  "@disclaimerAndTos": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "accepteula": "Accept EULA",
+  "@accepteula": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "accepttac": "Accept TERMS and CONDITIONS",
+  "@accepttac": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "confirmeula": "By clicking the button below, you confirm to have read and accept the 'EULA' and 'Terms and Conditions'.",
+  "@confirmeula": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "gasFee": "{coin} fee",
+  "@gasFee": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
-      "coinName": {}
+      "coin": {}
     }
-  },
-  "noOrderAvailable": "Click to create an order",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "No orders, please go to trade.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "No claimable rewards",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "No reward claimable - please try again in 1h.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "No such coin",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "No history.",
-  "@noSwaps": {
-    "type": "text"
   },
   "notEnoughGas": "Not enough {coin} for transaction!",
   "@notEnoughGas": {
     "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "notEnoughtBalanceForFee": "Not enough balance for fees - trade a smaller amount",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Note: Matched order cannot be cancelled again",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Add a Note",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Note",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Nothing found",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "{sell}/{buy} swap was completed successfully",
-  "@notifSwapCompletedText": {
+  "gasNotActive": "Please activate {coin}.",
+  "@gasNotActive": {
     "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Swap completed",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} swap failed",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Swap failed",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} swap started",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "New swap started",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Swap status changed",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} swap was timed out",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Swap timed out",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "You have received {coin} transaction!",
-  "@notifTxText": {
-    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "notifTxTitle": "Incoming transaction",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "No Transactions",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} Assets",
-  "@numberAssets": {
+  "youWillReceiveClaim": "You will receive {amount} {coin}",
+  "@youWillReceiveClaim": {
     "type": "text",
+    "placeholders_order": [
+      "amount",
+      "coin"
+    ],
     "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Official press release",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ok",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Delete",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Old logs",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Space used",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Open Error Message",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Optional",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Less",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "More",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "All {coin} orders will be canceled.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
+      "amount": {},
       "coin": {}
     }
-  },
-  "orderCreated": "Order created",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Order successfully created",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Address",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Cancel",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Expedient: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Expensive: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "for",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Identical to CEX",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "min.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Price",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Receive",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Select",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Sells",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Open Details on single tap and select Order by long tap",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Spend",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Details",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% filled",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Order matched",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Order matching",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "orders",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Active",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "History",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Amt. ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "Price ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Total ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": " Order",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Unknown Type Order",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Overwrite",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": " This is your own order!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Paid from balance:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Paid from received volume:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Paid with ",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "Password must contain at least 12 characters, with one lower-case, one upper-case and one special symbol.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Pay",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Do you accept this transaction?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "To Address ",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Amount: ",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Coin: ",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Cancel",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Payment Requested",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} is not active. Please activate and try again.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Place your order",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "Play at full volume",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Please Add A Coin",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Please restart the app to try again, or press the button below.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Portfolio",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Powered by Komodo",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "price",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Private Key",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Private Keys",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Confirmations",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Use custom protection settings",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "OFF",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "ON",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Warning, this atomic swap is not dPoW protected. ",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Pubkey",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "QR Code Scanner",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Do you store my private keys?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "Which devices can I use {appName} on?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "How is trading on {appName} different from trading on other DEXs?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "How long does each atomic swap take?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "Do I need to be online for the duration of the swap?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "How are the fees on {appName} calculated?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Do you provide user support?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Do you have country restrictions?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Who is behind {appName}?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "Is it possible to develop my own white-label exchange on {appName}?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "It's a new era! We have officially changed our name from 'AtomicDEX' to 'Komodo Wallet'",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "RECEIVE",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Receive",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "We recommend storing it offline.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Disable",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Requested Trade",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "CLEAR",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Reset form",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "RESTORE",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Retrying activating all coins...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Retry activating all",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Claim your rewards",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Cancel",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Something went wrong. Please try again later.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "Transaction is in progress",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "processing",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO amount less than 10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "One hour not passed yet",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 hour",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Ok",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Rewards status:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "Read more about KMD active user rewards",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Receive",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Success! {amount} KMD received.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Fiat",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Rewards,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Status",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Time left",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Rewards information:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO amt,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} day(s)",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}h {minutes}m",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}min",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Rewards information",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Russian",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Save merged",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Scroll to the bottom to continue...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Search a coin",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Select all Avax tokens",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Select all BEP tokens",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Select all Cosmos Network",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Select all ERC tokens",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Select all ETC tokens",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Select all Fantom tokens",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Select all HecoChain tokens",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Select all Harmony tokens",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Select all Iris Network",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Select all Kucoin tokens",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Select all Moonriver tokens",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Select all Polygon tokens",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Select all QRC tokens",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Select all SmartBCH tokens",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Select all SLP tokens",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Select all SmartChains",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Select all Test Assets",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Select all Ubiq coins",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Select all UTXO coins",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Select all ZHTLC coins",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Search for Ticker",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Security",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Seed Phrase",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Your new Seed Phrase",
-  "@seedPhraseTitle": {
-    "type": "text"
   },
   "seeOrders": "Click to see {amount} orders",
   "@seeOrders": {
     "type": "text",
+    "placeholders_order": [
+      "amount"
+    ],
     "placeholders": {
       "amount": {}
     }
   },
-  "seeTxHistory": "View Transaction History",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Select coin",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Select the coins you want to add to your portfolio.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Activate coins:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Select the coin you want to BUY",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Select the coin you want to SELL",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectedOrder": "Selected order:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Select file",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Select Language",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Select Your Payment Method",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Sell",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Warning, you're willing to sell test coins WITHOUT real value!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "SEND",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Are you sure you want to delete ",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": " wallet?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "If so, make sure you ",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": " record your seed phrase.",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": " In order to restore your wallet in the future.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Languages",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Settings",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "SET UP A PASSWORD",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Share",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "My {coinName} address: \n{address}",
-  "@shareAddress": {
+  "clickToSee": "Click to see ",
+  "@clickToSee": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "price": "price",
+  "@price": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "availableVolume": "max vol",
+  "@availableVolume": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "configureWallet": "Configuring your wallet, please wait...",
+  "@configureWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "titleCurrentAsk": "Order selected",
+  "@titleCurrentAsk": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txFeeTitle": "transaction fee:",
+  "@txFeeTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tradingFee": "trading fee:",
+  "@tradingFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapGasAmount": "{coin} balance not sufficient to pay transaction fees.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
-      "coinName": {},
-      "address": {}
+      "coin": {}
     }
   },
-  "showAddress": "Show Address",
-  "@showAddress": {
-    "type": "text"
+  "swapGasAmountRequired": "{coin} balance not sufficient to pay transaction fees. {coin} {amount} required.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders_order": [
+      "coin",
+      "amount"
+    ],
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "invalidSwap": "Unable to proceed swap",
+  "@invalidSwap": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "showDetails": "Show Details",
   "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "Showing {count} of {maxCount} orders. ",
-  "@showingOrders": {
     "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "showMyOrders": "Show My Orders",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Sign in with password",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Forgot the password? Restore wallet from seed",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Simple",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Activate",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Please enter {coin} amount to buy",
-  "@simpleTradeBuyHint": {
+  "exchangeRate": "Exchange rate:",
+  "@exchangeRate": {
     "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "simpleTradeBuyTitle": "Buy",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Close",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "Max active coins number is {maxCoins}. Please deactivate some.",
-  "@simpleTradeMaxActiveCoins": {
+  "selectedOrder": "Selected order:",
+  "@selectedOrder": {
     "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "simpleTradeNotActive": "{coin} is not active!",
-  "@simpleTradeNotActive": {
+  "minOrder": "Min order volume:",
+  "@minOrder": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "maxOrder": "Max order volume:",
+  "@maxOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "invalidSwapDetailsLink": "Details",
+  "@invalidSwapDetailsLink": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapGasActivate": "Please activate {coin} and top-up balance first",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "simpleTradeRecieve": "Receive",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Please enter {coin} amount to sell",
-  "@simpleTradeSellHint": {
+  "tradePreimageError": "Failed to calculate trade fees",
+  "@tradePreimageError": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "remove": "Disable",
+  "@remove": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "walletOnly": "Wallet only",
+  "@walletOnly": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "emptyWallet": "Wallet name must not be empty",
+  "@emptyWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "walletMaxChar": "Wallet name must have a max of 40 characters",
+  "@walletMaxChar": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "walletInUse": "Wallet name is already in use",
+  "@walletInUse": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "dexIsNotAvailable": "DEX is not available for this coin",
+  "@dexIsNotAvailable": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterCoin": "Search a coin",
+  "@searchFilterCoin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleSmartChain": "Select all SmartChains",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleTestCoins": "Select all Test Assets",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleERC": "Select all ERC tokens",
+  "@searchFilterSubtitleERC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleSLP": "Select all SLP tokens",
+  "@searchFilterSubtitleSLP": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleCosmos": "Select all Cosmos Network",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleIris": "Select all Iris Network",
+  "@searchFilterSubtitleIris": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleKRC": "Select all Kucoin tokens",
+  "@searchFilterSubtitleKRC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleHRC": "Select all Harmony tokens",
+  "@searchFilterSubtitleHRC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleETC": "Select all ETC tokens",
+  "@searchFilterSubtitleETC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleSBCH": "Select all SmartBCH tokens",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleAVX": "Select all Avax tokens",
+  "@searchFilterSubtitleAVX": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleUBQ": "Select all Ubiq coins",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleBEP": "Select all BEP tokens",
+  "@searchFilterSubtitleBEP": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitlePLG": "Select all Polygon tokens",
+  "@searchFilterSubtitlePLG": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleQRC": "Select all QRC tokens",
+  "@searchFilterSubtitleQRC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleHCO": "Select all HecoChain tokens",
+  "@searchFilterSubtitleHCO": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleZHTLC": "Select all ZHTLC coins",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleFTM": "Select all Fantom tokens",
+  "@searchFilterSubtitleFTM": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleMVR": "Select all Moonriver tokens",
+  "@searchFilterSubtitleMVR": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "customFee": "Custom fee",
+  "@customFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "gasLimit": "Gas limit",
+  "@gasLimit": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "gasPrice": "Gas price",
+  "@gasPrice": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "customFeeWarning": "Only use custom fees if you know what you are doing!",
+  "@customFeeWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchFilterSubtitleutxo": "Select all UTXO coins",
+  "@searchFilterSubtitleutxo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "builtOnKmd": "Built on Komodo",
+  "@builtOnKmd": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "poweredOnKmd": "Powered by Komodo",
+  "@poweredOnKmd": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "errorNotEnoughGas": "Not enough gas - use at least {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders_order": [
+      "gas"
+    ],
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "orderCancel": "All {coin} orders will be canceled.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "simpleTradeSellTitle": "Sell",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Send",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Show less",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Show more",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "Unable to activate {coin}",
-  "@simpleTradeUnableActivate": {
+  "deleteConfirm": "Confirm deactivation",
+  "@deleteConfirm": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deleteSpan1": "Do you want to remove ",
+  "@deleteSpan1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deleteSpan2": " from your portfolio? All unmatched orders will be canceled. ",
+  "@deleteSpan2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deleteSpan3": " will also be deactivated",
+  "@deleteSpan3": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cantDeleteDefaultCoinTitle": "Can't disable ",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cantDeleteDefaultCoinSpan": " is a default coin. Default coins can't be disabled.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cantDeleteDefaultCoinOk": "Ok",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "share": "Share",
+  "@share": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "warningShareLogs": "Warning - in special cases this log data contains sensitive information that can be used to spend coins from failed swaps!",
+  "@warningShareLogs": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enterOldPinCode": "Enter your old PIN",
+  "@enterOldPinCode": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enterNewPinCode": "Enter your new PIN",
+  "@enterNewPinCode": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "authenticate": "authenticate",
+  "@authenticate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "settingLanguageTitle": "Languages",
+  "@settingLanguageTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "englishLanguage": "English",
+  "@englishLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "frenchLanguage": "French",
+  "@frenchLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deutscheLanguage": "Deutsch",
+  "@deutscheLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "chineseLanguage": "Chinese",
+  "@chineseLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "russianLanguage": "Russian",
+  "@russianLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "japaneseLanguage": "Japanese",
+  "@japaneseLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "turkishLanguage": "Turkish",
+  "@turkishLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hungarianLanguage": "Hungarian",
+  "@hungarianLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "spanishLanguage": "Spanish",
+  "@spanishLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "koreanLanguage": "Korean",
+  "@koreanLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "ukrainianLanguage": "Ukrainian",
+  "@ukrainianLanguage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "faucetName": "FAUCET",
+  "@faucetName": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "faucetSuccess": "Success",
+  "@faucetSuccess": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "faucetError": "Error",
+  "@faucetError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "faucetTimedOut": "Request timed out",
+  "@faucetTimedOut": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "faucetInProgress": "Sending request to {coin} faucet...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "skip": "Skip",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Dismiss",
-  "@snackbarDismiss": {
-    "type": "text"
+  "Optional": "Optional",
+  "@Optional": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "Sound": "Sound",
   "@Sound": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Play at full volume": "Play at full volume",
+  "@Play at full volume": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Taker": "Taker",
+  "@Taker": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "you have a fresh order that is trying to match with an existing order": "you have a fresh order that is trying to match with an existing order",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Maker": "Maker",
+  "@Maker": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "you have an order that new orders can match with": "you have an order that new orders can match with",
+  "@you have an order that new orders can match with": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Active": "Active",
+  "@Active": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "you have an active swap in progress": "you have an active swap in progress",
+  "@you have an active swap in progress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Failed": "Failed",
+  "@Failed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "a swap fails": "a swap fails",
+  "@a swap fails": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Applause": "Applause",
+  "@Applause": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "a swap runs to completion": "a swap runs to completion",
+  "@a swap runs to completion": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "Can't play that": "Can't play that",
+  "@Can't play that": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "soundCantPlayThatMsg": "Pick an mp3 or wav file please. We'll play it when {description}.",
   "@soundCantPlayThatMsg": {
     "type": "text",
+    "placeholders_order": [
+      "description"
+    ],
     "placeholders": {
       "description": {
         "example": "a swap runs to completion"
@@ -3083,6 +3159,9 @@
   "soundPlayedWhen": "Played when {description}",
   "@soundPlayedWhen": {
     "type": "text",
+    "placeholders_order": [
+      "description"
+    ],
     "placeholders": {
       "description": {
         "example": "a swap runs to completion"
@@ -3091,571 +3170,2372 @@
   },
   "soundsDialogTitle": "Sounds",
   "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Understood, don't show it anymore",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Sound",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Sound settings",
-  "@soundSettingsTitle": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "soundsExplanation": "You'll hear sound notifications during the swap process and when you have an active maker order placed.\nAtomic swaps protocol requires participants to be online for a successful trade, and sound notifications help to achieve that.",
   "@soundsExplanation": {
-    "type": "text"
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "soundsNote": "Note that you can set your custom sounds in application settings.",
   "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Spanish",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startSwap": "Start Swap",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Step",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Success!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Support",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "If you have any questions, or think you've found a technical problem with the {appName} app, you can report it and get support from our team.",
-  "@supportLinksDesc": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "soundsDoNotShowAgain": "Understood, don't show it anymore",
+  "@soundsDoNotShowAgain": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "soundSettingsTitle": "Sound settings",
+  "@soundSettingsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "soundSettingsLink": "Sound",
+  "@soundSettingsLink": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsTab": "Markets",
+  "@marketsTab": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsTitle": "MARKETS",
+  "@marketsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsPrice": "PRICE",
+  "@marketsPrice": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsOrderbook": "ORDER BOOK",
+  "@marketsOrderbook": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsChart": "Chart",
+  "@marketsChart": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsDepth": "Depth",
+  "@marketsDepth": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsPrice": "Price",
+  "@orderDetailsPrice": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsSells": "Sells",
+  "@orderDetailsSells": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsFor": "for",
+  "@orderDetailsFor": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsMin": "min.",
+  "@orderDetailsMin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsAddress": "Address",
+  "@orderDetailsAddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsExpedient": "Expedient: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders_order": [
+      "delta"
+    ],
     "placeholders": {
-      "appName": {}
+      "delta": {}
     }
   },
-  "swap": "swap",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Current",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "CONFIRM EXCHANGE DETAILS",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Estimate",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Swap failed",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Please activate {coin} and top-up balance first",
-  "@swapGasActivate": {
+  "orderDetailsExpensive": "Expensive: CEX {delta}%",
+  "@orderDetailsExpensive": {
     "type": "text",
+    "placeholders_order": [
+      "delta"
+    ],
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsIdentical": "Identical to CEX",
+  "@orderDetailsIdentical": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsReceive": "Receive",
+  "@orderDetailsReceive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsSpend": "Spend",
+  "@orderDetailsSpend": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "ownOrder": " This is your own order!",
+  "@ownOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsSelectCoins": "Please select coins",
+  "@marketsSelectCoins": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "coinSelectTitle": "Select Coin",
+  "@coinSelectTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "coinSelectNotFound": "No active coins",
+  "@coinSelectNotFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "coinSelectClear": "Clear",
+  "@coinSelectClear": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "ordersTablePrice": "Price ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "swapGasAmount": "{coin} balance not sufficient to pay transaction fees.",
-  "@swapGasAmount": {
+  "ordersTableAmount": "Amt. ({coin})",
+  "@ordersTableAmount": {
     "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
       "coin": {}
     }
   },
-  "swapGasAmountRequired": "{coin} balance not sufficient to pay transaction fees. {coin} {amount} required.",
-  "@swapGasAmountRequired": {
+  "ordersTableTotal": "Total ({coin})",
+  "@ordersTableTotal": {
     "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
-      "coin": {},
+      "coin": {}
+    }
+  },
+  "marketsNoBids": "No bids found",
+  "@marketsNoBids": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsNoAsks": "No asks found",
+  "@marketsNoAsks": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "marketsOrderDetails": "Order Details",
+  "@marketsOrderDetails": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "candleChartError": "Something went wrong. Try again later.",
+  "@candleChartError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTitle": "Rewards information",
+  "@rewardsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsReadMore": "Read more about KMD active user rewards",
+  "@rewardsReadMore": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsCancel": "Cancel",
+  "@rewardsCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsReceive": "Receive",
+  "@rewardsReceive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noRewards": "No claimable rewards",
+  "@noRewards": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTableTitle": "Rewards information:",
+  "@rewardsTableTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTableUXTO": "UTXO amt,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTableRewards": "Rewards,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTableFiat": "Fiat",
+  "@rewardsTableFiat": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTableTime": "Time left",
+  "@rewardsTableTime": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTableStatus": "Status",
+  "@rewardsTableStatus": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsPopupTitle": "Rewards status:",
+  "@rewardsPopupTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsPopupOk": "Ok",
+  "@rewardsPopupOk": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rewardsTimeDays": "{dd} day(s)",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders_order": [
+      "dd"
+    ],
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}h {minutes}m",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders_order": [
+      "hh",
+      "minutes"
+    ],
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}min",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders_order": [
+      "mm"
+    ],
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsSuccess": "Success! {amount} KMD received.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders_order": [
+      "amount"
+    ],
+    "placeholders": {
       "amount": {}
     }
   },
-  "swapOngoing": "Swap ongoing",
-  "@swapOngoing": {
-    "type": "text"
+  "rewardsError": "Something went wrong. Please try again later.",
+  "@rewardsError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "swapProgress": "Progress details",
-  "@swapProgress": {
-    "type": "text"
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "swapStarted": "Started",
-  "@swapStarted": {
-    "type": "text"
+  "rewardsLowAmountLong": "UTXO amount less than 10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "swapSucceful": "Swap successful",
-  "@swapSucceful": {
-    "type": "text"
+  "rewardsInProgressShort": "processing",
+  "@rewardsInProgressShort": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "swapTotal": "Total",
-  "@swapTotal": {
-    "type": "text"
+  "rewardsInProgressLong": "Transaction is in progress",
+  "@rewardsInProgressLong": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "swapUUID": "Swap UUID",
-  "@swapUUID": {
-    "type": "text"
+  "rewardsOneHourShort": "<1 hour",
+  "@rewardsOneHourShort": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "switchTheme": "Switch Theme",
-  "@switchTheme": {
-    "type": "text"
+  "rewardsOneHourLong": "One hour not passed yet",
+  "@rewardsOneHourLong": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
+  "rewardsButton": "Claim your rewards",
+  "@rewardsButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
+  "seeTxHistory": "View Transaction History",
+  "@seeTxHistory": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
+  "retryActivating": "Retrying activating all coins...",
+  "@retryActivating": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Taker",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Taker Order",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Timeout",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "CREATE A PASSWORD",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Order selected",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "To",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "To address:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "You have ",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": " assets enabled. Enabled assets max limit is ",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". Please disable some assets before adding more.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Too many assets enabled",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Total Fees:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "TRADE",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "SWAP COMPLETED!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "TRADE DETAILS",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Failed to calculate trade fees",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "trading fee:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Trading Mode:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Transaction Address",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Transaction Hidden",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "This transaction was hidden due to a possible phishing attempt.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
+  "willBeRedirected": "You will be redirected to portfolio page on completion.",
+  "@willBeRedirected": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "tryRestarting": "If even then some coins are still not activated, try restarting the app.",
   "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Turkish",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Block",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Confirmations",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "CONFIRMED",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Fee",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "transaction fee:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "Transaction ID",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Transactions Left: {left}",
-  "@txleft": {
     "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Too many requests.\nTransactions history requests limit exceeded.\nPlease try again later.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "UNCONFIRMED",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Ukrainian",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "unlock",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Unlock Funds",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "Successfully unlocked {amnt} funds - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "unspendable",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "New version available",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Checking for updates...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "You are using version {version}",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "New version available. Please update.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Version {version} available. Please update.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Update available",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Skip for now",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "{appName} update",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Update",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Already up to date",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Not enough balance for scanned ",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": " payment request.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Insufficient balance",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Value: ",
-  "@value": {
-    "type": "text"
-  },
-  "version": "version",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Explorer",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Seed & Private Keys",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Volumes",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "Wallet name is already in use",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "Wallet name must have a max of 40 characters",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Wallet only",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "Warning!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ok",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Warning - in special cases this log data contains sensitive information that can be used to spend coins from failed swaps!",
-  "@warningShareLogs": {
-    "type": "text"
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "weFailedTo": "We failed to activate {coinAbbr}",
   "@weFailedTo": {
     "type": "text",
+    "placeholders_order": [
+      "coinAbbr"
+    ],
     "placeholders": {
       "coinAbbr": {}
     }
+  },
+  "pleaseRestart": "Please restart the app to try again, or press the button below.",
+  "@pleaseRestart": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "retryAll": "Retry activating all",
+  "@retryAll": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "automaticRedirected": "You will be automatically redirected to portfolio page when the retry activation process completes.",
+  "@automaticRedirected": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "weFailedToActivate": "We failed to activate {coinAbbr}.\nPlease restart the app to try again.",
   "@weFailedToActivate": {
     "type": "text",
+    "placeholders_order": [
+      "coinAbbr"
+    ],
     "placeholders": {
       "coinAbbr": {}
     }
   },
-  "welcomeInfo": "{appName} mobile is a next generation multi-coin wallet with native third generation DEX functionality and more.",
-  "@welcomeInfo": {
+  "isUnavailable": "{coinAbbr} is unavailable :(",
+  "@isUnavailable": {
     "type": "text",
+    "placeholders_order": [
+      "coinAbbr"
+    ],
     "placeholders": {
-      "appName": {}
+      "coinAbbr": {}
     }
   },
-  "welcomeLetSetUp": "LET'S GET SET UP!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "WELCOME",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "wallet",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "You will be redirected to portfolio page on completion.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "This will take a while and the app must be kept in the foreground.\nTerminating the app while activation is in progress could lead to issues.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Withdraw",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "You have previously denied {appName} access to the camera.\nPlease manually change camera permission in your phone settings to proceed with the QR code scan.",
-  "@withdrawCameraAccessText": {
+  "multiTab": "Multi",
+  "@multiTab": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiFixErrors": "Please fix all errors before continuing",
+  "@multiFixErrors": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiCreate": "Create",
+  "@multiCreate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiCreateOrder": "Order",
+  "@multiCreateOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiCreateOrders": "Orders",
+  "@multiCreateOrders": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiBasePlaceholder": "Coin",
+  "@multiBasePlaceholder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiSellTitle": "Sell:",
+  "@multiSellTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiBaseSelectTitle": "Sell",
+  "@multiBaseSelectTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiBaseAmtPlaceholder": "Amount",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiReceiveTitle": "Receive:",
+  "@multiReceiveTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiTablePrice": "Price/CEX",
+  "@multiTablePrice": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiTableAmt": "Receive Amt.",
+  "@multiTableAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiFiatDesc": "Please enter fiat amount to receive:",
+  "@multiFiatDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiFiatCancel": "Cancel",
+  "@multiFiatCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiFiatFill": "Autofill",
+  "@multiFiatFill": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiEthFee": "fee",
+  "@multiEthFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiLowerThanFee": "Not enough {coin} to pay fees. MIN balance is {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders_order": [
+      "coin",
+      "fee"
+    ],
     "placeholders": {
-      "appName": {}
+      "coin": {},
+      "fee": {}
     }
   },
-  "withdrawCameraAccessTitle": "Access Denied",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Confirm Withdrawal",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Something went wrong. Try again later.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "WITHDRAW {amount} {coinName}",
-  "@withdrawValue": {
+  "multiConfirmTitle": "Create {number} Order(s):",
+  "@multiConfirmTitle": {
     "type": "text",
+    "placeholders_order": [
+      "number"
+    ],
     "placeholders": {
-      "amount": {},
-      "coinName": {}
+      "number": {}
     }
   },
-  "wrongCoinSpan1": "You are trying to scan a payment QR code for ",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": " but you are on the ",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": " withdraw screen",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Wrong coin",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "The passwords do not match. Please try again.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Yes",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "You are sending:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "you have a fresh order that is trying to match with an existing order",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "you have an active swap in progress",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "you have an order that new orders can match with",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "your wallet",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "You will receive {amount} {coin}",
-  "@youWillReceiveClaim": {
+  "multiConfirmCancel": "Cancel",
+  "@multiConfirmCancel": {
     "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiConfirmConfirm": "Confirm",
+  "@multiConfirmConfirm": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiInvalidSellAmt": "Invalid sell amount",
+  "@multiInvalidSellAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiMaxSellAmt": "Max sell amount is",
+  "@multiMaxSellAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiMinSellAmt": "Min sell amount is",
+  "@multiMinSellAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "multiInvalidAmt": "Invalid amount",
+  "@multiInvalidAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "invalidCoinAddress": "Invalid {coin} address",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
     "placeholders": {
-      "amount": {},
       "coin": {}
     }
   },
-  "youWillReceived": "You will receive: ",
-  "@youWillReceived": {
-    "type": "text"
+  "multiActivateGas": "Activate {coin} and top-up balance first",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiLowGas": "{coin} balance is too low",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMinReceiveAmt": "Min receive amount is",
+  "@multiMinReceiveAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressBook": "Address book",
+  "@addressBook": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressBookTitle": "Address Book",
+  "@addressBookTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactTitle": "Contact details",
+  "@contactTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressBookEmpty": "Address book is empty",
+  "@addressBookEmpty": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressBookFilter": "Only showing contacts with {title} addresses",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders_order": [
+      "title"
+    ],
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "createContact": "Create Contact",
+  "@createContact": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactTitleName": "Name",
+  "@contactTitleName": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "editContact": "Edit Contact",
+  "@editContact": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactCancel": "Cancel",
+  "@contactCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactSave": "Save",
+  "@contactSave": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactDiscardBtn": "Discard",
+  "@contactDiscardBtn": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactExit": "Exit",
+  "@contactExit": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactExitWarning": "Discard your changes?",
+  "@contactExitWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressAdd": "Add Address",
+  "@addressAdd": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressSelectCoin": "Select Coin",
+  "@addressSelectCoin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "searchForTicker": "Search for Ticker",
+  "@searchForTicker": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactDelete": "Delete Contact",
+  "@contactDelete": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactDeleteWarning": "Are you sure you want to delete contact {name}?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders_order": [
+      "name"
+    ],
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDeleteBtn": "Delete",
+  "@contactDeleteBtn": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactNotFound": "No contacts found",
+  "@contactNotFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contactEdit": "Edit",
+  "@contactEdit": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressNotFound": "Nothing found",
+  "@addressNotFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noSuchCoin": "No such coin",
+  "@noSuchCoin": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "addressCoinInactive": "You can not send funds to {abbr} address, because {abbr} is not activated. Please go to portfolio.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders_order": [
+      "abbr"
+    ],
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "warningOkBtn": "Ok",
+  "@warningOkBtn": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "emptyName": "Contact name cannot be empty",
+  "@emptyName": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "emptyCoin": "Input {abbr} address",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders_order": [
+      "abbr"
+    ],
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "camoPinTitle": "Camouflage PIN",
+  "@camoPinTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinLink": "Camouflage PIN",
+  "@camoPinLink": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinOn": "On",
+  "@camoPinOn": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinOff": "Off",
+  "@camoPinOff": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "matchingCamoTitle": "Invalid PIN",
+  "@matchingCamoTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "matchingCamoChange": "Change",
+  "@matchingCamoChange": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinDesc": "If You'll unlock the app with the Camouflage PIN, a fake LOW balance will be shown and the Camouflage PIN config option will NOT be visible in the settings",
+  "@camoPinDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "matchingCamoPinError": "Your general PIN and Camouflage PIN are the same.\nCamouflage mode will not be available.\nPlease change Camouflage PIN.",
+  "@matchingCamoPinError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinBioProtectionConflict": "Camouflage PIN and Bio protection can't be enabled at the same time.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinBioProtectionConflictTitle": "Camo PIN and Bio protection conflict.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "generalPinNotActive": "General PIN protection is not active.\nCamouflage mode will not be available.\nPlease activate PIN protection.",
+  "@generalPinNotActive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "fakeBalanceAmt": "Fake balance amount:",
+  "@fakeBalanceAmt": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinNotFound": "Camouflage PIN not found",
+  "@camoPinNotFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinCreate": "Create Camouflage PIN",
+  "@camoPinCreate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinSaved": "Camouflage PIN saved",
+  "@camoPinSaved": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinInvalid": "Invalid Camouflage PIN",
+  "@camoPinInvalid": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoPinChange": "Change Camouflage PIN",
+  "@camoPinChange": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoSetupTitle": "Camouflage PIN Setup",
+  "@camoSetupTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "camoSetupSubtitle": "Enter new Camouflage PIN",
+  "@camoSetupSubtitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "protectionCtrlOn": "ON",
+  "@protectionCtrlOn": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "protectionCtrlOff": "OFF",
+  "@protectionCtrlOff": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "protectionCtrlConfirmations": "Confirmations",
+  "@protectionCtrlConfirmations": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "dPow": "Komodo dPoW security",
+  "@dPow": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "protectionCtrlCustom": "Use custom protection settings",
+  "@protectionCtrlCustom": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "protectionCtrlWarning": "Warning, this atomic swap is not dPoW protected. ",
+  "@protectionCtrlWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "buyOrderType": "Convert to Maker if not matched",
+  "@buyOrderType": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cexChangeRate": "CEXchange rate",
+  "@cexChangeRate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exchangeExpedient": "Expedient",
+  "@exchangeExpedient": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exchangeExpensive": "Expensive",
+  "@exchangeExpensive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exchangeIdentical": "Identical to CEX",
+  "@exchangeIdentical": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "comparedToCex": "compared to CEX",
+  "@comparedToCex": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "comparedTo24hrCex": "compared to avg. 24h CEX price",
+  "@comparedTo24hrCex": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "ordersActive": "Active",
+  "@ordersActive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "ordersHistory": "History",
+  "@ordersHistory": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsTitle": "Details",
+  "@orderDetailsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsSettings": "Open Details on single tap and select Order by long tap",
+  "@orderDetailsSettings": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsCancel": "Cancel",
+  "@orderDetailsCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderDetailsSelect": "Select",
+  "@orderDetailsSelect": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noMatchingOrders": "No matching orders found",
+  "@noMatchingOrders": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerOrder": "Maker Order",
+  "@makerOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "takerOrder": "Taker Order",
+  "@takerOrder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapCurrent": "Current",
+  "@swapCurrent": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapEstimated": "Estimate",
+  "@swapEstimated": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapStarted": "Started",
+  "@swapStarted": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapTotal": "Total",
+  "@swapTotal": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "swapProgress": "Progress details",
+  "@swapProgress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "closeMessage": "Close Error Message",
+  "@closeMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "openMessage": "Open Error Message",
+  "@openMessage": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifTxTitle": "Incoming transaction",
+  "@notifTxTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifTxText": "You have received {coin} transaction!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Swap completed",
+  "@notifSwapCompletedTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifSwapCompletedText": "{sell}/{buy} swap was completed successfully",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders_order": [
+      "sell",
+      "buy"
+    ],
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Swap failed",
+  "@notifSwapFailedTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifSwapFailedText": "{sell}/{buy} swap failed",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders_order": [
+      "sell",
+      "buy"
+    ],
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Swap timed out",
+  "@notifSwapTimeoutTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} swap was timed out",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders_order": [
+      "sell",
+      "buy"
+    ],
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStatusTitle": "Swap status changed",
+  "@notifSwapStatusTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifSwapStartedTitle": "New swap started",
+  "@notifSwapStartedTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notifSwapStartedText": "{sell}/{buy} swap started",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders_order": [
+      "sell",
+      "buy"
+    ],
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "language": "Language",
+  "@language": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "currency": "Currency",
+  "@currency": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hideBalance": "Hide balances",
+  "@hideBalance": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "switchTheme": "Switch Theme",
+  "@switchTheme": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cexData": "CEX data",
+  "@cexData": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cexDataDesc": "Markets data (prices, charts, etc.) marked with this icon originates from third party sources (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "checkForUpdates": "Check for updates",
+  "@checkForUpdates": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "logoutWarning": "Are you sure you want to logout now?",
+  "@logoutWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "currencyDialogTitle": "Currency",
+  "@currencyDialogTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "txLimitExceeded": "Too many requests.\nTransactions history requests limit exceeded.\nPlease try again later.",
+  "@txLimitExceeded": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "milliseconds": "ms",
+  "@milliseconds": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "minutes": "m",
+  "@minutes": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "longMinutes": "minutes",
+  "@longMinutes": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "hours": "h",
+  "@hours": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "moreTab": "More",
+  "@moreTab": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "less": "Less",
+  "@less": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "oldLogsTitle": "Old logs",
+  "@oldLogsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "oldLogsDelete": "Delete",
+  "@oldLogsDelete": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "deletingWallet": "Deleting wallet...",
+  "@deletingWallet": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "oldLogsUsed": "Space used",
+  "@oldLogsUsed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "okButton": "Ok",
+  "@okButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "closePreview": "Close preview",
+  "@closePreview": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cancelButton": "Cancel",
+  "@cancelButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "scrollToContinue": "Scroll to the bottom to continue...",
+  "@scrollToContinue": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "developerTitle": "Developer",
+  "@developerTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enableTestCoins": "Enable Test Coins",
+  "@enableTestCoins": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsTitle": "Maker Order details",
+  "@makerDetailsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsSell": "Sell",
+  "@makerDetailsSell": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsFor": "Receive",
+  "@makerDetailsFor": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsPrice": "Price",
+  "@makerDetailsPrice": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsCancel": "Cancel order",
+  "@makerDetailsCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsId": "Order ID",
+  "@makerDetailsId": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsCreated": "Created at",
+  "@makerDetailsCreated": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsNoSwaps": "No swaps were started by this order",
+  "@makerDetailsNoSwaps": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "makerDetailsSwaps": "Swaps started by this order",
+  "@makerDetailsSwaps": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderFilled": "{fill}% filled",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders_order": [
+      "fill"
+    ],
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "noteTitle": "Note",
+  "@noteTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "notePlaceholder": "Add a Note",
+  "@notePlaceholder": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importLink": "Import",
+  "@importLink": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importSingleSwapLink": "Import Single Swap",
+  "@importSingleSwapLink": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportLink": "Export",
+  "@exportLink": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importTitle": "Import",
+  "@importTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importSingleSwapTitle": "Import Swap",
+  "@importSingleSwapTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportTitle": "Export",
+  "@exportTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportDesc": "Please select items to export into encrypted file.",
+  "@exportDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importLoadDesc": "Please select encrypted file to import.",
+  "@importLoadDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importLoadSwapDesc": "Please select plain text swap file to import.",
+  "@importLoadSwapDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importLoading": "Opening...",
+  "@importLoading": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importDesc": "Items to be imported:",
+  "@importDesc": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportNotesTitle": "Notes",
+  "@exportNotesTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportContactsTitle": "Contacts",
+  "@exportContactsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportSwapsTitle": "Swaps",
+  "@exportSwapsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "nothingFound": "Nothing found",
+  "@nothingFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportButton": "Export",
+  "@exportButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importButton": "Import",
+  "@importButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "emptyExportPass": "Encryption password can't be empty",
+  "@emptyExportPass": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "emptyImportPass": "Password can't be empty",
+  "@emptyImportPass": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "matchExportPass": "Passwords must match",
+  "@matchExportPass": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noItemsToExport": "No items selected",
+  "@noItemsToExport": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noItemsToImport": "No items selected",
+  "@noItemsToImport": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectFileImport": "Select file",
+  "@selectFileImport": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importFileNotFound": "File not found",
+  "@importFileNotFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "fingerprint": "Fingerprint",
+  "@fingerprint": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importPassword": "Password",
+  "@importPassword": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importPassCancel": "Cancel",
+  "@importPassCancel": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importPassOk": "Ok",
+  "@importPassOk": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "exportSuccessTitle": "Items have been successfully exported:",
+  "@exportSuccessTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importSuccessTitle": "Items have been successfully imported:",
+  "@importSuccessTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importDecryptError": "Invalid password or corrupted data",
+  "@importDecryptError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importSwapJsonDecodingError": "Error decoding json file",
+  "@importSwapJsonDecodingError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderTypePartial": " Order",
+  "@orderTypePartial": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderTypeUnknown": "Unknown Type Order",
+  "@orderTypeUnknown": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "couldntImportError": "Couldn't import: ",
+  "@couldntImportError": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importSomeItemsSkippedWarning": "Some items have been skipped",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importSwapFailed": "Failed to import swap",
+  "@importSwapFailed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "importInvalidSwapData": "Invalid swap data. Please provide a valid swap status JSON file.",
+  "@importInvalidSwapData": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "activating": "Activating {coinName}",
+  "@activating": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Do not close the app. Tap for more info...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "activation": "{coinName} Activation",
+  "@activation": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "coinsAreActivated": "{protocolName} coins are activated",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders_order": [
+      "protocolName"
+    ],
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "{protocolName} coins are not activated",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders_order": [
+      "protocolName"
+    ],
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} coins activated successfully",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders_order": [
+      "protocolName"
+    ],
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} Activation in Progress",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders_order": [
+      "protocolName"
+    ],
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "activateCoins": "Activate {protocolName} coins?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders_order": [
+      "protocolName"
+    ],
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "moreInfo": "More Info",
+  "@moreInfo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "showAddress": "Show Address",
+  "@showAddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "transactionHiddenPhishing": "This transaction was hidden due to a possible phishing attempt.",
+  "@transactionHiddenPhishing": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "transactionAddress": "Transaction Address",
+  "@transactionAddress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "transactionHidden": "Transaction Hidden",
+  "@transactionHidden": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "couldNotLaunchUrl": "Could not launch URL",
+  "@couldNotLaunchUrl": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "willTakeTime": "This will take a while and the app must be kept in the foreground.\nTerminating the app while activation is in progress could lead to issues.",
+  "@willTakeTime": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "minimizingWillTerminate": "Warning: Minimizing the app on iOS will terminate the activation process.",
+  "@minimizingWillTerminate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enableNotificationsForActivationProgress": "Please enable notifications to get updates on the activation progress.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "qrCodeScanner": "QR Code Scanner",
+  "@qrCodeScanner": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "foundQrCode": "Found QR Code",
+  "@foundQrCode": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "contract": "Contract",
+  "@contract": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "startSwap": "Start Swap",
+  "@startSwap": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "none": "None",
+  "@none": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cexRate": "CEX Rate",
+  "@cexRate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "incomingTransactionsProtectionSettings": "Incoming  {coinName} txs protection settings",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "showingOrders": "Showing {count} of {maxCount} orders. ",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders_order": [
+      "count",
+      "maxCount"
+    ],
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "orderBookLess": "Less",
+  "@orderBookLess": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "orderBookMore": "More",
+  "@orderBookMore": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "basedOnCoinRatio": "based on {coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName1",
+      "coinName2"
+    ],
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "send trading fee transaction fee",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "detailedFeesTradingFee": "trading fee",
+  "@detailedFeesTradingFee": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "detailedFeesSendCoinTransactionFee": "send {coinName} transaction fee",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesReceiveCoinTransactionFee": "receive {coinName} transaction fee",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders_order": [
+      "coinName"
+    ],
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "filtersButton": "Filter",
+  "@filtersButton": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersStatus": "Status",
+  "@filtersStatus": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersAll": "All",
+  "@filtersAll": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersSuccessful": "Successful",
+  "@filtersSuccessful": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersFailed": "Failed",
+  "@filtersFailed": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersFrom": "From date",
+  "@filtersFrom": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersTo": "To date",
+  "@filtersTo": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersType": "Taker/Maker",
+  "@filtersType": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersMaker": "Maker",
+  "@filtersMaker": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "all": "All",
+  "@all": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersTaker": "Taker",
+  "@filtersTaker": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersSell": "Sell coin",
+  "@filtersSell": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersReceive": "Receive coin",
+  "@filtersReceive": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "filtersClearAll": "Clear all filters",
+  "@filtersClearAll": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "uriInsufficientBalanceTitle": "Insufficient balance",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "uriInsufficientBalanceSpan1": "Not enough balance for scanned ",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "uriInsufficientBalanceSpan2": " payment request.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enablingTooManyAssetsTitle": "Trying to enable too many assets",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enablingTooManyAssetsSpan1": "You have ",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enablingTooManyAssetsSpan2": " assets enabled and trying to enable ",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enablingTooManyAssetsSpan3": " more. Enabled assets max limit is ",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "enablingTooManyAssetsSpan4": ". Please disable some assets before adding more.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "coinsActivatedLimitReached": "You have selected the max number of assets",
+  "@coinsActivatedLimitReached": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tooManyAssetsEnabledTitle": "Too many assets enabled",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tooManyAssetsEnabledSpan1": "You have ",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tooManyAssetsEnabledSpan2": " assets enabled. Enabled assets max limit is ",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "tooManyAssetsEnabledSpan3": ". Please disable some assets before adding more.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsTitle": "Payment Requested",
+  "@paymentUriDetailsTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsCoinSpan": "Coin: ",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsAddressSpan": "To Address ",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsAmountSpan": "Amount: ",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsAcceptQuestion": "Do you accept this transaction?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsAccept": "Pay",
+  "@paymentUriDetailsAccept": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriDetailsDeny": "Cancel",
+  "@paymentUriDetailsDeny": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "paymentUriInactiveCoin": "{abbr} is not active. Please activate and try again.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders_order": [
+      "abbr"
+    ],
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "wrongCoinTitle": "Wrong coin",
+  "@wrongCoinTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "wrongCoinSpan1": "You are trying to scan a payment QR code for ",
+  "@wrongCoinSpan1": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "wrongCoinSpan2": " but you are on the ",
+  "@wrongCoinSpan2": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "wrongCoinSpan3": " withdraw screen",
+  "@wrongCoinSpan3": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeSellTitle": "Sell",
+  "@simpleTradeSellTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeBuyTitle": "Buy",
+  "@simpleTradeBuyTitle": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeRecieve": "Receive",
+  "@simpleTradeRecieve": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeSend": "Send",
+  "@simpleTradeSend": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeClose": "Close",
+  "@simpleTradeClose": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeActivate": "Activate",
+  "@simpleTradeActivate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeMaxActiveCoins": "Max active coins number is {maxCoins}. Please deactivate some.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders_order": [
+      "maxCoins"
+    ],
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeUnableActivate": "Unable to activate {coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} is not active!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyHint": "Please enter {coin} amount to buy",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellHint": "Please enter {coin} amount to sell",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeShowLess": "Show less",
+  "@simpleTradeShowLess": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "simpleTradeShowMore": "Show more",
+  "@simpleTradeShowMore": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "noCoinFound": "No coin found",
+  "@noCoinFound": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "rebrandingAnnouncement": "It's a new era! We have officially rebranded from 'AtomicDEX' to 'Komodo Wallet'",
+  "@rebrandingAnnouncement": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "officialPressRelease": "Official press release",
+  "@officialPressRelease": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "shouldScanPastTransaction": "Scan for past {coin} transactions?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "cancelActivation": "Cancel Activation",
+  "@cancelActivation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cancelActivationQuestion": "Are you sure you want to cancel activation?",
+  "@cancelActivationQuestion": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "cofirmCancelActivation": "Are you sure you want to cancel activation?",
+  "@cofirmCancelActivation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "syncTransactionsQuestion": "Which {name} transactions would you like to sync?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders_order": [
+      "name"
+    ],
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "syncNewTransactions": "Sync new transactions",
+  "@syncNewTransactions": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "syncFromDate": "Sync from specified date",
+  "@syncFromDate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "syncFromSaplingActivation": "Sync from sapling activation",
+  "@syncFromSaplingActivation": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "selectDate": "Select a Date",
+  "@selectDate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "startDate": "Start Date",
+  "@startDate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "futureTransactions": "We will sync future transactions made after activation associated with your public key. This is the quickest option and takes up the least amount of storage.",
+  "@futureTransactions": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "allPastTransactions": "Your wallet will show any past transactions. This will take significant storage and time as all blocks will be downloaded and scanned.",
+  "@allPastTransactions": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "pastTransactionsFromDate": "Your wallet will show your past transactions made after the specified date.",
+  "@pastTransactionsFromDate": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2023-10-06T11:55:34.625736",
+  "@@last_modified": "2023-10-08T14:29:27.352621",
   "mobileDataWarning": "Please note that now you're using cellular data and participation in {appName} P2P network consume internet traffic. It's better to use a WiFi network if your cellular data plan is costly.",
   "@mobileDataWarning": {
     "type": "text",
@@ -3622,6 +3622,16 @@
       "coinAbbr": {}
     }
   },
+  "failedToCancelActivation": "Failed to cancel activation of {coinAbbr}",
+  "@failedToCancelActivation": {
+    "type": "text",
+    "placeholders_order": [
+      "coinAbbr"
+    ],
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
   "isUnavailable": "{coinAbbr} is unavailable :(",
   "@isUnavailable": {
     "type": "text",
@@ -5461,6 +5471,38 @@
     "placeholders": {
       "coin": {}
     }
+  },
+  "activationCancelled": "Coin activation cancelled",
+  "@activationCancelled": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
+  "coinActivationSuccessfull": "Successfully activated {coin}",
+  "@coinActivationSuccessfull": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "coinActivationCancelled": "{coin} activation cancelled",
+  "@coinActivationCancelled": {
+    "type": "text",
+    "placeholders_order": [
+      "coin"
+    ],
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "pleaseAcceptAllCoinActivationRequests": "Please accept all special coin activation requests or deselect the coins.",
+  "@pleaseAcceptAllCoinActivationRequests": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
   },
   "cancelActivation": "Cancel Activation",
   "@cancelActivation": {

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,3726 +1,5528 @@
 {
-  "@@locale": "ru",
-  "accepteula": "Принять EULA",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Принять ПРАВИЛА и УСЛОВИЯ",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Активировать биометрическую защиту",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "Активировать защиту PIN",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "Активировать монеты {protocolName}?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Обратите внимание, что теперь вы используете сотовые данные, а участие в P2P-сети {appName} потребляет интернет-трафик. Лучше использовать сеть Wi-Fi, если ваш тарифный план сотовой связи является дорогостоящим.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Доступ запрещен",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "Ранее вы запретили {appName} доступ к камере.\nВручную измените разрешения для камеры в настройках телефона, чтобы продолжить сканирование QR-кода.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "Добро пожаловать",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "кошелек",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} mobile - это мульти-монетный кошелек с функциональностью DEX третьего поколения и многим другим.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "ДАВАЙТЕ ВСЕ НАСТРОИМ!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "Обновление {appName}",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "Установлена версия {version}",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Проверка обновлений...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Установлена последняя версия",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Доступна новая версия",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Обновление",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Пропустить",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Доступно обновление",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Доступна новая версия. Пожалуйста, обновитесь.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "Доступна версия {version}. Пожалуйста, обновитесь.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Помощь",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Помощь и поддержка",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Часто задаваемые вопросы",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Поддержка",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Если у вас есть какие-либо вопросы или вы считаете, что обнаружили техническую проблему с приложением {appName}, вы можете сообщить об этом и получить поддержку от нашей команды.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "Вы храните мои приватные ключи?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "Нет! Мы никогда не храним конфиденциальные данные, включая ваши приватные ключи, seed ключи или PIN-код. Эти данные хранятся только на устройстве пользователя и никуда не передаются. Вы полностью контролируете свои активы.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "Чем торговля на {appName} отличается от торговли на других DEX?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Другие DEX обычно позволяют торговать только активами, принадлежащими к одному блокчейну, используют прокси-токены и разрешают размещать только один ордер, использующий ваш баланс.\n\n{appName} позволяет вам торговать между разными блокчейнами без использования прокси-токенов. Вы также можете разместить несколько заказов, используя одни и те же средства. Например, вы можете выставить ордера на продажу 0,1 BTC за KMD, QTUM и VRSC - первый исполненный ордер автоматически отменит все остальные ордера.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "Сколько времени занимает каждый атомарный своп?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Есть несколько факторов, определяющих время обработки каждого свопа. Время блокировки торгуемых активов зависит от каждой сети (биткоин блокчейн обычно является самым медленным). Кроме того, пользователь может редактировать параметры безопасности. Например, в {appName} можно установить количество подтверждений, после которых KMD транзакция считается успешной, равным 3, что сокращает время обмена по сравнению с транзакциями, ожидающими <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">нотариального заверения</a>.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "Необходимо ли мне быть в сети во время свопа?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Да. Приложение должно оставаться подключенным к Интернету для успешного завершения каждого атомарного свопа (очень короткие перерывы в подключении обычно допустимы). В противном случае существует риск отмены сделки, если вы являетесь мейкером, и риск потери средств, если вы тейкер. Протокол атомарного свопа требует, чтобы оба участника оставались в сети и контролировали задействованные блокчейны, чтобы процесс оставался атомарным.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "Как рассчитываются комиссии на {appName}?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "При торговле на {appName} необходимо учитывать две категории комиссий.\n\n1. {appName} взимает приблизительно 0,13% (1/777 объема торгов, но не ниже 0,0001) в качестве комиссии за торговлю для тейкер ордеров, а для ордеров-мейкеров комиссия равна нулю.\n\n2. Как мейкеры, так и тейкеры должны платят обычные комиссии за транзакции в используемых блокчейнах при совершении атомарного свопа .\n\nКомиссиии сети могут сильно различаться в зависимости от выбранной вами торговой пары.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "Предоставляете ли вы поддержку пользователей?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "Да! {appName} предлагает поддержку через <a href=\"{link}\"> {name} сервер {appCompanyShort} </a>. Команда и сообщество всегда рады помочь!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "Есть ли у вас какие-либо географические ограничения?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "Нет! {appName} полностью децентрализована. Ограничить доступ пользователей третьими лицами невозможно.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "Кто стоит за {appName}?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} разработан командой {appCompanyShort}. {appCompanyShort} - один из наиболее авторитетных блокчейн-проектов, работающих над инновационными решениями, такими как атомарные свопы, delayed Proof of Work и совместимая многоцепочечная архитектура.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "Можно ли разработать собственную white-label биржу на технологии {appName}?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "Абсолютно! Вы можете прочитать нашу <a href=\"https://developers.komodoplatform.com/\">документацию для разработчиков</a> для получения более подробной информации или связаться с нами по вопросам партнерства. Есть конкретный технический вопрос? Сообщество разработчиков {appName} всегда готово помочь!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "На каких устройствах я могу использовать {appName}?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "Приложение {appName} доступно для мобильных устройств на Android и iPhone, а также для компьютеров в <a href=\"https://komodoplatform.com/\">операционных системах Windows, Mac и Linux</a>.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Лента",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Лента новостей",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Узнать больше",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Здесь ничего нет",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Лента новостей обновлена",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Убрать",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Новости",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Продолжительность",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "Невозможно обновить ленту новостей",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "Невозможно обновить ленту новостей",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Новых новостей нет",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Дата",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "Новости Комодо",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "Задать PIN",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "Введите свой PIN-код",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "войти",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "новый аккаунт",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Новый аккаунт",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} активирован успешно!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Соединение...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Активировать монету",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} Активов",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Введите свою seed-фразу",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Например: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "подтвердить",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "Внимание, вы пытаетесь купить тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "Критический заряд батареи ({batteryLevelCritical}%) для безопасного выполнения свопа. Пожалуйста поставьте его на зарядку и повторите попытку.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "Заряд батареи ниже {batteryLevelLow}%. Пожалуйста подумайте о зарядке телефона.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "Ваш телефон находится в режиме экономии заряда батареи. Пожалуйста, отключите этот режим или НЕ переводите приложение в фоновый режим, в противном случае приложение может быть убито операционной системой, и обмен не удастся.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "Внимание, вы пытаетесь продать тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Купить",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Продать",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "Мой {coinName} адрес:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Вывести",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "Значение слишком высокое или маленькое",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Количество",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Адрес получателя",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "ВЫВЕСТИ {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Подтвердите вывод",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Что-то пошло не так. Попробуйте позже.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Закрыть",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "Подтвердите seed-ключ",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Ваш новый seed-ключ",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Важно: перед тем как продолжить, сохраните свою seed-фразу в надежном месте!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Мы рекомендуем хранить ее на оффлайн носителе.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "далее",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "Подтвердите PIN-код",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Установить маскировочный PIN",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Подтвердить маскировочный PIN",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Ошибка, пожалуйста попробуйте еще раз",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Настройки",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Безопасность",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "Активировать защиту PIN",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Отключить скриншоты/предварительный просмотр",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "Экран заблокирован",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "Изменить PIN-код",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Выйти",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "MAX",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "МИН",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Общие комиссии:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Оплачено с баланса:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Режим Торговли",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Пропустить",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Слияние",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Перезаписать",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Текущее значение",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Новое значение",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Объединенное значение:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Сохранить объединенные",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "Уже существует",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Просто",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Расширенные",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Оплачено с полученного объема:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Сумма для продажи",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Вы получите:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "Выберите монету, которую хотите продать",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "Выберите монету, которую хотите купить",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "обмен",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Обмен начался, пожалуйста подождите!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "Поиск сделки в процессе, пожалуйста , подождите {seconde} секунд!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Комиссия сети",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "комиссия",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Портфолио",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Всего",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Расчетная общая стоимость",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Выберите способ оплаты",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Объемы",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Разместить ордер",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "Скоро будет...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Маркетплейс",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Вы отправляете:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Код:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Стоимость:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Оплачено c",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "Пожалуйста, введите данные",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "Недостаточный баланс",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Значение Gwei должно быть до {value}.",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "Комиссия должна быть не более {value}",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "Лимит должен быть до {value}",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "Невалидный адрес",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Segwit адреса не поддерживаются",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "На адрес:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "ПОЛУЧИТЬ",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "ОТПРАВИТЬ",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Публичный ключ",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "назад",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "отменить",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "детали",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Да",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "Нет",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Замечание: Выбранный ордер не может быть снова отменен",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "Не спрашивать снова",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Отменить Ордер",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "Вы уверены, что хотите отменить ордер",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "неизрасходованный",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "Детали TX скоро будут добавлены!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "история",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "сделка",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "Детали будут скоро добавлены!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Поиск сделки в процессе",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Сделка найдена",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Обмен в процессе",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Успешный обмен",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Таймаут",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Конвертировать",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "Обмен не удался",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Ошибка, пожалуйста попробуйте позже",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Последние Транзакции",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "Идет транзакция, пожалуйста, подождите",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Заканчиваем, пожалуйста, подождите",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Отправить логи",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Загрузка книги ордеров...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "Востребовать",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "Востребовать KMD вознаграждение?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "Успех!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "Нет вознаграждения для востребования - повторите попытку через 1 час.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Загрузка...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Осталось транзакций: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} недостаточно баланса чтобы оплатить торговую комиссию",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Новости",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Новостная лента",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "Скопировано",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "Из",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "В",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "ПОДТВЕРЖДЕНА",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "НЕПОДТВЕРЖДЕНА",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Блок",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Подтверждения",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Комиссия",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "ID транзакции",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Памятка",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "Нет истории.",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "СДЕЛКА",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "ОЧИСТИТЬ",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Сбросить форму",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "Обмен завершен!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Шаг",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "ДЕТАЛИ СДЕЛКИ",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Запрошенная сделка",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "UUID обмена",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "ПРОСМАТРИВАТЬ",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "СОХРАНЕННЫЕ",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaNotSavedDescription": "У вас нет сохраненных статей",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "ПОСМОТРЕТЬ ЛЕНТУ",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "По",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "Пожалуйста, аутентифицируйтесь!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "Нет транзакций",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Готово",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Активировать монеты:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Выберите монеты, которые вы хотите добавить в свое портфолио.",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "Нет новостей - пожалуйста проверьте позже!",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "Запрос на обмен не может быть отменен и является окончательным!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "Эта транзакция может занять до 10 минут - НЕ закрывайте приложение!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "ПОДТВЕРДИТЕ ДЕТАЛИ ОБМЕНА",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Минимальное требуемое количество",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "Использовать собственное минимальное количество",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "Значение должно быть указано в цифрах",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Должно быть меньше чем сумма продажи",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "Должно быть больше чем {minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "Проверьте seed-фразу",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕПРОВЕРИМ ВАШ SEED-КЛЮЧ",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "Ваш seed-ключ необходим для доступа к кошельку - поэтому мы хотим убедиться, что она правильная. Мы зададим вам три разных вопроса о вашей seed-фразе, чтобы убедиться, что вы сможете легко восстановить свой кошелек, когда захотите.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "Какое {index} слово в вашем seed-ключе?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "Введите {index} слово",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "ПРОДОЛЖИТЬ",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "ВЕРНУТЬСЯ И ПРОВЕРИТЬ СНОВА",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Обозреватель",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Активировать биометрическую защиту",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Разрешить произвольный seed-ключ",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "Предупреждение!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "Я понимаю",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Пользовательские исходные фразы могут быть менее безопасными и их легче взломать, чем сгенерированные исходные фразы или закрытый ключ (WIF), совместимые с BIP39. Чтобы подтвердить, что вы понимаете риск и знаете, что делаете, введите \"{iUnderstand}\" в поле ниже.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Введите свой пароль",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "ваш кошелек",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "Войти с помощью seed-ключа",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Войти с паролем",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Введите свой seed-ключ",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "Пароли не совпадают. Пожалуйста, попробуйте еще раз.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Назовите свой кошелек",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Вы можете зашифровать свой кошелек паролем. Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Подтвердите пароль",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "Я не хочу использовать пароль",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "ВЫ УВЕРЕНЫ?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "УСТАНОВИТЬ ПАРОЛЬ",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "СОЗДАТЬ КОШЕЛЕК",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "ВОССТАНОВИТЬ",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Пароль",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "Пароль должен содержать не менее 12 символов, включая один строчный, один заглавный и один специальный символ.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Создать пароль",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Подтвердите Пароль",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Текущий пароль",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Настройки Log Out",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Log Out при выходе",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Удалить кошелек",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Удалить",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Вы уверены, что хотите удалить",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "кошелек?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Если это так, убедитесь, что вы",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "записали свой seed-ключ.",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "Для того, чтобы восстановить свой кошелек в будущем.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Бэкап",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "версия",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Seed & Приватные ключи",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "Seed Фраза",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Приватные ключи",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Приватный ключ",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Пожалуйста, введите Ваш пароль чтобы продолжить.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "Скопировать",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "разблокировать",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "Успешно разблокировано {amnt} средств - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Разблокировать средства",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "Нет ордеров, пожалуйста перейдите в торговлю.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Пожалуйста, введите сумму {coinName}.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "Обменный курс",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Получить",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "разместить ордер",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "ОБМЕН",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "ордера",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Выберите монету",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗Осторожно! Объем торгов на рынке {coinName} за 24 часа составляет менее 10 000 долларов!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Выбрать Язык",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Нет средств",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "Нет доступных средств - пожалуйста, внесите депозит.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Перейти в портфолио",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Нажмите, чтобы создать ордер",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Недостаточное количество",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "Минимальное количество необходимое для этого ордера составляет",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Ордер создан",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Ордер успешно создан",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "ПОКАЗАТЬ МОИ ОРДЕРЫ",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "Минимальная сумма продажи составляет {number} {coinName}.",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "СОЗДАТЬ ПАРОЛЬ",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "Минимальная сумма покупки: {number} {coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "Минимальная сумма на продажу {number} {coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "Минимальная сумма ордера {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Для начала вы должны ввести сумму на продажу",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Шифрую кошелек",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Расшифровываю кошелек",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "Недостаточно баланса для комиссий - выполните сделку на меньшую сумму",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "Отсутствует подключение к Интернет",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Построено на Komodo",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Пожалуйста добавьте монету",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "Соединение с интернетом восстановлено",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Обновить",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Легальные аспекты",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Disclaimer & ToS",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "Принять EULA",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "Принять ПРАВИЛА и УСЛОВИЯ",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "Нажимая кнопку ниже, вы подтверждаете, что прочитали «EULA» и «Terms and Conditions» и принимаете их",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} комиссия",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "Не достаточно {coin} для транзакции!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Пожалуйста активируйте {coin}",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "Вы получите {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "Нажмите, чтобы увидеть {amount} ордеров",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Нажмите, чтобы увидеть",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "цена",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "макс объем",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "Настройка кошелька, пожалуйста, подождите",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Ордер выбран",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "комиссия сети:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "торговая комиссия:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию. {coin} {amount} требуется.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "Невозможно продолжить своп",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Показать детали",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Рейтинг обменника",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Выбранный ордер:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "Минимальные объем ордера",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Максимальный размер ордера",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Подробнее",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Пожалуйста сначала активируйте {coin} и пополните баланс",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Ошибка при расчете торговой комиссии",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Отключить",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Только кошелек",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "Имя кошелька не должно быть пустым",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "Имя кошелька не должно превышать 40 символов",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "Имя кошелька уже используется",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX не доступен для этой монеты",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Поиск монеты",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Выбрать все Smartchain",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Выбрать все Тестовые Активы",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Выбрать все ERC токены",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Выбрать все токены SLP",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Выбрать всю сеть Cosmos",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Выбрать всю сеть Iris",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Выбрать все Kucoin токены",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Выбрать все Harmony токены",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Выбрать все ETC токены",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Выбрать все SmartBCH токены",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Выбрать все Avax токены",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Выбрать все Ubiq монеты",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Выбрать все BEP токены",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Выбрать все Polygon токены",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Выбрать все QRC токены",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Выбрать все HecoChain токены",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Выбрать все монеты ZHTLC",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Выбрать все Fantom токены",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Выбрать все Moonriver токены",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Настроить комиссию",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "Лимит газа",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "Цена Gas",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "Используйте настраиваемые комиссии только если знаете, что делаете!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Выбрать все UTXO монеты",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Построено на Komodo",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Разработано Komodo",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "Не достаточно газа - используйте минимум {gas} Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Все {coin} ордеры будут отменены.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Подтвердить деактивацию",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "Вы хотите удалить",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "из вашего портфолио? Все несовпавшие ордеры будут отменены.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " также будет деактивирован",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "Не возможно отключить",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "это монета настроенная по умолчанию. Монеты по умолчанию не могут быть отключены.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ок",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "ПОДЕЛИТЬСЯ",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Предупреждение - в особых случаях логи могут содержать конфиденциальную информацию, которую можно использовать для доступа к монетам из незавершенных свопов!",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Введите свой старый PIN",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Введите новый PIN",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "аутентификация",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Языки",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "Английский",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Французский",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Немецкий",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Китайский",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Русский",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Японский",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Турецкий",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Венгерский",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "Испанский",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Корейский",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Украинский",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "FAUCET",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Успешно",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Ошибка",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "Время запроса истекло",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "Отправка запроса на кран {coin}",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "Необязательный",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Звук",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "Воспроизводить на полную громкость",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Тейкер",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "есть новый ордер, который совпадает с вашим размещенным ордером",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Мейкер",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "у вас есть ордер, которому могут соответствовать новые ордеры",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Активные",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "у вас уже есть активный своп в процессе",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Неудавшиеся \t",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "своп не был завершен",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Аплодисменты",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "своп завершается",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "Невозможно воспроизвести",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Выберите файл в формате mp3 или wav. Воспроизводится, когда {description}.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "Воспроизводится, когда {description}",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Звуки",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "Вы будете слышать звуковые уведомления во время процесса обмена и при размещении активного ордера.\nДля успешной торговли, протокол Atomic swaps требует чтобы участники были онлайн и звуковые уведомления помогают достичь этого.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Обратите внимание что вы можете установить свои собственные звуки в настройках приложения.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Я понимаю, больше это не показывать",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Настройки звука",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Звук",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Рынки",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "РЫНКИ",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "ЦЕНА",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "ОРДЕРБУК",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "График",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Глубина",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Цена",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Ордеры продаж",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "на",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "мин.",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Адрес",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "На -{delta}% ниже цен CEX",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "На +{delta}% выше цен CEX",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "Совпадает с СЕХ",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Получите",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Отправьте",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "Это ваш ордер!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Пожалуйста, выберите монету",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Выбрать монету",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "Нет активных монет",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Очистить",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "Цена ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "Сумма ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "Всего ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "Нет бидов",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "Нет асков",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Детали ордера",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Что-то пошло не так. Попробуйте позже.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Инфо о вознаграждениях:",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "Узнать больше о KMD вознаграждениях",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Отменить",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Получить",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "Нет доступных вознаграждений",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Инфо о вознаграждениях:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "Вознаграждений\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "Фиат",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Осталось",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Статус",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Статус вознаграждений:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "ОК",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} дней}",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}ч {minutes}мин",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "мин {mm}",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "Получено {amount} KMD.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Что-то пошло не так. Попробуйте позже.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXO меньше 10",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "обработка",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "Транзакция в процессе",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "Меньше часа",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Час еще не прошел",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Забрать вашу награду",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "Показать историю транзакций",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Попытка активации всех монет...",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "По завершении вы будете перенаправлены на страницу портфолио.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "даже если после этого некоторые монеты все еще не активированы, попробуйте перезапустить приложение.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "Ошибка активации {coinAbbr}",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Пожалуйста перезапустите приложение чтобы попробовать снова или нажмите на кнопку ниже.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Попытка активации всего",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Вы будете автоматически перенаправлены на страницу портфолио после завершения процесса повторной активации.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "Ошибка активации {coinAbbr}\nПожалуйста перезапустите приложение и попробуйте снова",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} недоступен :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Мульти",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Исправьте ошибки, прежде чем продолжить",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Создать",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Ордер",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Ордеры",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Монета",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Продать:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Продать",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Сумма",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Получить",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "Цена/СЕХ",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Получ. сумма",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Введите сумму в фиате для получения:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "Отменить",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Автозаполнение",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "комис.",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "Недостаточно {coin} чтобы оплатить налог. МИН баланс {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "Создать {number} ордер(ов):",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "Отменить",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Подтвердить",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Неверная сумма продажи",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "Макс сумма к продаже",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "Мин сумма к продаже",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Некорректная сумма",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "Неверный адрес {coin}",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "Активируйте {coin} и пополните баланс",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin} баланс очень низкий",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "Мин сумма к получению",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Адресная книга",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Адресная книга",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Контактная информация",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "Адресная книга пуста",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Отображаются только контакты с {title} адресами",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Добавить контакт",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "Имя",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Редактировать",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "Отмена",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Сохранить",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Сбросить",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Выйти",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Сбросить изменения?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Добавить адрес",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Выбрать валюту",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Найти Тикер",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Удалить контакт",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "Вы уверены, что хотите удалить {name}?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "Удалить",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "Контакты не найдены",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Изменить",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Не найдено",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "Нет такой монеты",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "Вы не можете отправить средства на адрес {abbr}, потому что {abbr} не активирован. Пожалуйста, перейдите в портфолио.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "OK",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "Имя контакта не может быть пустым",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "Введите {abbr} адрес",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Маскировочный PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Маскировочный PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "Вкл",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Выкл",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "Неверный PIN",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Изменить",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Если вы разблокируете приложение с маскировочным PIN-кодом, будет показан поддельный баланс, а настройки маскировочного PIN-кода НЕ будут отображаться в приложении",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Общий PIN и маскировочный PIN совпадают.\nРежим маскировки будет недоступен.\nИзмените маскировочный PIN",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "Маскировочный PIN и BIO защита не могут быть включены одновременно.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Конфликт маскировочного и Bio защитных PIN",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "Общая защита PIN-кодом не активна.\nРежим маскировки будет недоступен.\nВключите защиту PIN-кодом.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Маскировочный баланс:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "Маскировочный PIN не найден",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Создать Маскировочный PIN",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "Маскировочный PIN сохранен",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "Неверный маскировочный PIN",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Изменить маскировочный PIN",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Установить маскировочный PIN",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Введите новый маскировочный PIN",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "ВКЛ",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "ВЫКЛ",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Подтверждений",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Защита Komodo dPoW",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Установить свои настройки защиты",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Внимание, этот своп не защищен dPoW!",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "Конвертировать в мейкер если нет совпадений",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "Цена CEXchange",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Ниже цен CEX",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Выше цен CEX",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "Идентичен CEX",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "сравнение с CEX",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "по сравнению со сред. Цена CEX за 24 часа",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Активные",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "История",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Подробности",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Из вкладки Подробности выберите Ордер одним долгим нажатием",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "Отменить",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Выбрать",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "Совпадающих ордеров не найдено",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Ордер Мейкера",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Ордер Тейкера",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Текущий",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "прибл",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "Начато",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Всего",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "Детали прогресса",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Закрыть сообщение об ошибке",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Открыть сообщение об ошибке",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Входящая транзакция",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "Вы получили {coin} транзакцию",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "Своп завершен",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "Своп {sell}/{buy} успешно завершен",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "Своп не был завершен",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "Своп {sell}/{buy} не прошел",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Превышен тайм-аут свопа",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "Превышен тайм-аут свопа {sell}/{buy}",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Статус свопа изменен",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Новый своп начался",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "Своп {sell}/{buy} начат",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Язык",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Валюта",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Спрятать баланс",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Переключить тему",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "Данные CEX",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Данные (цены, графики и т.д.), отмеченные этим значком, получены из сторонних источников (<a href=\"https://www.coingecko.com/\"> coingecko.com </a>, <a href = \" https://openrates.io/\">openrates.io </a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Проверить обновления",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "Вы уверены, что хотите выйти?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Валюта",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Слишком много запросов.\nПревышен лимит запросов истории транзакций.\nПовторите попытку позже.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "мс",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "сек",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "мин",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "минуты",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "ч",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "Ещё",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "Меньше",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Старые логи",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Удалить",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Удаляю кошелек",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Использовано места",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Ок",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Закрыть предпросмотр",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "отменить",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "Прокрутите вниз, чтобы продолжить...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Разработчик",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Включить тестовые монеты",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Подробности ордера Мейкера",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Продать",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Получить",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Цена",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Отменить ордер",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "Ордер ID",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "Создано в",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Свопы по этому ордеру не запускались",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "Свопы начатые по этому ордеру",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% заполнено",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Заметка",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Добавить заметку",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "Импорт",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Импортировать одиночный своп файл",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Экспорт",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "Импорт",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Импортировать своп файл",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Экспорт",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Пожалуйста выберите элементы для экспорта в зашифрованный файл.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Пожалуйста выберите зашифрованный файл для импорта.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Пожалуйста выберите текстовый своп файл для импорта",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Открываю...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "Элементы к импорту",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Заметки",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Контакты",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Свопы",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Ничего не найдено",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Экспорт",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "Импортировать",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "Зашифрованный пароль не может быть пустым",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "Пароль не может быть пустым",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "Пароли должны совпадать",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "Ничего не выбрано",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "Ничего не выбрано",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Выбрать файл",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Файл не найден",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Отпечаток",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Пароль",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "Отмена",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Ок",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "Элементы которые были успешно экспортированы:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "Элементы которые были успешно импортированы:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Неверный пароль или поврежденные данные",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Ошибка декодирования json файла",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Ордер",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Неизвестный тип ордера",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "Не удалось импортировать:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Некоторые элементы были пропущены",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "Ошибка при импорте своп файла",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Неверные данные своп. Предоставьте действительный JSON-файл состояния своп.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "Активация {coinName}",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "Не закрывайте приложение. Нажмите, чтобы узнать больше...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName} Активация",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "Монеты {protocolName} активированы",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "Монеты {protocolName} не активированы",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "Монеты {protocolName} успешно активированы",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} активируется",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "Активировать монеты {protocolName}?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Больше информации",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Показать адрес",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Эта транзакция была скрыта из-за возможной попытки фишинга.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "Адрес транзакции",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "Транзакция скрыта",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "Не удалось запустить URL",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Это займет некоторое время, и приложение должно оставаться на переднем плане.\nЗакрытие приложения во время активации может привести к проблемам.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Предупреждение: сворачивание приложения на iOS приведет к прекращению процесса активации.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Пожалуйста, включите уведомления, чтобы получать обновления о ходе активации.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "Сканер QR-кода",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "Найден QR-код",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Договор",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Начать обмен",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Никто",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "Курс CEX",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Настройки защиты входящих txs-транзакций {coinName}",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "Показано {count} из {maxCount} заказов.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "Меньше",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "Более",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "на основе {coinName1}/{coinName2}",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "отправить торговую комиссию комиссию за транзакцию",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "торговая комиссия",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "отправить комиссию за транзакцию {coinName}",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "получить комиссию за транзакцию {coinName}",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Фильтр",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Статус",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Все",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Успешно",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Не удалось",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "С даты",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "На дату",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Тейкер/Мейкер",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Майкер",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "Все",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Тейкер",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Продать монету",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Получить монету",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Очистить все фильтры",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Недостаточный баланс",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "Недостаточно баланса для отсканированного",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "платежного запроса.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Попытка подключения других активов",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "У вас есть",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "подключенные активы и активы в состоянии подключения",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "Максимальный лимит подключенных активов .",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": "Пожалуйста отключите некоторые чтобы добавить новые.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Вы выбрали максимальное количество активов",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Подключено слишком много активов",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "У вас имеются",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "включенные активы. Максимальный предел включенных активов",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ". Пожалуйста, отключите некоторые из них перед добавлением новых.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Оплата запрошена",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Монета:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "На Адрес",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "Остаток:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "Вы подтверждаете эту транзакцию?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Оплата",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "Отмена:",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} не активен. Пожалуйста активируйте и попробуйте снова.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Некорректная монета",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "Вы пытаетесь сканировать QR code для оплаты",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "но вы сейчас находитесь",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "на экране вывода",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Продать",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Купить",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Получить",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Отправить",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Закрыть",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Активировать",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "Максимальное количество активных монет: {maxCoins}. Пожалуйста деактивируйте некоторые из них.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "Не удалось активировать {coin}",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} не активна",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Пожалуйста введите сумму {coin} для покупки",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Пожалуйста введите сумму {coin} для продажи",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Скрыть",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Показать больше",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "Монета не найдена",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "Это новая эра! Мы официально изменили наше название с «AtomicDEX» на «Komodo Wallet».",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "Официальный пресс-релиз",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "Сканировать прошлые транзакции с {coin}?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "Отменить активацию",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "Вы уверены, что хотите отменить активацию?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "Вы уверены, что хотите отменить активацию?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "Какие транзакции {name} вы хотите синхронизировать?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "Синхронизировать новые транзакции",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Синхронизировать с указанной даты",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Синхронизация с активацией саженца",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Выберите дату",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Дата начала",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "Мы будем синхронизировать будущие транзакции, совершенные после активации, связанные с вашим открытым ключом. Это самый быстрый вариант и занимает меньше всего места.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "Ваш кошелек покажет все прошлые транзакции. Это потребует значительного объема памяти и времени, поскольку все блоки будут загружены и отсканированы.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "Ваш кошелек покажет ваши прошлые транзакции, совершенные после указанной даты.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "Активация {coinName}",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} Активация",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} активируется",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Активные",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Активировать монету",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} активирован успешно!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Добавить адрес",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Адресная книга",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "Адресная книга пуста",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Отображаются только контакты с {title} адресами",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Адресная книга",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "Вы не можете отправить средства на адрес {abbr}, потому что {abbr} не активирован. Пожалуйста, перейдите в портфолио.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Не найдено",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Выбрать валюту",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Адрес получателя",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Расширенные",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "Все",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Разрешить произвольный seed-ключ",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "Ваш кошелек покажет все прошлые транзакции. Это потребует значительного объема памяти и времени, поскольку все блоки будут загружены и отсканированы.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "Уже существует",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Количество",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Сумма для продажи",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "Нет! Мы никогда не храним конфиденциальные данные, включая ваши приватные ключи, seed ключи или PIN-код. Эти данные хранятся только на устройстве пользователя и никуда не передаются. Вы полностью контролируете свои активы.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "Приложение {appName} доступно для мобильных устройств на Android и iPhone, а также для компьютеров в <a href=\"https://komodoplatform.com/\">операционных системах Windows, Mac и Linux</a>.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Другие DEX обычно позволяют торговать только активами, принадлежащими к одному блокчейну, используют прокси-токены и разрешают размещать только один ордер, использующий ваш баланс.\n\n{appName} позволяет вам торговать между разными блокчейнами без использования прокси-токенов. Вы также можете разместить несколько заказов, используя одни и те же средства. Например, вы можете выставить ордера на продажу 0,1 BTC за KMD, QTUM и VRSC - первый исполненный ордер автоматически отменит все остальные ордера.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Есть несколько факторов, определяющих время обработки каждого свопа. Время блокировки торгуемых активов зависит от каждой сети (биткоин блокчейн обычно является самым медленным). Кроме того, пользователь может редактировать параметры безопасности. Например, в {appName} можно установить количество подтверждений, после которых KMD транзакция считается успешной, равным 3, что сокращает время обмена по сравнению с транзакциями, ожидающими <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">нотариального заверения</a>.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Да. Приложение должно оставаться подключенным к Интернету для успешного завершения каждого атомарного свопа (очень короткие перерывы в подключении обычно допустимы). В противном случае существует риск отмены сделки, если вы являетесь мейкером, и риск потери средств, если вы тейкер. Протокол атомарного свопа требует, чтобы оба участника оставались в сети и контролировали задействованные блокчейны, чтобы процесс оставался атомарным.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "При торговле на {appName} необходимо учитывать две категории комиссий.\n\n1. {appName} взимает приблизительно 0,13% (1/777 объема торгов, но не ниже 0,0001) в качестве комиссии за торговлю для тейкер ордеров, а для ордеров-мейкеров комиссия равна нулю.\n\n2. Как мейкеры, так и тейкеры должны платят обычные комиссии за транзакции в используемых блокчейнах при совершении атомарного свопа .\n\nКомиссиии сети могут сильно различаться в зависимости от выбранной вами торговой пары.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "Да! {appName} предлагает поддержку через <a href=\"{link}\"> {name} сервер {appCompanyShort} </a>. Команда и сообщество всегда рады помочь!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "Нет! {appName} полностью децентрализована. Ограничить доступ пользователей третьими лицами невозможно.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} разработан командой {appCompanyShort}. {appCompanyShort} - один из наиболее авторитетных блокчейн-проектов, работающих над инновационными решениями, такими как атомарные свопы, delayed Proof of Work и совместимая многоцепочечная архитектура.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "Абсолютно! Вы можете прочитать нашу <a href=\"https://developers.komodoplatform.com/\">документацию для разработчиков</a> для получения более подробной информации или связаться с нами по вопросам партнерства. Есть конкретный технический вопрос? Сообщество разработчиков {appName} всегда готово помочь!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Аплодисменты",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "ВЫ УВЕРЕНЫ?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "своп не был завершен",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "своп завершается",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "аутентификация",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Вы будете автоматически перенаправлены на страницу портфолио после завершения процесса повторной активации.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "макс объем",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "назад",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Бэкап",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "на основе {coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "Критический заряд батареи ({batteryLevelCritical}%) для безопасного выполнения свопа. Пожалуйста поставьте его на зарядку и повторите попытку.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "Заряд батареи ниже {batteryLevelLow}%. Пожалуйста подумайте о зарядке телефона.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "Ваш телефон находится в режиме экономии заряда батареи. Пожалуйста, отключите этот режим или НЕ переводите приложение в фоновый режим, в противном случае приложение может быть убито операционной системой, и обмен не удастся.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Обменный курс",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Построено на Komodo",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Построено на Komodo",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Купить",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Конвертировать в мейкер если нет совпадений",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Обмен начался, пожалуйста подождите!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Поиск сделки в процессе, пожалуйста , подождите {seconde} секунд!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "Внимание, вы пытаетесь купить тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Маскировочный PIN и BIO защита не могут быть включены одновременно.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Конфликт маскировочного и Bio защитных PIN",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Изменить маскировочный PIN",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Создать Маскировочный PIN",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Если вы разблокируете приложение с маскировочным PIN-кодом, будет показан поддельный баланс, а настройки маскировочного PIN-кода НЕ будут отображаться в приложении",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "Неверный маскировочный PIN",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Маскировочный PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Маскировочный PIN не найден",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Выкл",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "Вкл",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Маскировочный PIN сохранен",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Маскировочный PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Введите новый маскировочный PIN",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Установить маскировочный PIN",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Установить маскировочный PIN",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "отменить",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Отменить активацию",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "Вы уверены, что хотите отменить активацию?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "отменить",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Отменить Ордер",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Что-то пошло не так. Попробуйте позже.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ок",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "это монета настроенная по умолчанию. Монеты по умолчанию не могут быть отключены.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Не возможно отключить",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Невозможно воспроизвести",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "Цена CEXchange",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "Данные CEX",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Данные (цены, графики и т.д.), отмеченные этим значком, получены из сторонних источников (<a href=\"https://www.coingecko.com/\"> coingecko.com </a>, <a href = \" https://openrates.io/\">openrates.io </a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "Курс CEX",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "Изменить PIN-код",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Проверить обновления",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Всего",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Проверьте seed-фразу",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "ПРОДОЛЖИТЬ",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "ВЕРНУТЬСЯ И ПРОВЕРИТЬ СНОВА",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "Введите {index} слово",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "Ваш seed-ключ необходим для доступа к кошельку - поэтому мы хотим убедиться, что она правильная. Мы зададим вам три разных вопроса о вашей seed-фразе, чтобы убедиться, что вы сможете легко восстановить свой кошелек, когда захотите.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "Какое {index} слово в вашем seed-ключе?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕПРОВЕРИМ ВАШ SEED-КЛЮЧ",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Китайский",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "Востребовать",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "Востребовать KMD вознаграждение?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Нажмите, чтобы увидеть",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Скопировано",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Скопировать",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Закрыть",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Закрыть сообщение об ошибке",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Закрыть предпросмотр",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Код:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "Вы уверены, что хотите отменить активацию?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Вы выбрали максимальное количество активов",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "Монеты {protocolName} активированы",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "Монеты {protocolName} успешно активированы",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "Монеты {protocolName} не активированы",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Очистить",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "Нет активных монет",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Выбрать монету",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Скоро будет...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "Детали TX скоро будут добавлены!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "Детали будут скоро добавлены!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "комиссия",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "по сравнению со сред. Цена CEX за 24 часа",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "сравнение с CEX",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Настройка кошелька, пожалуйста, подождите",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "подтвердить",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Подтвердить маскировочный PIN",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Вы уверены, что хотите отменить ордер",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "Нажимая кнопку ниже, вы подтверждаете, что прочитали «EULA» и «Terms and Conditions» и принимаете их",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Подтвердите пароль",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "Подтвердите PIN-код",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Подтвердите seed-ключ",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Соединение...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Отмена",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Удалить контакт",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Удалить",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "Вы уверены, что хотите удалить {name}?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Сбросить",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Изменить",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Выйти",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Сбросить изменения?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "Контакты не найдены",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Сохранить",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Контактная информация",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Имя",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Договор",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Конвертировать",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "Не удалось запустить URL",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "Не удалось импортировать:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "сделка",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "СОЗДАТЬ КОШЕЛЕК",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Добавить контакт",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "Задать PIN",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Валюта",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Валюта",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Текущее значение",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Настроить комиссию",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "Используйте настраиваемые комиссии только если знаете, что делаете!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Пользовательские исходные фразы могут быть менее безопасными и их легче взломать, чем сгенерированные исходные фразы или закрытый ключ (WIF), совместимые с BIP39. Чтобы подтвердить, что вы понимаете риск и знаете, что делаете, введите \"{iUnderstand}\" в поле ниже.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Дата",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Расшифровываю кошелек",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Удалить",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Подтвердить деактивацию",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "Вы хотите удалить",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "из вашего портфолио? Все несовпавшие ордеры будут отменены.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " также будет деактивирован",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Удалить кошелек",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Удаляю кошелек",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "получить комиссию за транзакцию {coinName}",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "отправить комиссию за транзакцию {coinName}",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "отправить торговую комиссию комиссию за транзакцию",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "торговая комиссия",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "детали",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Немецкий",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Разработчик",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX не доступен для этой монеты",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Отключить скриншоты/предварительный просмотр",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Disclaimer & ToS",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Готово",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Не закрывайте приложение. Нажмите, чтобы узнать больше...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Не спрашивать снова",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "Я не хочу использовать пароль",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Защита Komodo dPoW",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Продолжительность",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Редактировать",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Введите {abbr} адрес",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "Зашифрованный пароль не может быть пустым",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "Пароль не может быть пустым",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Имя контакта не может быть пустым",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "Имя кошелька не должно быть пустым",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Вы все еще можете включить {остается}, Выбрано: {выбрано}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Пожалуйста, включите уведомления, чтобы получать обновления о ходе активации.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Включить тестовые монеты",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "У вас есть",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "подключенные активы и активы в состоянии подключения",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "Максимальный лимит подключенных активов .",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": "Пожалуйста отключите некоторые чтобы добавить новые.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Попытка подключения других активов",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Шифрую кошелек",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "Английский",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Введите новый PIN",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Введите свой старый PIN",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Пожалуйста, введите Ваш пароль чтобы продолжить.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Введите свой PIN-код",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Введите свою seed-фразу",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Для начала вы должны ввести сумму на продажу",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Недостаточный баланс",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Невалидный адрес",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Segwit адреса не поддерживаются",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Не достаточно газа - используйте минимум {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Ошибка, пожалуйста попробуйте еще раз",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Ошибка, пожалуйста попробуйте позже",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "Значение слишком высокое или маленькое",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Пожалуйста, введите данные",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Расчетная общая стоимость",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Например: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Ниже цен CEX",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Выше цен CEX",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Идентичен CEX",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Рейтинг обменника",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "ОБМЕН",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Экспорт",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Контакты",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Пожалуйста выберите элементы для экспорта в зашифрованный файл.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Экспорт",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Заметки",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Элементы которые были успешно экспортированы:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Свопы",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Экспорт",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Неудавшиеся \t",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Маскировочный баланс:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Часто задаваемые вопросы",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Ошибка",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Отправка запроса на кран {coin}",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "FAUCET",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Успешно",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "Время запроса истекло",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Отправить логи",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Новости",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Здесь ничего нет",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "Новости Комодо",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Узнать больше",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Лента",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Лента новостей",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Невозможно обновить ленту новостей",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Невозможно обновить ленту новостей",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Лента новостей обновлена",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Новых новостей нет",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Комиссия должна быть не более {value}",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Все",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Фильтр",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Очистить все фильтры",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Не удалось",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "С даты",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Майкер",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Получить монету",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Продать монету",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Статус",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Успешно",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Тейкер",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "На дату",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Тейкер/Мейкер",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Отпечаток",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Заканчиваем, пожалуйста, подождите",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "Найден QR-код",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Французский",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "Из",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "Мы будем синхронизировать будущие транзакции, совершенные после активации, связанные с вашим открытым ключом. Это самый быстрый вариант и занимает меньше всего места.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} комиссия",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "Лимит газа",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Пожалуйста активируйте {coin}",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "Цена Gas",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "Общая защита PIN-кодом не активна.\nРежим маскировки будет недоступен.\nВключите защиту PIN-кодом.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Важно: перед тем как продолжить, сохраните свою seed-фразу в надежном месте!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "Идет транзакция, пожалуйста, подождите",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Перейти в портфолио",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Значение Gwei должно быть до {value}.",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Помощь",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Помощь и поддержка",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Спрятать баланс",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Подтвердите Пароль",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Создать пароль",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Текущий пароль",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Введите свой пароль",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Введите свой seed-ключ",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Назовите свой кошелек",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Пароль",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "история",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "ч",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Венгерский",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Импортировать",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Неверный пароль или поврежденные данные",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "Элементы к импорту",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Файл не найден",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Неверные данные своп. Предоставьте действительный JSON-файл состояния своп.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Импорт",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Пожалуйста выберите зашифрованный файл для импорта.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Открываю...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Пожалуйста выберите текстовый своп файл для импорта",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Отмена",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Ок",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Пароль",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Импортировать одиночный своп файл",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Импортировать своп файл",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Некоторые элементы были пропущены",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Элементы которые были успешно импортированы:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Ошибка при импорте своп файла",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Ошибка декодирования json файла",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Импорт",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Настройки защиты входящих txs-транзакций {coinName}",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "Запрос на обмен не может быть отменен и является окончательным!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "Эта транзакция может занять до 10 минут - НЕ закрывайте приложение!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Вы можете зашифровать свой кошелек паролем. Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} недостаточно баланса чтобы оплатить торговую комиссию",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "Минимальное количество необходимое для этого ордера составляет",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Недостаточное количество",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Обновить",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Соединение с интернетом восстановлено",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Неверный адрес {coin}",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "Невозможно продолжить своп",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Подробнее",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} недоступен :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "Я понимаю",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Японский",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Корейский",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Язык",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Последние Транзакции",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Легальные аспекты",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Меньше",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Осторожно! Объем торгов на рынке {coinName} за 24 часа составляет менее 10 000 долларов!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "Лимит должен быть до {value}",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Загрузка...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Загрузка книги ордеров...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "Экран заблокирован",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "Пожалуйста, аутентифицируйтесь!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "войти",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Выйти",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Log Out при выходе",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Настройки Log Out",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "Вы уверены, что хотите выйти?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "минуты",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "разместить ордер",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Мейкер",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Отменить ордер",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Создано в",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Получить",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "Ордер ID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Свопы по этому ордеру не запускались",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Цена",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Продать",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Свопы начатые по этому ордеру",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Подробности ордера Мейкера",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Ордер Мейкера",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Маркетплейс",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "График",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Глубина",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "Нет асков",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "Нет бидов",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "ОРДЕРБУК",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Детали ордера",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "ЦЕНА",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Пожалуйста, выберите монету",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Рынки",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "РЫНКИ",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Пароли должны совпадать",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Изменить",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Общий PIN и маскировочный PIN совпадают.\nРежим маскировки будет недоступен.\nИзмените маскировочный PIN",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "Неверный PIN",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAX",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Максимальный размер ордера",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Новости",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "ПРОСМАТРИВАТЬ",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "ПОСМОТРЕТЬ ЛЕНТУ",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "По",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "У вас нет сохраненных статей",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "СОХРАНЕННЫЕ",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Памятка",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Слияние",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Объединенное значение:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "мс",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "МИН",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Предупреждение: сворачивание приложения на iOS приведет к прекращению процесса активации.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "Минимальные объем ордера",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "мин",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "Минимальная сумма продажи составляет {number} {coinName}.",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "Минимальная сумма покупки: {number} {coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "Минимальная сумма ордера {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "Минимальная сумма на продажу {number} {coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "Должно быть больше чем {minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Должно быть меньше чем сумма продажи",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Минимальное требуемое количество",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Использовать собственное минимальное количество",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Обратите внимание, что теперь вы используете сотовые данные, а участие в P2P-сети {appName} потребляет интернет-трафик. Лучше использовать сеть Wi-Fi, если ваш тарифный план сотовой связи является дорогостоящим.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Больше информации",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "Ещё",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Активируйте {coin} и пополните баланс",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Сумма",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Монета",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Продать",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Отменить",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Подтвердить",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "Создать {number} ордер(ов):",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Создать",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Ордер",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Ордеры",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "комис.",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Отменить",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Введите сумму в фиате для получения:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Автозаполнение",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Исправьте ошибки, прежде чем продолжить",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Некорректная сумма",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Неверная сумма продажи",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "Недостаточно {coin} чтобы оплатить налог. МИН баланс {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} баланс очень низкий",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "Макс сумма к продаже",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "Мин сумма к получению",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "Мин сумма к продаже",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Получить",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Продать:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Мульти",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Получ. сумма",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Цена/СЕХ",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Комиссия сети",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "новый аккаунт",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Новый аккаунт",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Новостная лента",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Новое значение",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "далее",
-  "@next": {
-    "type": "text"
-  },
-  "no": "Нет",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "Нет новостей - пожалуйста проверьте позже!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "Монета не найдена",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Нет средств",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "Нет доступных средств - пожалуйста, внесите депозит.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "Отсутствует подключение к Интернет",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "Ничего не выбрано",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "Ничего не выбрано",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "Совпадающих ордеров не найдено",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Никто",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "Значение должно быть указано в цифрах",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Пожалуйста, введите сумму {coinName}.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Нажмите, чтобы создать ордер",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "Нет ордеров, пожалуйста перейдите в торговлю.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "Нет доступных вознаграждений",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "Нет вознаграждения для востребования - повторите попытку через 1 час.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "Нет такой монеты",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "Нет истории.",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "Не достаточно {coin} для транзакции!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "Недостаточно баланса для комиссий - выполните сделку на меньшую сумму",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Замечание: Выбранный ордер не может быть снова отменен",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Добавить заметку",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Заметка",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Ничего не найдено",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "Своп {sell}/{buy} успешно завершен",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Своп завершен",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "Своп {sell}/{buy} не прошел",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Своп не был завершен",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "Своп {sell}/{buy} начат",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Новый своп начался",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Статус свопа изменен",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "Превышен тайм-аут свопа {sell}/{buy}",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Превышен тайм-аут свопа",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "Вы получили {coin} транзакцию",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Входящая транзакция",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "Нет транзакций",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} Активов",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Официальный пресс-релиз",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ок",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Удалить",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Старые логи",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Использовано места",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Открыть сообщение об ошибке",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Необязательный",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Меньше",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "Более",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Все {coin} ордеры будут отменены.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Ордер создан",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Ордер успешно создан",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Адрес",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Отменить",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "На -{delta}% ниже цен CEX",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "На +{delta}% выше цен CEX",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "на",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Совпадает с СЕХ",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "мин.",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Цена",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Получите",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Выбрать",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Ордеры продаж",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Из вкладки Подробности выберите Ордер одним долгим нажатием",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Отправьте",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Подробности",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% заполнено",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Сделка найдена",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Поиск сделки в процессе",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "ордера",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Активные",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "История",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Сумма ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "Цена ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Всего ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Ордер",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Неизвестный тип ордера",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Перезаписать",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "Это ваш ордер!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Оплачено с баланса:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Оплачено с полученного объема:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Оплачено c",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "Пароль должен содержать не менее 12 символов, включая один строчный, один заглавный и один специальный символ.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "Ваш кошелек покажет ваши прошлые транзакции, совершенные после указанной даты.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Оплата",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Вы подтверждаете эту транзакцию?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "На Адрес",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Остаток:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Монета:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Отмена:",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Оплата запрошена",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} не активен. Пожалуйста активируйте и попробуйте снова.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Разместить ордер",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "Воспроизводить на полную громкость",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Пожалуйста добавьте монету",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Пожалуйста перезапустите приложение чтобы попробовать снова или нажмите на кнопку ниже.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Портфолио",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Разработано Komodo",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "цена",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Приватный ключ",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Приватные ключи",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Подтверждений",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Установить свои настройки защиты",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "ВЫКЛ",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "ВКЛ",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Внимание, этот своп не защищен dPoW!",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Публичный ключ",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "Сканер QR-кода",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Вы храните мои приватные ключи?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "На каких устройствах я могу использовать {appName}?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "Чем торговля на {appName} отличается от торговли на других DEX?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "Сколько времени занимает каждый атомарный своп?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "Необходимо ли мне быть в сети во время свопа?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "Как рассчитываются комиссии на {appName}?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Предоставляете ли вы поддержку пользователей?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Есть ли у вас какие-либо географические ограничения?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Кто стоит за {appName}?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "Можно ли разработать собственную white-label биржу на технологии {appName}?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "Это новая эра! Мы официально изменили наше название с «AtomicDEX» на «Komodo Wallet».",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "ПОЛУЧИТЬ",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Получить",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Мы рекомендуем хранить ее на оффлайн носителе.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Отключить",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Запрошенная сделка",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "ОЧИСТИТЬ",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Сбросить форму",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "ВОССТАНОВИТЬ",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Попытка активации всех монет...",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Попытка активации всего",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Забрать вашу награду",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Отменить",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Что-то пошло не так. Попробуйте позже.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "Транзакция в процессе",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "обработка",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO меньше 10",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Час еще не прошел",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "Меньше часа",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "ОК",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Статус вознаграждений:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "Узнать больше о KMD вознаграждениях",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Получить",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Получено {amount} KMD.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Фиат",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Вознаграждений\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Статус",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Осталось",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Инфо о вознаграждениях:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} дней}",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}ч {minutes}мин",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "мин {mm}",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Инфо о вознаграждениях:",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Русский",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Сохранить объединенные",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Прокрутите вниз, чтобы продолжить...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Поиск монеты",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Выбрать все Avax токены",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Выбрать все BEP токены",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Выбрать всю сеть Cosmos",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Выбрать все ERC токены",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Выбрать все ETC токены",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Выбрать все Fantom токены",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Выбрать все HecoChain токены",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Выбрать все Harmony токены",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Выбрать всю сеть Iris",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Выбрать все Kucoin токены",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Выбрать все Moonriver токены",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Выбрать все Polygon токены",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Выбрать все QRC токены",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Выбрать все SmartBCH токены",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Выбрать все токены SLP",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Выбрать все Smartchain",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Выбрать все Тестовые Активы",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Выбрать все Ubiq монеты",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Выбрать все UTXO монеты",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Выбрать все монеты ZHTLC",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Найти Тикер",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "сек",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Безопасность",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Seed Фраза",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Ваш новый seed-ключ",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "Нажмите, чтобы увидеть {amount} ордеров",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "Показать историю транзакций",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Выберите монету",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Выберите монеты, которые вы хотите добавить в свое портфолио.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Активировать монеты:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Выберите монету, которую хотите купить",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Выберите монету, которую хотите продать",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Выберите дату",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Выбранный ордер:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Выбрать файл",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Выбрать Язык",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Выберите способ оплаты",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Продать",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Внимание, вы пытаетесь продать тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "ОТПРАВИТЬ",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Вы уверены, что хотите удалить",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "кошелек?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Если это так, убедитесь, что вы",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "записали свой seed-ключ.",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "Для того, чтобы восстановить свой кошелек в будущем.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Языки",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Настройки",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "УСТАНОВИТЬ ПАРОЛЬ",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "ПОДЕЛИТЬСЯ",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "Мой {coinName} адрес:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "Сканировать прошлые транзакции с {coin}?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Показать адрес",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Показать детали",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "Показано {count} из {maxCount} заказов.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "ПОКАЗАТЬ МОИ ОРДЕРЫ",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Войти с паролем",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Войти с помощью seed-ключа",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Просто",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Активировать",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Пожалуйста введите сумму {coin} для покупки",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Купить",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Закрыть",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "Максимальное количество активных монет: {maxCoins}. Пожалуйста деактивируйте некоторые из них.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} не активна",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Получить",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Пожалуйста введите сумму {coin} для продажи",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Продать",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Отправить",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Скрыть",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Показать больше",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "Не удалось активировать {coin}",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Пропустить",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Убрать",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Звук",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Выберите файл в формате mp3 или wav. Воспроизводится, когда {description}.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "Воспроизводится, когда {description}",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Звуки",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Я понимаю, больше это не показывать",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Звук",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Настройки звука",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "Вы будете слышать звуковые уведомления во время процесса обмена и при размещении активного ордера.\nДля успешной торговли, протокол Atomic swaps требует чтобы участники были онлайн и звуковые уведомления помогают достичь этого.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Обратите внимание что вы можете установить свои собственные звуки в настройках приложения.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Испанский",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Дата начала",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Начать обмен",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Шаг",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Успех!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Поддержка",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Если у вас есть какие-либо вопросы или вы считаете, что обнаружили техническую проблему с приложением {appName}, вы можете сообщить об этом и получить поддержку от нашей команды.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "обмен",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Текущий",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "ПОДТВЕРДИТЕ ДЕТАЛИ ОБМЕНА",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "прибл",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Обмен не удался",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Пожалуйста сначала активируйте {coin} и пополните баланс",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию. {coin} {amount} требуется.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Обмен в процессе",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "Детали прогресса",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "Начато",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Успешный обмен",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Всего",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "UUID обмена",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Переключить тему",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Синхронизировать с указанной даты",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Синхронизация с активацией саженца",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Синхронизировать новые транзакции",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "Какие транзакции {name} вы хотите синхронизировать?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Тейкер",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Ордер Тейкера",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Таймаут",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "СОЗДАТЬ ПАРОЛЬ",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Ордер выбран",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "В",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "На адрес:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "У вас имеются",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "включенные активы. Максимальный предел включенных активов",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". Пожалуйста, отключите некоторые из них перед добавлением новых.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Подключено слишком много активов",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Общие комиссии:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "СДЕЛКА",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "Обмен завершен!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "ДЕТАЛИ СДЕЛКИ",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Ошибка при расчете торговой комиссии",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "торговая комиссия:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Режим Торговли",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Адрес транзакции",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Транзакция скрыта",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Эта транзакция была скрыта из-за возможной попытки фишинга.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "даже если после этого некоторые монеты все еще не активированы, попробуйте перезапустить приложение.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Турецкий",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Блок",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Подтверждения",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "ПОДТВЕРЖДЕНА",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Комиссия",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "комиссия сети:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "ID транзакции",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Осталось транзакций: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Слишком много запросов.\nПревышен лимит запросов истории транзакций.\nПовторите попытку позже.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "НЕПОДТВЕРЖДЕНА",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Украинский",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "разблокировать",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Разблокировать средства",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "Успешно разблокировано {amnt} средств - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "неизрасходованный",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Доступна новая версия",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Проверка обновлений...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "Установлена версия {version}",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Доступна новая версия. Пожалуйста, обновитесь.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Доступна версия {version}. Пожалуйста, обновитесь.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Доступно обновление",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Пропустить",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "Обновление {appName}",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Обновление",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Установлена последняя версия",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Недостаточно баланса для отсканированного",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "платежного запроса.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Недостаточный баланс",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Стоимость:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "версия",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Обозреватель",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Seed & Приватные ключи",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Объемы",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "Имя кошелька уже используется",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "Имя кошелька не должно превышать 40 символов",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Только кошелек",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "Предупреждение!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "OK",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Предупреждение - в особых случаях логи могут содержать конфиденциальную информацию, которую можно использовать для доступа к монетам из незавершенных свопов!",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "Ошибка активации {coinAbbr}",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "Ошибка активации {coinAbbr}\nПожалуйста перезапустите приложение и попробуйте снова",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} mobile - это мульти-монетный кошелек с функциональностью DEX третьего поколения и многим другим.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "ДАВАЙТЕ ВСЕ НАСТРОИМ!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "Добро пожаловать",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "кошелек",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "По завершении вы будете перенаправлены на страницу портфолио.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Это займет некоторое время, и приложение должно оставаться на переднем плане.\nЗакрытие приложения во время активации может привести к проблемам.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Вывести",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "Ранее вы запретили {appName} доступ к камере.\nВручную измените разрешения для камеры в настройках телефона, чтобы продолжить сканирование QR-кода.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Доступ запрещен",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Подтвердите вывод",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Что-то пошло не так. Попробуйте позже.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "ВЫВЕСТИ {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "Вы пытаетесь сканировать QR code для оплаты",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "но вы сейчас находитесь",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "на экране вывода",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Некорректная монета",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "Пароли не совпадают. Пожалуйста, попробуйте еще раз.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Да",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Вы отправляете:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "есть новый ордер, который совпадает с вашим размещенным ордером",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "у вас уже есть активный своп в процессе",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "у вас есть ордер, которому могут соответствовать новые ордеры",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "ваш кошелек",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "Вы получите {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Вы получите:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,3652 +1,3726 @@
 {
-    "accepteula": "Принять EULA",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "Принять ПРАВИЛА и УСЛОВИЯ",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Активировать биометрическую защиту",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "Активировать защиту PIN",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "Активировать монеты {protocolName}?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "Активация {coinName}",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName} Активация",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} активируется",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Активные",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Активировать монету",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} активирован успешно!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Добавить адрес",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Адресная книга",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "Адресная книга пуста",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Отображаются только контакты с {title} адресами",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Адресная книга",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "Вы не можете отправить средства на адрес {abbr}, потому что {abbr} не активирован. Пожалуйста, перейдите в портфолио.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Не найдено",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Выбрать валюту",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Адрес получателя",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Расширенные",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "Все",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Разрешить произвольный seed-ключ",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "Уже существует",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Количество",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Сумма для продажи",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "Нет! Мы никогда не храним конфиденциальные данные, включая ваши приватные ключи, seed ключи или PIN-код. Эти данные хранятся только на устройстве пользователя и никуда не передаются. Вы полностью контролируете свои активы.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "Приложение {appName} доступно для мобильных устройств на Android и iPhone, а также для компьютеров в <a href=\"https://komodoplatform.com/\">операционных системах Windows, Mac и Linux</a>.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Другие DEX обычно позволяют торговать только активами, принадлежащими к одному блокчейну, используют прокси-токены и разрешают размещать только один ордер, использующий ваш баланс.\n\n{appName} позволяет вам торговать между разными блокчейнами без использования прокси-токенов. Вы также можете разместить несколько заказов, используя одни и те же средства. Например, вы можете выставить ордера на продажу 0,1 BTC за KMD, QTUM и VRSC - первый исполненный ордер автоматически отменит все остальные ордера.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Есть несколько факторов, определяющих время обработки каждого свопа. Время блокировки торгуемых активов зависит от каждой сети (биткоин блокчейн обычно является самым медленным). Кроме того, пользователь может редактировать параметры безопасности. Например, в {appName} можно установить количество подтверждений, после которых KMD транзакция считается успешной, равным 3, что сокращает время обмена по сравнению с транзакциями, ожидающими <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">нотариального заверения</a>.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Да. Приложение должно оставаться подключенным к Интернету для успешного завершения каждого атомарного свопа (очень короткие перерывы в подключении обычно допустимы). В противном случае существует риск отмены сделки, если вы являетесь мейкером, и риск потери средств, если вы тейкер. Протокол атомарного свопа требует, чтобы оба участника оставались в сети и контролировали задействованные блокчейны, чтобы процесс оставался атомарным.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "При торговле на {appName} необходимо учитывать две категории комиссий.\n\n1. {appName} взимает приблизительно 0,13% (1/777 объема торгов, но не ниже 0,0001) в качестве комиссии за торговлю для тейкер ордеров, а для ордеров-мейкеров комиссия равна нулю.\n\n2. Как мейкеры, так и тейкеры должны платят обычные комиссии за транзакции в используемых блокчейнах при совершении атомарного свопа .\n\nКомиссиии сети могут сильно различаться в зависимости от выбранной вами торговой пары.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "Да! {appName} предлагает поддержку через <a href=\"{link}\"> {name} сервер {appCompanyShort} </a>. Команда и сообщество всегда рады помочь!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "Нет! {appName} полностью децентрализована. Ограничить доступ пользователей третьими лицами невозможно.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} разработан командой {appCompanyShort}. {appCompanyShort} - один из наиболее авторитетных блокчейн-проектов, работающих над инновационными решениями, такими как атомарные свопы, delayed Proof of Work и совместимая многоцепочечная архитектура.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "Абсолютно! Вы можете прочитать нашу <a href=\"https://developers.komodoplatform.com/\">документацию для разработчиков</a> для получения более подробной информации или связаться с нами по вопросам партнерства. Есть конкретный технический вопрос? Сообщество разработчиков {appName} всегда готово помочь!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Аплодисменты",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "ВЫ УВЕРЕНЫ?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "своп не был завершен",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "своп завершается",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "аутентификация",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Вы будете автоматически перенаправлены на страницу портфолио после завершения процесса повторной активации.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "макс объем",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "назад",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Бэкап",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "на основе {coinName1}/{coinName2}",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "Критический заряд батареи ({batteryLevelCritical}%) для безопасного выполнения свопа. Пожалуйста поставьте его на зарядку и повторите попытку.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "Заряд батареи ниже {batteryLevelLow}%. Пожалуйста подумайте о зарядке телефона.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "Ваш телефон находится в режиме экономии заряда батареи. Пожалуйста, отключите этот режим или НЕ переводите приложение в фоновый режим, в противном случае приложение может быть убито операционной системой, и обмен не удастся.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "Обменный курс",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Построено на Komodo",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Построено на Komodo",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Купить",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "Конвертировать в мейкер если нет совпадений",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Обмен начался, пожалуйста подождите!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "Поиск сделки в процессе, пожалуйста , подождите {seconde} секунд!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "Внимание, вы пытаетесь купить тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "Маскировочный PIN и BIO защита не могут быть включены одновременно.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Конфликт маскировочного и Bio защитных PIN",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Изменить маскировочный PIN",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Создать Маскировочный PIN",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Если вы разблокируете приложение с маскировочным PIN-кодом, будет показан поддельный баланс, а настройки маскировочного PIN-кода НЕ будут отображаться в приложении",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "Неверный маскировочный PIN",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Маскировочный PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "Маскировочный PIN не найден",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Выкл",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "Вкл",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "Маскировочный PIN сохранен",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Маскировочный PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Введите новый маскировочный PIN",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Установить маскировочный PIN",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Установить маскировочный PIN",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "отменить",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "отменить",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Отменить Ордер",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Что-то пошло не так. Попробуйте позже.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ок",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "это монета настроенная по умолчанию. Монеты по умолчанию не могут быть отключены.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "Не возможно отключить",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "Невозможно воспроизвести",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "Цена CEXchange",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "Данные CEX",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Данные (цены, графики и т.д.), отмеченные этим значком, получены из сторонних источников (<a href=\"https://www.coingecko.com/\"> coingecko.com </a>, <a href = \" https://openrates.io/\">openrates.io </a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "Курс CEX",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "Изменить PIN-код",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Проверить обновления",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Всего",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "Проверьте seed-фразу",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "ПРОДОЛЖИТЬ",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "ВЕРНУТЬСЯ И ПРОВЕРИТЬ СНОВА",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "Введите {index} слово",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "Ваш seed-ключ необходим для доступа к кошельку - поэтому мы хотим убедиться, что она правильная. Мы зададим вам три разных вопроса о вашей seed-фразе, чтобы убедиться, что вы сможете легко восстановить свой кошелек, когда захотите.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "Какое {index} слово в вашем seed-ключе?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕПРОВЕРИМ ВАШ SEED-КЛЮЧ",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Китайский",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "Востребовать",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "Востребовать KMD вознаграждение?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Нажмите, чтобы увидеть",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "Скопировано",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "Скопировать",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Закрыть",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Закрыть сообщение об ошибке",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Закрыть предпросмотр",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Код:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Вы выбрали максимальное количество активов",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "Монеты {protocolName} активированы",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "Монеты {protocolName} успешно активированы",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "Монеты {protocolName} не активированы",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Очистить",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "Нет активных монет",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Выбрать монету",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "Скоро будет...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "Детали TX скоро будут добавлены!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "Детали будут скоро добавлены!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "комиссия",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "по сравнению со сред. Цена CEX за 24 часа",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "сравнение с CEX",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "Настройка кошелька, пожалуйста, подождите",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "подтвердить",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Подтвердить маскировочный PIN",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "Вы уверены, что хотите отменить ордер",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "Нажимая кнопку ниже, вы подтверждаете, что прочитали «EULA» и «Terms and Conditions» и принимаете их",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Подтвердите пароль",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "Подтвердите PIN-код",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "Подтвердите seed-ключ",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Соединение...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "Отмена",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Удалить контакт",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "Удалить",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "Вы уверены, что хотите удалить {name}?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Сбросить",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Изменить",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Выйти",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Сбросить изменения?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "Контакты не найдены",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Сохранить",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Контактная информация",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "Имя",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Договор",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Конвертировать",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "Не удалось запустить URL",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "Не удалось импортировать:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "сделка",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "СОЗДАТЬ КОШЕЛЕК",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Добавить контакт",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "Задать PIN",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Валюта",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Валюта",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Текущее значение",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Настроить комиссию",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "Используйте настраиваемые комиссии только если знаете, что делаете!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Пользовательские исходные фразы могут быть менее безопасными и их легче взломать, чем сгенерированные исходные фразы или закрытый ключ (WIF), совместимые с BIP39. Чтобы подтвердить, что вы понимаете риск и знаете, что делаете, введите \"{iUnderstand}\" в поле ниже.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Дата",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Расшифровываю кошелек",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Удалить",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Подтвердить деактивацию",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "Вы хотите удалить",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "из вашего портфолио? Все несовпавшие ордеры будут отменены.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " также будет деактивирован",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Удалить кошелек",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Удаляю кошелек",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "получить комиссию за транзакцию {coinName}",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "отправить комиссию за транзакцию {coinName}",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "отправить торговую комиссию комиссию за транзакцию",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "торговая комиссия",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "детали",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Немецкий",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Разработчик",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX не доступен для этой монеты",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Отключить скриншоты/предварительный просмотр",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Disclaimer & ToS",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Готово",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "Не закрывайте приложение. Нажмите, чтобы узнать больше...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "Не спрашивать снова",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "Я не хочу использовать пароль",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Защита Komodo dPoW",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Продолжительность",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Редактировать",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "Введите {abbr} адрес",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "Зашифрованный пароль не может быть пустым",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "Пароль не может быть пустым",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "Имя контакта не может быть пустым",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "Имя кошелька не должно быть пустым",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enableNotificationsForActivationProgress": "Пожалуйста, включите уведомления, чтобы получать обновления о ходе активации.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Включить тестовые монеты",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "У вас есть",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "подключенные активы и активы в состоянии подключения",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "Максимальный лимит подключенных активов .",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": "Пожалуйста отключите некоторые чтобы добавить новые.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Попытка подключения других активов",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Шифрую кошелек",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "Английский",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Введите новый PIN",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Введите свой старый PIN",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Пожалуйста, введите Ваш пароль чтобы продолжить.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "Введите свой PIN-код",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Введите свою seed-фразу",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Для начала вы должны ввести сумму на продажу",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "Недостаточный баланс",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "Невалидный адрес",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Segwit адреса не поддерживаются",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "Не достаточно газа - используйте минимум {gas} Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Ошибка, пожалуйста попробуйте еще раз",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Ошибка, пожалуйста попробуйте позже",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "Значение слишком высокое или маленькое",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "Пожалуйста, введите данные",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Расчетная общая стоимость",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Например: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Ниже цен CEX",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Выше цен CEX",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "Идентичен CEX",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Рейтинг обменника",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "ОБМЕН",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Экспорт",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Контакты",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Пожалуйста выберите элементы для экспорта в зашифрованный файл.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Экспорт",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Заметки",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "Элементы которые были успешно экспортированы:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Свопы",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Экспорт",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Неудавшиеся \t",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Маскировочный баланс:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Часто задаваемые вопросы",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Ошибка",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "Отправка запроса на кран {coin}",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "FAUCET",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Успешно",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "Время запроса истекло",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Отправить логи",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Новости",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Здесь ничего нет",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "Новости Комодо",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Узнать больше",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Лента",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Лента новостей",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "Невозможно обновить ленту новостей",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "Невозможно обновить ленту новостей",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Лента новостей обновлена",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Новых новостей нет",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "Комиссия должна быть не более {value}",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Все",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Фильтр",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Очистить все фильтры",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Не удалось",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "С даты",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Майкер",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Получить монету",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Продать монету",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Статус",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Успешно",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Тейкер",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "На дату",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Тейкер/Мейкер",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Отпечаток",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Заканчиваем, пожалуйста, подождите",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "Найден QR-код",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Французский",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "Из",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} комиссия",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "Лимит газа",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Пожалуйста активируйте {coin}",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "Цена Gas",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "Общая защита PIN-кодом не активна.\nРежим маскировки будет недоступен.\nВключите защиту PIN-кодом.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Важно: перед тем как продолжить, сохраните свою seed-фразу в надежном месте!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "Идет транзакция, пожалуйста, подождите",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Перейти в портфолио",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Значение Gwei должно быть до {value}.",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "Помощь",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Помощь и поддержка",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Спрятать баланс",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Подтвердите Пароль",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Создать пароль",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Текущий пароль",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Введите свой пароль",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Введите свой seed-ключ",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Назовите свой кошелек",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Пароль",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "история",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "ч",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Венгерский",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "Импортировать",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Неверный пароль или поврежденные данные",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "Элементы к импорту",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Файл не найден",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Неверные данные своп. Предоставьте действительный JSON-файл состояния своп.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "Импорт",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Пожалуйста выберите зашифрованный файл для импорта.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Открываю...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Пожалуйста выберите текстовый своп файл для импорта",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "Отмена",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Ок",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Пароль",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Импортировать одиночный своп файл",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Импортировать своп файл",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Некоторые элементы были пропущены",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "Элементы которые были успешно импортированы:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "Ошибка при импорте своп файла",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Ошибка декодирования json файла",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "Импорт",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Настройки защиты входящих txs-транзакций {coinName}",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "Запрос на обмен не может быть отменен и является окончательным!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "Эта транзакция может занять до 10 минут - НЕ закрывайте приложение!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Вы можете зашифровать свой кошелек паролем. Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} недостаточно баланса чтобы оплатить торговую комиссию",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "Минимальное количество необходимое для этого ордера составляет",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Недостаточное количество",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Обновить",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "Соединение с интернетом восстановлено",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "Невозможно продолжить своп",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Подробнее",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} недоступен :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "Я понимаю",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Японский",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Корейский",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Язык",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Последние Транзакции",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Легальные аспекты",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "Меньше",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗Осторожно! Объем торгов на рынке {coinName} за 24 часа составляет менее 10 000 долларов!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "Лимит должен быть до {value}",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "Загрузка...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Загрузка книги ордеров...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "Экран заблокирован",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "Пожалуйста, аутентифицируйтесь!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "войти",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Выйти",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Log Out при выходе",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Настройки Log Out",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "Вы уверены, что хотите выйти?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "минуты",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "разместить ордер",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Мейкер",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Отменить ордер",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "Создано в",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Получить",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "Ордер ID",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Свопы по этому ордеру не запускались",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Цена",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Продать",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "Свопы начатые по этому ордеру",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Подробности ордера Мейкера",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Ордер Мейкера",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Маркетплейс",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "График",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Глубина",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "Нет асков",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "Нет бидов",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "ОРДЕРБУК",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Детали ордера",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "ЦЕНА",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Пожалуйста, выберите монету",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Рынки",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "РЫНКИ",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "Пароли должны совпадать",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Изменить",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Общий PIN и маскировочный PIN совпадают.\nРежим маскировки будет недоступен.\nИзмените маскировочный PIN",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "Неверный PIN",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "MAX",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Максимальный размер ордера",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Новости",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "ПРОСМАТРИВАТЬ",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "ПОСМОТРЕТЬ ЛЕНТУ",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "По",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "У вас нет сохраненных статей",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "СОХРАНЕННЫЕ",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Памятка",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Слияние",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Объединенное значение:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "мс",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "МИН",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Предупреждение: сворачивание приложения на iOS приведет к прекращению процесса активации.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "Минимальные объем ордера",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "мин",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "Минимальная сумма продажи составляет {number} {coinName}.",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "Минимальная сумма покупки: {number} {coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "Минимальная сумма ордера {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "Минимальная сумма на продажу {number} {coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "Должно быть больше чем {minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Должно быть меньше чем сумма продажи",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Минимальное требуемое количество",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "Использовать собственное минимальное количество",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Обратите внимание, что теперь вы используете сотовые данные, а участие в P2P-сети {appName} потребляет интернет-трафик. Лучше использовать сеть Wi-Fi, если ваш тарифный план сотовой связи является дорогостоящим.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Больше информации",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "Ещё",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Активируйте {coin} и пополните баланс",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Сумма",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Монета",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Продать",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "Отменить",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Подтвердить",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "Создать {number} ордер(ов):",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Создать",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Ордер",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Ордеры",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "комис.",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "Отменить",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Введите сумму в фиате для получения:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Автозаполнение",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Исправьте ошибки, прежде чем продолжить",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Некорректная сумма",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Неверная сумма продажи",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "Недостаточно {coin} чтобы оплатить налог. МИН баланс {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin} баланс очень низкий",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "Макс сумма к продаже",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "Мин сумма к получению",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "Мин сумма к продаже",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Получить",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Продать:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Мульти",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Получ. сумма",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "Цена/СЕХ",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Комиссия сети",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "новый аккаунт",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Новый аккаунт",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Новостная лента",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Новое значение",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "далее",
-    "@next": {
-        "type": "text"
-    },
-    "no": "Нет",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "Нет новостей - пожалуйста проверьте позже!",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "Монета не найдена",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Нет средств",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "Нет доступных средств - пожалуйста, внесите депозит.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "Отсутствует подключение к Интернет",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "Ничего не выбрано",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "Ничего не выбрано",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "Совпадающих ордеров не найдено",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Никто",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "Значение должно быть указано в цифрах",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Пожалуйста, введите сумму {coinName}.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Нажмите, чтобы создать ордер",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "Нет ордеров, пожалуйста перейдите в торговлю.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "Нет доступных вознаграждений",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "Нет вознаграждения для востребования - повторите попытку через 1 час.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "Нет такой монеты",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "Нет истории.",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "Не достаточно {coin} для транзакции!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "Недостаточно баланса для комиссий - выполните сделку на меньшую сумму",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Замечание: Выбранный ордер не может быть снова отменен",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Добавить заметку",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Заметка",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Ничего не найдено",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "Своп {sell}/{buy} успешно завершен",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "Своп завершен",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "Своп {sell}/{buy} не прошел",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "Своп не был завершен",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "Своп {sell}/{buy} начат",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Новый своп начался",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Статус свопа изменен",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "Превышен тайм-аут свопа {sell}/{buy}",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Превышен тайм-аут свопа",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "Вы получили {coin} транзакцию",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Входящая транзакция",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "Нет транзакций",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} Активов",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "Официальный пресс-релиз",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Ок",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Удалить",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Старые логи",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Использовано места",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Открыть сообщение об ошибке",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "Необязательный",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "Меньше",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "Более",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Все {coin} ордеры будут отменены.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Ордер создан",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Ордер успешно создан",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Адрес",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "Отменить",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "На -{delta}% ниже цен CEX",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "На +{delta}% выше цен CEX",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "на",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "Совпадает с СЕХ",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "мин.",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Цена",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Получите",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Выбрать",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Ордеры продаж",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Из вкладки Подробности выберите Ордер одним долгим нажатием",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Отправьте",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Подробности",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% заполнено",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Сделка найдена",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Поиск сделки в процессе",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "ордера",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Активные",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "История",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "Сумма ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "Цена ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "Всего ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Ордер",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Неизвестный тип ордера",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Перезаписать",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "Это ваш ордер!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Оплачено с баланса:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Оплачено с полученного объема:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Оплачено c",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "Пароль должен содержать не менее 12 символов, включая один строчный, один заглавный и один специальный символ.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Оплата",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "Вы подтверждаете эту транзакцию?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "На Адрес",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "Остаток:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Монета:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "Отмена:",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Оплата запрошена",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} не активен. Пожалуйста активируйте и попробуйте снова.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Разместить ордер",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "Воспроизводить на полную громкость",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Пожалуйста добавьте монету",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Пожалуйста перезапустите приложение чтобы попробовать снова или нажмите на кнопку ниже.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Портфолио",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Разработано Komodo",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "цена",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Приватный ключ",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Приватные ключи",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Подтверждений",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Установить свои настройки защиты",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "ВЫКЛ",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "ВКЛ",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Внимание, этот своп не защищен dPoW!",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Публичный ключ",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "Сканер QR-кода",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "Вы храните мои приватные ключи?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "На каких устройствах я могу использовать {appName}?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "Чем торговля на {appName} отличается от торговли на других DEX?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "Сколько времени занимает каждый атомарный своп?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "Необходимо ли мне быть в сети во время свопа?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "Как рассчитываются комиссии на {appName}?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "Предоставляете ли вы поддержку пользователей?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "Есть ли у вас какие-либо географические ограничения?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "Кто стоит за {appName}?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "Можно ли разработать собственную white-label биржу на технологии {appName}?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "Это новая эра! Мы официально изменили наше название с «AtomicDEX» на «Komodo Wallet».",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "ПОЛУЧИТЬ",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Получить",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Мы рекомендуем хранить ее на оффлайн носителе.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Отключить",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Запрошенная сделка",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "ОЧИСТИТЬ",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Сбросить форму",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "ВОССТАНОВИТЬ",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Попытка активации всех монет...",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Попытка активации всего",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Забрать вашу награду",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Отменить",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Что-то пошло не так. Попробуйте позже.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "Транзакция в процессе",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "обработка",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXO меньше 10",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Час еще не прошел",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "Меньше часа",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "ОК",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Статус вознаграждений:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "Узнать больше о KMD вознаграждениях",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Получить",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "Получено {amount} KMD.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "Фиат",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "Вознаграждений\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Статус",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Осталось",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Инфо о вознаграждениях:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} дней}",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}ч {minutes}мин",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "мин {mm}",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "Инфо о вознаграждениях:",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Русский",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Сохранить объединенные",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "Прокрутите вниз, чтобы продолжить...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Поиск монеты",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Выбрать все Avax токены",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Выбрать все BEP токены",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Выбрать всю сеть Cosmos",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Выбрать все ERC токены",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Выбрать все ETC токены",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Выбрать все Fantom токены",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Выбрать все HecoChain токены",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Выбрать все Harmony токены",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Выбрать всю сеть Iris",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Выбрать все Kucoin токены",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Выбрать все Moonriver токены",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Выбрать все Polygon токены",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Выбрать все QRC токены",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Выбрать все SmartBCH токены",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Выбрать все токены SLP",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Выбрать все Smartchain",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Выбрать все Тестовые Активы",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Выбрать все Ubiq монеты",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Выбрать все UTXO монеты",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Выбрать все монеты ZHTLC",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Найти Тикер",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "сек",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Безопасность",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "Seed Фраза",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Ваш новый seed-ключ",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "Нажмите, чтобы увидеть {amount} ордеров",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "Показать историю транзакций",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Выберите монету",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Выберите монеты, которые вы хотите добавить в свое портфолио.",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Активировать монеты:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "Выберите монету, которую хотите купить",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "Выберите монету, которую хотите продать",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Выбранный ордер:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Выбрать файл",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Выбрать Язык",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Выберите способ оплаты",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Продать",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "Внимание, вы пытаетесь продать тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "ОТПРАВИТЬ",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Вы уверены, что хотите удалить",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "кошелек?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Если это так, убедитесь, что вы",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "записали свой seed-ключ.",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "Для того, чтобы восстановить свой кошелек в будущем.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Языки",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Настройки",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "УСТАНОВИТЬ ПАРОЛЬ",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "ПОДЕЛИТЬСЯ",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "Мой {coinName} адрес:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Показать адрес",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Показать детали",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "Показано {count} из {maxCount} заказов.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "ПОКАЗАТЬ МОИ ОРДЕРЫ",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Войти с паролем",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "Войти с помощью seed-ключа",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Просто",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Активировать",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Пожалуйста введите сумму {coin} для покупки",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Купить",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Закрыть",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "Максимальное количество активных монет: {maxCoins}. Пожалуйста деактивируйте некоторые из них.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} не активна",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Получить",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Пожалуйста введите сумму {coin} для продажи",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Продать",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Отправить",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Скрыть",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Показать больше",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "Не удалось активировать {coin}",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Пропустить",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Убрать",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Звук",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Выберите файл в формате mp3 или wav. Воспроизводится, когда {description}.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "Воспроизводится, когда {description}",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Звуки",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Я понимаю, больше это не показывать",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Звук",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Настройки звука",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "Вы будете слышать звуковые уведомления во время процесса обмена и при размещении активного ордера.\nДля успешной торговли, протокол Atomic swaps требует чтобы участники были онлайн и звуковые уведомления помогают достичь этого.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Обратите внимание что вы можете установить свои собственные звуки в настройках приложения.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "Испанский",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Начать обмен",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Шаг",
-    "@step": {
-        "type": "text"
-    },
-    "success": "Успех!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Поддержка",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Если у вас есть какие-либо вопросы или вы считаете, что обнаружили техническую проблему с приложением {appName}, вы можете сообщить об этом и получить поддержку от нашей команды.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "обмен",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Текущий",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "ПОДТВЕРДИТЕ ДЕТАЛИ ОБМЕНА",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "прибл",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "Обмен не удался",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Пожалуйста сначала активируйте {coin} и пополните баланс",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию. {coin} {amount} требуется.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Обмен в процессе",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "Детали прогресса",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "Начато",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Успешный обмен",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Всего",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "UUID обмена",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Переключить тему",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ЖТЛК",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Тейкер",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Ордер Тейкера",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Таймаут",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "СОЗДАТЬ ПАРОЛЬ",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Ордер выбран",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "В",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "На адрес:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "У вас имеются",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "включенные активы. Максимальный предел включенных активов",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ". Пожалуйста, отключите некоторые из них перед добавлением новых.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Подключено слишком много активов",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Общие комиссии:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "СДЕЛКА",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "Обмен завершен!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "ДЕТАЛИ СДЕЛКИ",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Ошибка при расчете торговой комиссии",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "торговая комиссия:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Режим Торговли",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "Адрес транзакции",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "Транзакция скрыта",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Эта транзакция была скрыта из-за возможной попытки фишинга.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "даже если после этого некоторые монеты все еще не активированы, попробуйте перезапустить приложение.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Турецкий",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Блок",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Подтверждения",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "ПОДТВЕРЖДЕНА",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Комиссия",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "комиссия сети:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "ID транзакции",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Осталось транзакций: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Слишком много запросов.\nПревышен лимит запросов истории транзакций.\nПовторите попытку позже.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "НЕПОДТВЕРЖДЕНА",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Украинский",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "разблокировать",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Разблокировать средства",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "Успешно разблокировано {amnt} средств - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "неизрасходованный",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Доступна новая версия",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Проверка обновлений...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "Установлена версия {version}",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Доступна новая версия. Пожалуйста, обновитесь.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "Доступна версия {version}. Пожалуйста, обновитесь.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Доступно обновление",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Пропустить",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "Обновление {appName}",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Обновление",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Установлена последняя версия",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "Недостаточно баланса для отсканированного",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "платежного запроса.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Недостаточный баланс",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Стоимость:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "версия",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Обозреватель",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Seed & Приватные ключи",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Объемы",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "Имя кошелька уже используется",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "Имя кошелька не должно превышать 40 символов",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Только кошелек",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "Предупреждение!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "OK",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Предупреждение - в особых случаях логи могут содержать конфиденциальную информацию, которую можно использовать для доступа к монетам из незавершенных свопов!",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "Ошибка активации {coinAbbr}",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "Ошибка активации {coinAbbr}\nПожалуйста перезапустите приложение и попробуйте снова",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} mobile - это мульти-монетный кошелек с функциональностью DEX третьего поколения и многим другим.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "ДАВАЙТЕ ВСЕ НАСТРОИМ!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "Добро пожаловать",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "кошелек",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "По завершении вы будете перенаправлены на страницу портфолио.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Это займет некоторое время, и приложение должно оставаться на переднем плане.\nЗакрытие приложения во время активации может привести к проблемам.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Вывести",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "Ранее вы запретили {appName} доступ к камере.\nВручную измените разрешения для камеры в настройках телефона, чтобы продолжить сканирование QR-кода.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Доступ запрещен",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Подтвердите вывод",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Что-то пошло не так. Попробуйте позже.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "ВЫВЕСТИ {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "Вы пытаетесь сканировать QR code для оплаты",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "но вы сейчас находитесь",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "на экране вывода",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Некорректная монета",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "Пароли не совпадают. Пожалуйста, попробуйте еще раз.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Да",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Вы отправляете:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "есть новый ордер, который совпадает с вашим размещенным ордером",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "у вас уже есть активный своп в процессе",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "у вас есть ордер, которому могут соответствовать новые ордеры",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "ваш кошелек",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "Вы получите {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Вы получите:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "ru",
+  "accepteula": "Принять EULA",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "Принять ПРАВИЛА и УСЛОВИЯ",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Активировать биометрическую защиту",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "Активировать защиту PIN",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "Активировать монеты {protocolName}?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "Активация {coinName}",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName} Активация",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} активируется",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Активные",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Активировать монету",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} активирован успешно!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Добавить адрес",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Адресная книга",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "Адресная книга пуста",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Отображаются только контакты с {title} адресами",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Адресная книга",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "Вы не можете отправить средства на адрес {abbr}, потому что {abbr} не активирован. Пожалуйста, перейдите в портфолио.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Не найдено",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Выбрать валюту",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Адрес получателя",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Расширенные",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "Все",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Разрешить произвольный seed-ключ",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "Ваш кошелек покажет все прошлые транзакции. Это потребует значительного объема памяти и времени, поскольку все блоки будут загружены и отсканированы.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "Уже существует",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Количество",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Сумма для продажи",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "Нет! Мы никогда не храним конфиденциальные данные, включая ваши приватные ключи, seed ключи или PIN-код. Эти данные хранятся только на устройстве пользователя и никуда не передаются. Вы полностью контролируете свои активы.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "Приложение {appName} доступно для мобильных устройств на Android и iPhone, а также для компьютеров в <a href=\"https://komodoplatform.com/\">операционных системах Windows, Mac и Linux</a>.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Другие DEX обычно позволяют торговать только активами, принадлежащими к одному блокчейну, используют прокси-токены и разрешают размещать только один ордер, использующий ваш баланс.\n\n{appName} позволяет вам торговать между разными блокчейнами без использования прокси-токенов. Вы также можете разместить несколько заказов, используя одни и те же средства. Например, вы можете выставить ордера на продажу 0,1 BTC за KMD, QTUM и VRSC - первый исполненный ордер автоматически отменит все остальные ордера.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Есть несколько факторов, определяющих время обработки каждого свопа. Время блокировки торгуемых активов зависит от каждой сети (биткоин блокчейн обычно является самым медленным). Кроме того, пользователь может редактировать параметры безопасности. Например, в {appName} можно установить количество подтверждений, после которых KMD транзакция считается успешной, равным 3, что сокращает время обмена по сравнению с транзакциями, ожидающими <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">нотариального заверения</a>.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Да. Приложение должно оставаться подключенным к Интернету для успешного завершения каждого атомарного свопа (очень короткие перерывы в подключении обычно допустимы). В противном случае существует риск отмены сделки, если вы являетесь мейкером, и риск потери средств, если вы тейкер. Протокол атомарного свопа требует, чтобы оба участника оставались в сети и контролировали задействованные блокчейны, чтобы процесс оставался атомарным.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "При торговле на {appName} необходимо учитывать две категории комиссий.\n\n1. {appName} взимает приблизительно 0,13% (1/777 объема торгов, но не ниже 0,0001) в качестве комиссии за торговлю для тейкер ордеров, а для ордеров-мейкеров комиссия равна нулю.\n\n2. Как мейкеры, так и тейкеры должны платят обычные комиссии за транзакции в используемых блокчейнах при совершении атомарного свопа .\n\nКомиссиии сети могут сильно различаться в зависимости от выбранной вами торговой пары.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "Да! {appName} предлагает поддержку через <a href=\"{link}\"> {name} сервер {appCompanyShort} </a>. Команда и сообщество всегда рады помочь!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "Нет! {appName} полностью децентрализована. Ограничить доступ пользователей третьими лицами невозможно.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} разработан командой {appCompanyShort}. {appCompanyShort} - один из наиболее авторитетных блокчейн-проектов, работающих над инновационными решениями, такими как атомарные свопы, delayed Proof of Work и совместимая многоцепочечная архитектура.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "Абсолютно! Вы можете прочитать нашу <a href=\"https://developers.komodoplatform.com/\">документацию для разработчиков</a> для получения более подробной информации или связаться с нами по вопросам партнерства. Есть конкретный технический вопрос? Сообщество разработчиков {appName} всегда готово помочь!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Аплодисменты",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "ВЫ УВЕРЕНЫ?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "своп не был завершен",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "своп завершается",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "аутентификация",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Вы будете автоматически перенаправлены на страницу портфолио после завершения процесса повторной активации.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "макс объем",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "назад",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Бэкап",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "на основе {coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "Критический заряд батареи ({batteryLevelCritical}%) для безопасного выполнения свопа. Пожалуйста поставьте его на зарядку и повторите попытку.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "Заряд батареи ниже {batteryLevelLow}%. Пожалуйста подумайте о зарядке телефона.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Ваш телефон находится в режиме экономии заряда батареи. Пожалуйста, отключите этот режим или НЕ переводите приложение в фоновый режим, в противном случае приложение может быть убито операционной системой, и обмен не удастся.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "Обменный курс",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Построено на Komodo",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Построено на Komodo",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Купить",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "Конвертировать в мейкер если нет совпадений",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Обмен начался, пожалуйста подождите!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "Поиск сделки в процессе, пожалуйста , подождите {seconde} секунд!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "Внимание, вы пытаетесь купить тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "Маскировочный PIN и BIO защита не могут быть включены одновременно.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Конфликт маскировочного и Bio защитных PIN",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Изменить маскировочный PIN",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Создать Маскировочный PIN",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Если вы разблокируете приложение с маскировочным PIN-кодом, будет показан поддельный баланс, а настройки маскировочного PIN-кода НЕ будут отображаться в приложении",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "Неверный маскировочный PIN",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Маскировочный PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "Маскировочный PIN не найден",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Выкл",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "Вкл",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "Маскировочный PIN сохранен",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Маскировочный PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Введите новый маскировочный PIN",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Установить маскировочный PIN",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Установить маскировочный PIN",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "отменить",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Отменить активацию",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "Вы уверены, что хотите отменить активацию?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "отменить",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Отменить Ордер",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Что-то пошло не так. Попробуйте позже.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ок",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "это монета настроенная по умолчанию. Монеты по умолчанию не могут быть отключены.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "Не возможно отключить",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "Невозможно воспроизвести",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "Цена CEXchange",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "Данные CEX",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Данные (цены, графики и т.д.), отмеченные этим значком, получены из сторонних источников (<a href=\"https://www.coingecko.com/\"> coingecko.com </a>, <a href = \" https://openrates.io/\">openrates.io </a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "Курс CEX",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "Изменить PIN-код",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Проверить обновления",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Всего",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "Проверьте seed-фразу",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "ПРОДОЛЖИТЬ",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "ВЕРНУТЬСЯ И ПРОВЕРИТЬ СНОВА",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "Введите {index} слово",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "Ваш seed-ключ необходим для доступа к кошельку - поэтому мы хотим убедиться, что она правильная. Мы зададим вам три разных вопроса о вашей seed-фразе, чтобы убедиться, что вы сможете легко восстановить свой кошелек, когда захотите.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "Какое {index} слово в вашем seed-ключе?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕПРОВЕРИМ ВАШ SEED-КЛЮЧ",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Китайский",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "Востребовать",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "Востребовать KMD вознаграждение?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Нажмите, чтобы увидеть",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "Скопировано",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "Скопировать",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Закрыть",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Закрыть сообщение об ошибке",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Закрыть предпросмотр",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Код:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "Вы уверены, что хотите отменить активацию?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Вы выбрали максимальное количество активов",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "Монеты {protocolName} активированы",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "Монеты {protocolName} успешно активированы",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "Монеты {protocolName} не активированы",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Очистить",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "Нет активных монет",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Выбрать монету",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "Скоро будет...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "Детали TX скоро будут добавлены!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "Детали будут скоро добавлены!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "комиссия",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "по сравнению со сред. Цена CEX за 24 часа",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "сравнение с CEX",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "Настройка кошелька, пожалуйста, подождите",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "подтвердить",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Подтвердить маскировочный PIN",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "Вы уверены, что хотите отменить ордер",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "Нажимая кнопку ниже, вы подтверждаете, что прочитали «EULA» и «Terms and Conditions» и принимаете их",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Подтвердите пароль",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "Подтвердите PIN-код",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "Подтвердите seed-ключ",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Соединение...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "Отмена",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Удалить контакт",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "Удалить",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "Вы уверены, что хотите удалить {name}?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Сбросить",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Изменить",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Выйти",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Сбросить изменения?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "Контакты не найдены",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Сохранить",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Контактная информация",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "Имя",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Договор",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Конвертировать",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "Не удалось запустить URL",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "Не удалось импортировать:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "сделка",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "СОЗДАТЬ КОШЕЛЕК",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Добавить контакт",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "Задать PIN",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Валюта",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Валюта",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Текущее значение",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Настроить комиссию",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "Используйте настраиваемые комиссии только если знаете, что делаете!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Пользовательские исходные фразы могут быть менее безопасными и их легче взломать, чем сгенерированные исходные фразы или закрытый ключ (WIF), совместимые с BIP39. Чтобы подтвердить, что вы понимаете риск и знаете, что делаете, введите \"{iUnderstand}\" в поле ниже.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Дата",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Расшифровываю кошелек",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Удалить",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Подтвердить деактивацию",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "Вы хотите удалить",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "из вашего портфолио? Все несовпавшие ордеры будут отменены.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " также будет деактивирован",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Удалить кошелек",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Удаляю кошелек",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "получить комиссию за транзакцию {coinName}",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "отправить комиссию за транзакцию {coinName}",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "отправить торговую комиссию комиссию за транзакцию",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "торговая комиссия",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "детали",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Немецкий",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Разработчик",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX не доступен для этой монеты",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Отключить скриншоты/предварительный просмотр",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Disclaimer & ToS",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Готово",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Не закрывайте приложение. Нажмите, чтобы узнать больше...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "Не спрашивать снова",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "Я не хочу использовать пароль",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Защита Komodo dPoW",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Продолжительность",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Редактировать",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "Введите {abbr} адрес",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "Зашифрованный пароль не может быть пустым",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "Пароль не может быть пустым",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "Имя контакта не может быть пустым",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "Имя кошелька не должно быть пустым",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Вы все еще можете включить {остается}, Выбрано: {выбрано}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Пожалуйста, включите уведомления, чтобы получать обновления о ходе активации.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Включить тестовые монеты",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "У вас есть",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "подключенные активы и активы в состоянии подключения",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "Максимальный лимит подключенных активов .",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": "Пожалуйста отключите некоторые чтобы добавить новые.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Попытка подключения других активов",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Шифрую кошелек",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "Английский",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Введите новый PIN",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Введите свой старый PIN",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Пожалуйста, введите Ваш пароль чтобы продолжить.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "Введите свой PIN-код",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Введите свою seed-фразу",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Для начала вы должны ввести сумму на продажу",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "Недостаточный баланс",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "Невалидный адрес",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Segwit адреса не поддерживаются",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "Не достаточно газа - используйте минимум {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Ошибка, пожалуйста попробуйте еще раз",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Ошибка, пожалуйста попробуйте позже",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "Значение слишком высокое или маленькое",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "Пожалуйста, введите данные",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Расчетная общая стоимость",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Например: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Ниже цен CEX",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Выше цен CEX",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "Идентичен CEX",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Рейтинг обменника",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "ОБМЕН",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Экспорт",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Контакты",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Пожалуйста выберите элементы для экспорта в зашифрованный файл.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Экспорт",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Заметки",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "Элементы которые были успешно экспортированы:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Свопы",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Экспорт",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Неудавшиеся \t",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Маскировочный баланс:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Часто задаваемые вопросы",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Ошибка",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "Отправка запроса на кран {coin}",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "FAUCET",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Успешно",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "Время запроса истекло",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Отправить логи",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Новости",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Здесь ничего нет",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "Новости Комодо",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Узнать больше",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Лента",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Лента новостей",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "Невозможно обновить ленту новостей",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "Невозможно обновить ленту новостей",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Лента новостей обновлена",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Новых новостей нет",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "Комиссия должна быть не более {value}",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Все",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Фильтр",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Очистить все фильтры",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Не удалось",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "С даты",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Майкер",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Получить монету",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Продать монету",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Статус",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Успешно",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Тейкер",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "На дату",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Тейкер/Мейкер",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Отпечаток",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Заканчиваем, пожалуйста, подождите",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "Найден QR-код",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Французский",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "Из",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "Мы будем синхронизировать будущие транзакции, совершенные после активации, связанные с вашим открытым ключом. Это самый быстрый вариант и занимает меньше всего места.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} комиссия",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "Лимит газа",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Пожалуйста активируйте {coin}",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "Цена Gas",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "Общая защита PIN-кодом не активна.\nРежим маскировки будет недоступен.\nВключите защиту PIN-кодом.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Важно: перед тем как продолжить, сохраните свою seed-фразу в надежном месте!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "Идет транзакция, пожалуйста, подождите",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Перейти в портфолио",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Значение Gwei должно быть до {value}.",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Помощь",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Помощь и поддержка",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Спрятать баланс",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Подтвердите Пароль",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Создать пароль",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Текущий пароль",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Введите свой пароль",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Введите свой seed-ключ",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Назовите свой кошелек",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Пароль",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "история",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "ч",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Венгерский",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "Импортировать",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Неверный пароль или поврежденные данные",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "Элементы к импорту",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Файл не найден",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Неверные данные своп. Предоставьте действительный JSON-файл состояния своп.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "Импорт",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Пожалуйста выберите зашифрованный файл для импорта.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Открываю...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Пожалуйста выберите текстовый своп файл для импорта",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "Отмена",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Ок",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Пароль",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Импортировать одиночный своп файл",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Импортировать своп файл",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Некоторые элементы были пропущены",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "Элементы которые были успешно импортированы:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "Ошибка при импорте своп файла",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Ошибка декодирования json файла",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "Импорт",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Настройки защиты входящих txs-транзакций {coinName}",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "Запрос на обмен не может быть отменен и является окончательным!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "Эта транзакция может занять до 10 минут - НЕ закрывайте приложение!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Вы можете зашифровать свой кошелек паролем. Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} недостаточно баланса чтобы оплатить торговую комиссию",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "Минимальное количество необходимое для этого ордера составляет",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Недостаточное количество",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Обновить",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "Соединение с интернетом восстановлено",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Неверный адрес {coin}",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "Невозможно продолжить своп",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Подробнее",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} недоступен :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "Я понимаю",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Японский",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Корейский",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Язык",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Последние Транзакции",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Легальные аспекты",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "Меньше",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗Осторожно! Объем торгов на рынке {coinName} за 24 часа составляет менее 10 000 долларов!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "Лимит должен быть до {value}",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Загрузка...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Загрузка книги ордеров...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "Экран заблокирован",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "Пожалуйста, аутентифицируйтесь!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "войти",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Выйти",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Log Out при выходе",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Настройки Log Out",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "Вы уверены, что хотите выйти?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "минуты",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "разместить ордер",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Мейкер",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Отменить ордер",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "Создано в",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Получить",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "Ордер ID",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Свопы по этому ордеру не запускались",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Цена",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Продать",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "Свопы начатые по этому ордеру",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Подробности ордера Мейкера",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Ордер Мейкера",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Маркетплейс",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "График",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Глубина",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "Нет асков",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "Нет бидов",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "ОРДЕРБУК",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Детали ордера",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "ЦЕНА",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Пожалуйста, выберите монету",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Рынки",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "РЫНКИ",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "Пароли должны совпадать",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Изменить",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Общий PIN и маскировочный PIN совпадают.\nРежим маскировки будет недоступен.\nИзмените маскировочный PIN",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "Неверный PIN",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "MAX",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Максимальный размер ордера",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Новости",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "ПРОСМАТРИВАТЬ",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "ПОСМОТРЕТЬ ЛЕНТУ",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "По",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "У вас нет сохраненных статей",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "СОХРАНЕННЫЕ",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Памятка",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Слияние",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Объединенное значение:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "мс",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "МИН",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Предупреждение: сворачивание приложения на iOS приведет к прекращению процесса активации.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "Минимальные объем ордера",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "мин",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "Минимальная сумма продажи составляет {number} {coinName}.",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "Минимальная сумма покупки: {number} {coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "Минимальная сумма ордера {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "Минимальная сумма на продажу {number} {coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "Должно быть больше чем {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Должно быть меньше чем сумма продажи",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Минимальное требуемое количество",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "Использовать собственное минимальное количество",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Обратите внимание, что теперь вы используете сотовые данные, а участие в P2P-сети {appName} потребляет интернет-трафик. Лучше использовать сеть Wi-Fi, если ваш тарифный план сотовой связи является дорогостоящим.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Больше информации",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "Ещё",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Активируйте {coin} и пополните баланс",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Сумма",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Монета",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Продать",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "Отменить",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Подтвердить",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "Создать {number} ордер(ов):",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Создать",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Ордер",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Ордеры",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "комис.",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "Отменить",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Введите сумму в фиате для получения:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Автозаполнение",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Исправьте ошибки, прежде чем продолжить",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Некорректная сумма",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Неверная сумма продажи",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "Недостаточно {coin} чтобы оплатить налог. МИН баланс {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin} баланс очень низкий",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "Макс сумма к продаже",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "Мин сумма к получению",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "Мин сумма к продаже",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Получить",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Продать:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Мульти",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Получ. сумма",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "Цена/СЕХ",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Комиссия сети",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "новый аккаунт",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Новый аккаунт",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Новостная лента",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Новое значение",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "далее",
+  "@next": {
+    "type": "text"
+  },
+  "no": "Нет",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "Нет новостей - пожалуйста проверьте позже!",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "Монета не найдена",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Нет средств",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "Нет доступных средств - пожалуйста, внесите депозит.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "Отсутствует подключение к Интернет",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "Ничего не выбрано",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "Ничего не выбрано",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "Совпадающих ордеров не найдено",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Никто",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "Значение должно быть указано в цифрах",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Пожалуйста, введите сумму {coinName}.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Нажмите, чтобы создать ордер",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "Нет ордеров, пожалуйста перейдите в торговлю.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "Нет доступных вознаграждений",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "Нет вознаграждения для востребования - повторите попытку через 1 час.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "Нет такой монеты",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "Нет истории.",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "Не достаточно {coin} для транзакции!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "Недостаточно баланса для комиссий - выполните сделку на меньшую сумму",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Замечание: Выбранный ордер не может быть снова отменен",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Добавить заметку",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Заметка",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Ничего не найдено",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "Своп {sell}/{buy} успешно завершен",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Своп завершен",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "Своп {sell}/{buy} не прошел",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Своп не был завершен",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "Своп {sell}/{buy} начат",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Новый своп начался",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Статус свопа изменен",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "Превышен тайм-аут свопа {sell}/{buy}",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Превышен тайм-аут свопа",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "Вы получили {coin} транзакцию",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Входящая транзакция",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "Нет транзакций",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} Активов",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "Официальный пресс-релиз",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Ок",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Удалить",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Старые логи",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Использовано места",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Открыть сообщение об ошибке",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "Необязательный",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "Меньше",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "Более",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Все {coin} ордеры будут отменены.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Ордер создан",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Ордер успешно создан",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Адрес",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "Отменить",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "На -{delta}% ниже цен CEX",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "На +{delta}% выше цен CEX",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "на",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "Совпадает с СЕХ",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "мин.",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Цена",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Получите",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Выбрать",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Ордеры продаж",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Из вкладки Подробности выберите Ордер одним долгим нажатием",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Отправьте",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Подробности",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% заполнено",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Сделка найдена",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Поиск сделки в процессе",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "ордера",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Активные",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "История",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "Сумма ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "Цена ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "Всего ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Ордер",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Неизвестный тип ордера",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Перезаписать",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "Это ваш ордер!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Оплачено с баланса:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Оплачено с полученного объема:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Оплачено c",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "Пароль должен содержать не менее 12 символов, включая один строчный, один заглавный и один специальный символ.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "Ваш кошелек покажет ваши прошлые транзакции, совершенные после указанной даты.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Оплата",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "Вы подтверждаете эту транзакцию?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "На Адрес",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "Остаток:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Монета:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "Отмена:",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Оплата запрошена",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} не активен. Пожалуйста активируйте и попробуйте снова.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Разместить ордер",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "Воспроизводить на полную громкость",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Пожалуйста добавьте монету",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Пожалуйста перезапустите приложение чтобы попробовать снова или нажмите на кнопку ниже.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Портфолио",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Разработано Komodo",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "цена",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Приватный ключ",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Приватные ключи",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Подтверждений",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Установить свои настройки защиты",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "ВЫКЛ",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "ВКЛ",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Внимание, этот своп не защищен dPoW!",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Публичный ключ",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "Сканер QR-кода",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "Вы храните мои приватные ключи?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "На каких устройствах я могу использовать {appName}?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "Чем торговля на {appName} отличается от торговли на других DEX?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "Сколько времени занимает каждый атомарный своп?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "Необходимо ли мне быть в сети во время свопа?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "Как рассчитываются комиссии на {appName}?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Предоставляете ли вы поддержку пользователей?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "Есть ли у вас какие-либо географические ограничения?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "Кто стоит за {appName}?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "Можно ли разработать собственную white-label биржу на технологии {appName}?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "Это новая эра! Мы официально изменили наше название с «AtomicDEX» на «Komodo Wallet».",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "ПОЛУЧИТЬ",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Получить",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Мы рекомендуем хранить ее на оффлайн носителе.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Отключить",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Запрошенная сделка",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "ОЧИСТИТЬ",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Сбросить форму",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "ВОССТАНОВИТЬ",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Попытка активации всех монет...",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Попытка активации всего",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Забрать вашу награду",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Отменить",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Что-то пошло не так. Попробуйте позже.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "Транзакция в процессе",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "обработка",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXO меньше 10",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Час еще не прошел",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "Меньше часа",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "ОК",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Статус вознаграждений:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "Узнать больше о KMD вознаграждениях",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Получить",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "Получено {amount} KMD.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "Фиат",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "Вознаграждений\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Статус",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Осталось",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Инфо о вознаграждениях:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} дней}",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}ч {minutes}мин",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "мин {mm}",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Инфо о вознаграждениях:",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Русский",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Сохранить объединенные",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "Прокрутите вниз, чтобы продолжить...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Поиск монеты",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Выбрать все Avax токены",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Выбрать все BEP токены",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Выбрать всю сеть Cosmos",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Выбрать все ERC токены",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Выбрать все ETC токены",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Выбрать все Fantom токены",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Выбрать все HecoChain токены",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Выбрать все Harmony токены",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Выбрать всю сеть Iris",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Выбрать все Kucoin токены",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Выбрать все Moonriver токены",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Выбрать все Polygon токены",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Выбрать все QRC токены",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Выбрать все SmartBCH токены",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Выбрать все токены SLP",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Выбрать все Smartchain",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Выбрать все Тестовые Активы",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Выбрать все Ubiq монеты",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Выбрать все UTXO монеты",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Выбрать все монеты ZHTLC",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Найти Тикер",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "сек",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Безопасность",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "Seed Фраза",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Ваш новый seed-ключ",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "Нажмите, чтобы увидеть {amount} ордеров",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "Показать историю транзакций",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Выберите монету",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Выберите монеты, которые вы хотите добавить в свое портфолио.",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Активировать монеты:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "Выберите монету, которую хотите купить",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "Выберите монету, которую хотите продать",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Выберите дату",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Выбранный ордер:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Выбрать файл",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Выбрать Язык",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Выберите способ оплаты",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Продать",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "Внимание, вы пытаетесь продать тестовые монеты БЕЗ РЕАЛЬНОЙ стоимости.",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "ОТПРАВИТЬ",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Вы уверены, что хотите удалить",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "кошелек?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Если это так, убедитесь, что вы",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "записали свой seed-ключ.",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "Для того, чтобы восстановить свой кошелек в будущем.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Языки",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Настройки",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "УСТАНОВИТЬ ПАРОЛЬ",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "ПОДЕЛИТЬСЯ",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "Мой {coinName} адрес:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "Сканировать прошлые транзакции с {coin}?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Показать адрес",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Показать детали",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "Показано {count} из {maxCount} заказов.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "ПОКАЗАТЬ МОИ ОРДЕРЫ",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Войти с паролем",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "Войти с помощью seed-ключа",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Просто",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Активировать",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Пожалуйста введите сумму {coin} для покупки",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Купить",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Закрыть",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "Максимальное количество активных монет: {maxCoins}. Пожалуйста деактивируйте некоторые из них.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} не активна",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Получить",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Пожалуйста введите сумму {coin} для продажи",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Продать",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Отправить",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Скрыть",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Показать больше",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "Не удалось активировать {coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Пропустить",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Убрать",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Звук",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Выберите файл в формате mp3 или wav. Воспроизводится, когда {description}.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "Воспроизводится, когда {description}",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Звуки",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Я понимаю, больше это не показывать",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Звук",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Настройки звука",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "Вы будете слышать звуковые уведомления во время процесса обмена и при размещении активного ордера.\nДля успешной торговли, протокол Atomic swaps требует чтобы участники были онлайн и звуковые уведомления помогают достичь этого.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Обратите внимание что вы можете установить свои собственные звуки в настройках приложения.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "Испанский",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Дата начала",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Начать обмен",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Шаг",
+  "@step": {
+    "type": "text"
+  },
+  "success": "Успех!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Поддержка",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Если у вас есть какие-либо вопросы или вы считаете, что обнаружили техническую проблему с приложением {appName}, вы можете сообщить об этом и получить поддержку от нашей команды.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "обмен",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Текущий",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "ПОДТВЕРДИТЕ ДЕТАЛИ ОБМЕНА",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "прибл",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "Обмен не удался",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Пожалуйста сначала активируйте {coin} и пополните баланс",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "Баланс {coin} недостаточен для оплаты комиссии за транзакцию. {coin} {amount} требуется.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Обмен в процессе",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "Детали прогресса",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "Начато",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Успешный обмен",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Всего",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "UUID обмена",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Переключить тему",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Синхронизировать с указанной даты",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Синхронизация с активацией саженца",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Синхронизировать новые транзакции",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "Какие транзакции {name} вы хотите синхронизировать?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Тейкер",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Ордер Тейкера",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Таймаут",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "СОЗДАТЬ ПАРОЛЬ",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Ордер выбран",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "В",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "На адрес:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "У вас имеются",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "включенные активы. Максимальный предел включенных активов",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ". Пожалуйста, отключите некоторые из них перед добавлением новых.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Подключено слишком много активов",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Общие комиссии:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "СДЕЛКА",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "Обмен завершен!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "ДЕТАЛИ СДЕЛКИ",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Ошибка при расчете торговой комиссии",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "торговая комиссия:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Режим Торговли",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "Адрес транзакции",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "Транзакция скрыта",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Эта транзакция была скрыта из-за возможной попытки фишинга.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "даже если после этого некоторые монеты все еще не активированы, попробуйте перезапустить приложение.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Турецкий",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Блок",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Подтверждения",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "ПОДТВЕРЖДЕНА",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Комиссия",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "комиссия сети:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "ID транзакции",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Осталось транзакций: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Слишком много запросов.\nПревышен лимит запросов истории транзакций.\nПовторите попытку позже.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "НЕПОДТВЕРЖДЕНА",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Украинский",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "разблокировать",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Разблокировать средства",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "Успешно разблокировано {amnt} средств - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "неизрасходованный",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Доступна новая версия",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Проверка обновлений...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "Установлена версия {version}",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Доступна новая версия. Пожалуйста, обновитесь.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "Доступна версия {version}. Пожалуйста, обновитесь.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Доступно обновление",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Пропустить",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "Обновление {appName}",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Обновление",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Установлена последняя версия",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "Недостаточно баланса для отсканированного",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "платежного запроса.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Недостаточный баланс",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Стоимость:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "версия",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Обозреватель",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Seed & Приватные ключи",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Объемы",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "Имя кошелька уже используется",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "Имя кошелька не должно превышать 40 символов",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Только кошелек",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "Предупреждение!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "OK",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Предупреждение - в особых случаях логи могут содержать конфиденциальную информацию, которую можно использовать для доступа к монетам из незавершенных свопов!",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "Ошибка активации {coinAbbr}",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "Ошибка активации {coinAbbr}\nПожалуйста перезапустите приложение и попробуйте снова",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} mobile - это мульти-монетный кошелек с функциональностью DEX третьего поколения и многим другим.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "ДАВАЙТЕ ВСЕ НАСТРОИМ!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "Добро пожаловать",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "кошелек",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "По завершении вы будете перенаправлены на страницу портфолио.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Это займет некоторое время, и приложение должно оставаться на переднем плане.\nЗакрытие приложения во время активации может привести к проблемам.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Вывести",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "Ранее вы запретили {appName} доступ к камере.\nВручную измените разрешения для камеры в настройках телефона, чтобы продолжить сканирование QR-кода.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Доступ запрещен",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Подтвердите вывод",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Что-то пошло не так. Попробуйте позже.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "ВЫВЕСТИ {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "Вы пытаетесь сканировать QR code для оплаты",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "но вы сейчас находитесь",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "на экране вывода",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Некорректная монета",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "Пароли не совпадают. Пожалуйста, попробуйте еще раз.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Да",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Вы отправляете:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "есть новый ордер, который совпадает с вашим размещенным ордером",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "у вас уже есть активный своп в процессе",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "у вас есть ордер, которому могут соответствовать новые ордеры",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "ваш кошелек",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "Вы получите {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Вы получите:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -3609,6 +3609,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "Не удалось отменить активацию {coinAbbr}.",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} недоступен :(",
     "@isUnavailable": {
         "type": "text",
@@ -5448,6 +5458,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "Активация монеты отменена",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "Успешно активирована {coin}",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "Активация {coin} отменена",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Пожалуйста, примите все специальные запросы на активацию монет или отмените выбор монет.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "Отменить активацию",
     "@cancelActivation": {

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,3652 +1,3726 @@
 {
-    "accepteula": "EULA'yı Kabul Et",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "ŞARTLARI ve KOŞULLARI Kabul Et",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Biyometrik korumayı etkinleştir",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "PIN korumasını etkinleştir",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "{protocolName} paraları etkinleştirilsin mi?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "{coinName} etkinleştiriliyor",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName} Aktivasyonu",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} Etkinleştirme Devam Ediyor",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Aktif",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Koin etkinleştir",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} başarıyla etkinleştirildi !",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Adres Ekle",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Adres defteri",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "Adres defteri boş",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Yalnızca {title} adresli kişiler gösteriliyor",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Adres Defteri",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "{abbr} etkinleştirilmediği için {abbr} adresine para gönderemezsiniz. Lütfen portföye gidiniz.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Bir şey bulunamadı",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Koin Seçin",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Alıcı adresi",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Gelişmiş",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "Hepsi",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Kişisel kelimeleri kullan",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "Zaten mevcut",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Tutar",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Satılacak Tutar",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "Hayır ! Komodo Wallet, gözetimsiz bir cüzdandır. Özel kelimeleriniz, gizli kelimeleriniz ve PIN kodunuz dahil hiçbir hassas bilgiyi kaydetmiyoruz. Bu bilgiler sadece kullanıcının cihazında tutulmaktadır ve başka bir yere gitmez. Bu sayede koin ve tokenlerinizin tüm kontrolü sizdedir.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName}, hem Android hem de iPhone'da mobil cihazlar için ve <a href=\"https://komodoplatform.com/\">Windows, Mac ve Linux işletim sistemlerinde</a> masaüstü için kullanılabilir.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Diğer DEX cüzdanlar genellikle aynı miktar koin ile tek bir alım satım emri vermeye izin verir, ara token kullanır, en önemlisi de tek bir blokzincirin koinlerinin alım satımına olanak sağlar.\n\n{appName} ise birbirinden farklı iki blokzincir ağı arasında ara token kullanmadan doğrudan takas yapmaya imkân sağlar. {appName} 'te aynı miktar koin ile birden fazla alım satım emri verebilirsiniz. Mesela 0.1 BTC ile KMD, QTUM ve VRSC için ayrı ayrı alım emirleri verebilirsiniz ve bunlardan birinin tamamlanması halinde diğerleri kendiliğinden iptal olmuş olurlar.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Her bir takasın tamamlanma sürecini etkileyen birkaç etken vardır. Takas edilen koinlerin bağlı olduğu blokzincirlerin blok çıkarım zamanları (Bitcoin en yavaşıdır) bunda etkilidir. Bunun yanında kullanıcılar, takas öncesinde güvenlik seçeneklerini özelleştirebilir. Mesela bir KMD takasına başlamadan evvel Komodo Wallet'da işlem için 3 onayın yeterli olduğu seçeneği işaretlediğinizde takas süresi <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">noterizasyon</a> eklenmeyeceğinden kısalacaktır.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Evet, takas boyunca uygulamanız açık ve internetinizin de (anlık kesintilerde bir sıkıntı yoktur) bağlı olması gerekmektedir. Aksi halde; eğer yapıcı emri (maker) veren siz iseniz takasın iptal olma durumu, alıcı emri (taker) veren iseniz de koinlerinizi kaybetme riski ortaya çıkar. Komodo Wallet protokolünde takası yapan her iki tarafın da işlem boyunca çevrimiçi olması ve takasın başarılı olması için gereklidir.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "{appName}'te alım satım yaparken bilinmesi gereken iki tür işlem ücreti vardır.\n\n1. {appName}, alıcı emirlerinden işlem başına yaklaşık olarak %0.13 (takriben 777'nin 1'i kadar, fakat bu da 0.0001'den az olmamak kaydıyla) işlem ücreti alırken, yapıcı emirlerinden herhangi bir ücret alınmamaktadır.\n\n2. Hem yapıcı hem de alıcı emir sahiplerinin ödemesi gerekli olan ve takasın gerçekleştiği blokzincirlerin standart ağ işlem ücretleri.\n\nAğ işlem ücretleri, takas yapmak istediğiniz paritelerin kendi işleyişlerine göre değişiklik göstermektedir.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "Evet! {appName}, <a href=\"{link}\">{appCompanyShort} {name}</a> aracılığıyla destek sunar. Ekip ve topluluk her zaman yardımcı olmaktan mutluluk duyar!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "Hayır ! {appName} tamamıyla merkeziyetsizdir ve kullanıcıların uygulamaya erişimi başkaları tarafından sınırlandırılamaz.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName}, {appCompanyShort} takımı tarafından geliştirilmiştir. {appCompanyShort}, koin takası, Geciktirilmiş İş Kanıtı (dPoW), birlikte çalışabilen çoklu zincir mimarisi gibi yenilikçi blokzincir çözümleri geliştiren köklü bir platformdur.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "Kesinlikle! Daha fazla ayrıntı için <a href=\"https://developers.komodoplatform.com/\">geliştirici belgelerimizi</a> okuyabilir veya ortaklık sorularınız için bizimle iletişime geçebilirsiniz. Belirli bir teknik sorunuz mu var? {appName} geliştirici topluluğu her zaman yardıma hazır!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Alkış",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "EMİN MİSİNİZ?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "Takas başarısız oldu",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "takas tamamlanmak üzere",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "Doğrula",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Tekrar aktivasyon işlemi bittiğinde doğrudan portföy sayfasına yönlendirileceksiniz.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "maksimum hacim",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "geri",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Yedekle",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "{coinName1}/{coinName2} temel alınarak",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "Telefonunuzun bataryası güvenli bir takası tamamlayamayacak ({batteryLevelCritical}%) kadar düşük. Lütfen önce şarja takıp sonra tekrar deneyiniz.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "Telefonunuzun bataryası %{batteryLevelLow}'den daha az. Lütfen telefonunuzu şarj ediniz.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "Telefonunuz batarya tasarruf modunda. Lütfen bu modu devre dışı bırakın ya da başvuru uygulamasını arka plana KOYMAYIN. Aksi halde uygulama, işletim sisteminiz tarafından kapatılabilir ve devam etmekte olan takasınız varsa başarısız olabilir.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "Mevcut en iyi fiyat",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Komodo Üzerinde Yapılmıştır",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Komodo Üzerinde Yapılmıştır",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Al",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "Eşleşme olmazsa Yapıcı Emrine çevir",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Takas işlendi, lütfen bekleyiniz.",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "Emir eşleşmesi devam ediyor, lütfen {seconde} saniye kadar bekleyiniz.",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan almak üzeresiniz.",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "Kamuflajlı PIN ve Biyometrik koruma aynı anda etkinleştirilemez.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Kamuflajlı PIN ve Biyometrik Koruma Çakışması",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Kamuflajlı PIN kodunuzu değiştirin",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Kamuflajlı PIN kodu oluşturun",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Uygulamanın kilidini Kamuflaj PIN'i ile açarsanız, sahte bir DÜŞÜK bakiye gösterilecek ve Kamuflaj PIN'i yapılandırma seçeneği ayarlarda GÖRÜNMEYECEK",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "Geçersiz Kamuflajlı PIN",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Kamuflajlı PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "Kamuflajlı PIN bulunamadı",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Kapalı",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "Açık",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "Kamuflajlı PIN kaydedildi",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Kamuflajlı PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Yeni bir kamuflajlı PIN girin",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Kamuflajlı PIN Kurulumu",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Kamuflajlı PIN Kurulumu",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "İptal",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "İptal",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Emri İptal Et",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Bir hata oluştu, lütfen daha sonra tekrar deneyiniz.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Tamam",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "Ön tanımlı bir koindir. Ön tanımlı koinler kaldırılamaz",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "Kaldırılamaz",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "Bu oynatılamıyor",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEX rasyosu",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "CEX verisi",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Bu simgeyle işaretlenen piyasa verileri (fiyatlar, çizelgeler vb.) üçüncü taraf kaynaklardan (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "CEX Oranı",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "PIN kodunu değiştir",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Güncellemeleri kontrol et",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Ödeme",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "Gizli kelimeleri kontrol edin",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "DEVAM",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "GERİ DÖN VE KONTROL ET",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "{index} kelimesini giriniz.",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "Gizli kelimeleriniz çok önemlidir, bu yüzden onları doğru kaydettiğinizden emin olmak istiyoruz. Cüzdanınızı istediğiniz zaman kolayca geri yükleyebilmeniz için gizli kelimeleriniz hakkında size şimdi üç farklı soru soracağız.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "Gizli kelimeleriniz arasından {index} olanı hangisidir ?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "GİZLİ KELİMELERİZİ BİR KEZ DAHA KONTROL EDİNİZ",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Çince",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "talep et",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "KMD ödülünüzü alın",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Görmek için tıklayın",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "Panoya kopyalandı",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "Panoya kopyala",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Kapat",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Hata mesajını kapat",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Ön izlemeyi kapat",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Kod:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Maksimum varlık sayısını seçtiniz",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "{protocolName} parası etkinleştirildi",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName} parası başarıyla etkinleştirildi",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "{protocolName} parası etkinleştirilmedi",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Temizle",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "Aktif koin yok",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Koin Seç",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "Yakında...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "TX detayları yakında !",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "Detaylar yakında !",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "komisyon ücreti",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "ortalama ile karşılaştırıldığında 24 saatlik CEX fiyatı",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "CEX ile kıyaslanınca",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "Cüzdanınız ayarlanıyor, lütfen bekleyiniz..",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "Onayla",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Kamuflajlı PIN'i Onaylayın",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "Emri iptal etmek istediğinizden emin misiniz ?",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "Aşağıdaki düğmeye tıklayarak 'EULA' ve 'Kullanım Şartları'nı okumuş ve kabul etmiş sayılırsınız",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Parolayı onayla",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "PIN kodunu onayla",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "Gizli Kelimeleri Onayla",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Bağlanıyor..",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "İptal",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Kişiyi Sil",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "Sil",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "{name} kişisini silmek istediğinizden emin misiniz ?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Vazgeç",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Düzenle",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Çık",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Değişiklikleri kaydetme ?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "Kişi bulunamadı",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Kaydet",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Kişi detayları",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "İsim",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Sözleşme",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Dönüştür",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "URL başlatılamadı",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "İçeri alınamıyor",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "Ticaret",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "CÜZDAN OLUŞTUR",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Kişi Ekle",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "PIN Kodu Oluştur",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Kur",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Kur",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Mevcut değer:",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Özelleştirilmiş gider",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "Özelleştirilmiş giderleri yalnızca ne yaptığınızdan emin olduğunuzda kullanın !",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Özelleştirilmiş gizli kelime kullanımı yeterince güvenli olmayabilir ve uygulama tarafından oluşturulan BIP39 uyumlu gizli kelimeler ya da özel anahtara (WIF) kıyasla daha kolay kırılabilmektedir. Riskleri kabul edip ne yaptığınızdan emin olduğunuzu tasdiklemek için aşağıdaki kutucuğa \"{iUnderstand}\" yazınız.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Tarih",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Cüzdan deşifre ediliyor",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Sil",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Devre dışı bırakmayı onayla",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "Kaldırmak istiyor musunuz",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "portföyünüzden mi? Eşleşmeyen tüm siparişler iptal edilecektir.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " ayrıca devre dışı bırakılacak",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Cüzdanı Sil",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Cüzdan siliniyor..",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "{coinName} işlem ücretini alın",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "{coinName} işlem ücretini gönder",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "işlem ücreti gönder işlem ücreti",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "işlem ücreti",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "detaylar",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Almanca",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Geliştirici",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "Bu koin DEX'te yoktur",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Ekran Görüntülerini/Önizlemeyi Devre Dışı Bırak",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Yasal Uyarı ve Kullanım Şartları",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Bitti",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "Uygulamayı kapatmayın. Daha fazla bilgi için dokunun...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "Tekrar sorma",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "Parola istemiyorum",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo dPoW Koruması",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Süre",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Kişiyi Düzenle",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "{abbr} adresini girin",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "Parola şifreleme kısmı boş kalamaz",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "Parola kısmı boş kalamaz",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "Kişi adı boş kalamaz",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "Cüzdan adı boş kalamaz",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enableNotificationsForActivationProgress": "Etkinleştirme ilerlemesiyle ilgili güncellemeleri almak için lütfen bildirimleri etkinleştirin.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Test Koinlerini Aktifleştir",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "Var",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "koininiz zaten ekli ve daha fazla etkinleştirmeye çalışıyorsunuz",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "Etkinleştirilebilir maksimum coin sayısı:",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": "Yenilerini eklemeden önce lütfen eskilerinden birkaçını kaldırın.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Çok fazla sayıda koin etkinleştirmeye çalışıyorsunuz",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Cüzdan şifreleniyor",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "İngilizce",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Yeni PIN kodunu giriniz",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Eski PIN kodunu giriniz",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Lütfen devam etmek için parolanızı giriniz",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "PIN Kodunuzu giriniz",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Gizli kelimelerinizi giriniz",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Önce satış miktarını girmelisiniz",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "Yeterli bakiye yok",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "Geçerli bir adres değil",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Segwiit adresler henüz desteklenmemektir",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "Yeteri kadar gaz ücreti yok, en az {gas} Gwei gerekli",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Hata, lütfen tekrar deneyiniz",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Hata, lütfen daha sonra deneyiniz",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "Değer çok yüksek ya da çok düşük",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "Lütfen veri giriniz",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Tahmini Toplam Değer",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Örnek: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Ucuz",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Pahalı",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "CEX'de",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Takas rasyosu:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "TAKAS",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Dışa Aktar",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Kişiler",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Lütfen şifrelenmiş dosyaya aktarılacak öğeleri seçiniz.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Dışa Aktar",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Notlar",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "Öğeler dışa başarıyla aktarıldı.",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Takaslar",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Dışa Aktar",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Başarısız",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Sahte bakiye tutarı:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Sıkça Sorulan Sorular",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Hata",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "{coin} musluğuna talep gönderiliyor..",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "MUSLUK",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Başarılı",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "Talep zaman aşımına uğradı",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Geri Bildirim Gönder",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Haberler",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Bir şey yok",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} haberleri",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Daha fazlası için..",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Bülten",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Haber Bülteni",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "Haber güncellemeleri alınamıyor",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "Haber güncellemeleri alınamıyor",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Haber bülteni güncellendi",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Zaten güncel",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "Ücretler en fazla {value} olmalıdır",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Hepsi",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Filtre",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Filtreleri temizle",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Başarısız",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "den itibaren",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Yapıcı Emir",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Coin al",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Coin sat",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Durum",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Başarılı",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Alıcı Emir",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "e kadar",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Alıcı/Yapıcı",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Parmak izi",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Bitiriliyor, lütfen bekleyin",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "QR Kodu Bulundu",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Fransızca",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "Gönderici",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} gideri",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "Gaz ücreti limiti",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Lütfen {coin} koinini aktifleştirin.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "Gaz ücreti",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "Normal PIN koruması aktif değil.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen PIN korumasını aktifleştirin.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Önemli: Devam etmeden önce gizli kelimelerinizi güvenli bir şekilde yedekleyin !",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "İşlem alınıyor, lütfen bekleyin",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Portföye git",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Gwei en fazla {value} olmalıdır",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "Yardım",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Yardım ve Destek",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Bakiyeleri gizle",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Parolayı Onayla",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Parola Oluştur",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Mevcut parola",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Parolanızı girin",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Gizli kelimelerinizi girin",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Cüzdanınızı adlandırın",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Parola",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "geçmiş",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "sa",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Macarca",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "İçeri Al",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Geçersiz şifre ya da hatalı dosya",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "İçeri alınacaklar:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Dosya bulunamadı",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Geçersiz takas bilgisi. Lütfen takas durumunu gösteren geçerli bir JSON dosyası ekleyin.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "İçeri Al",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Lütfen içeri alınacak şifrelenmiş dosyayı seçin.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Açılıyor..",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Lütfen içeri alınacak düz metin takas dosyasını seçin.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "İptal",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "Tamam",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Parola",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Tek Takas İçeri Al",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Takas İçeri Al",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Bazı öğeler atlandı.",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "Öğeler başarıyla içeri alındı.",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "Takas içeri alma başarısız oldu.",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Json dosyası çözülürken hata oluştu.",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "İçeri Al",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Gelen {coinName} txs koruma ayarları",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Güvenlı bir parola kullanın ve onu, uygulamayı kullandığınız cihazda saklamayın.",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "Takas talebi geri alınamaz ve bu nihai bir işlemdir !",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "Bu işlem 60 dakikaya kadar sürebilir. Uygulamayı KAPATMAYINIZ !",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Cüzdanınızın güvenlik tehditlerine karşı şifrelenebilmesi için bir parola ayarlamalısınız.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} bakiyesi, alım satım işlem ücretlerini karşılamaya yetmiyor.",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "Bu işlem için gereken en az hacim şu kadardır",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Yetersiz hacim",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Yenile",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "İnternet Bağlantısı Yeniden Sağlandı",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "Takasa devam edilemiyor",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Detaylar",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} mevcut değil :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "Anladım",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Japonca",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Koreli",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Diller",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Son İşlemler",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Yasal",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "Daha az",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗Dikkat! {coinName} piyasasının 24 saatlik işlem hacmi 10 bin dolardan az!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "Sınır en fazla {value} olmalıdır",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "Yükleniyor..",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Emir defteri yükleniyor...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "Ekran kilitli",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "Lütfen doğrulayın !",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "Giriş",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Çıkış",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Kapanışta Çıkış Yap",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Çıkış Ayarları",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "Çıkmak istediğinizden emin misiniz ?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "dakikalar",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "bir emir girin",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Yapıcı Emri",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Emri iptal et",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "de oluşturuldu",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Almak",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "Emir ID",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Bu emirle herhangi bir takas başlamadı",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Fiyat",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Sat",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "Bu emirle takas başladı",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Yapıcı Emri detayları",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Yapıcı Emri",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Pazar",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "Tablo",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Derinlik",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "Soru bulunamadı",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "Teklif bulunamadı",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "EMİR DEFTERİ",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Emir Detayları",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "FİYAT",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Lütfen koinleri seçiniz",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Piyasalar",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "PİYASALAR",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "Parolalar uyuşmalı",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Değiştir",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Normal PIN ve Kamuflajlı PIN kodlarınız aynı.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen Kamuflajlı PIN kodunuzu değiştiriniz.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "Geçersiz PIN",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "MAKSİMUM",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Maksimum Emir Hacmi",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Haberler",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "GÖZAT",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "BÜLTENE GÖZAT",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "Yazar:",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "KAYDEDİLMİŞ BİR MAKALENİZ YOK",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "KAYDEDİLDİ",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Hafıza",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Birleştir",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Birleştirilmiş değer:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "ms",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "DK",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Uyarı: iOS'ta uygulamanın simge durumuna küçültülmesi etkinleştirme sürecini sonlandıracaktır.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "En düşük emir hacmi",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "dk",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "{coinName} için yapılabilecek en düşük satış hacmi: {number}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "{coinName} için yapılabilecek en düşük alım hacmi: {number}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "En düşük emir için: {buyCoin} {buyAmount}\n({sellCoin} {sellAmount})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "{coinName} için en düşük satım miktarı: {number}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "{minValue} {coin}'den büyük olmalı",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Satış miktarından düşük olmalı",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Gereken en düşük hacim",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "hacim",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Lütfen artık hücresel veri kullandığınızı ve {appName} P2P ağına katılımınızın internet trafiğini tükettiğini unutmayın. Hücresel veri planınız maliyetliyse bir WiFi ağı kullanmak daha iyidir.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Daha fazla bilgi",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "Daha Fazla",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Önce {coin}'i etkinleştirin ve bakiyeyi tamamlayın",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Miktar",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Koin",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Sat",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "İptal",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Onayla",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "{number} Sipariş oluştur:",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Oluştur",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Emir",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Emirler",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "tutar",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "İptal",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Lütfen almak istediğiniz itibari para miktarını giriniz:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Otomatik doldur",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Devam etmeden önce lütfen hataları gideriniz",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Geçersiz miktar",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Geçersiz satış miktarı",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "İşlem masrafını ödemeye yetecek {coin} yok. En az {fee} {coin} olmalı.",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin} bakiyesi yetersiz",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "En fazla satış miktarı:",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "En az alım miktarı:",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "En satış miktarı:",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Al:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Sat:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Çoklu",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Alınacak Miktar",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "CEX/Ücret",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Ağ ücreti",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "yeni hesap",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Yeni Hesap",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Haber akışı",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Yeni değer:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "sonraki",
-    "@next": {
-        "type": "text"
-    },
-    "no": "Hayır",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "Şimdilik bir haber yok. Lütfen daha sonra tekrar deneyiniz.",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "Koin bulunamadı",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Fon yok",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "Fon mevcut değil. Lütfen para yatırın.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "İnternet Bağlantısı Yok",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "Bir öğe seçilmedi",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "Bir öğe seçilmedi",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "Eşleşen sipariş bulunamadı",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Hiçbiri",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "Girilen değer rakam olmalı",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Uygun bir {coinName} emri bulunmuyor - bir emir girmeyi deneyin veya daha sonra yeniden kontrol edin.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Emir oluşturmak için tıklayın",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "Emir yok, lütfen ticarete gidin.",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "Alınabilecek bir ödül yok",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "Alabileceğiniz bir ödül mevcut değil - 1 saat sonra yeniden deneyin.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "Böyle bir koin yok",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "Geçmiş yok.",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "İşlem için yeteri kadar {coin} yok !",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "Takas masrafını karşılayacak bakiye bulunmuyor - daha küçük tutar deneyin",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Eşleşmiş bir emir tekrardan iptal edilemez.",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Not Ekle",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Not",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Bir şey bulunamadı",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "{sell}/{buy} takası başarıyla tamamlandı",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "Takas tamamlandı",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy} takası başarısız oldu",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "Takas başarısız",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy} takası başladı",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Yeni takas başladı",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Takas durumu değişti",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy} takas zaman aşımına uğradı",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Takas zaman aşımına uğradı",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "{coin} işlemi aldınız!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Gelen işlem",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "İşlem Yok",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} Varlıklar",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "Resmi basın açıklaması",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Tamam",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Sil",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Eski kayıtlar",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Boşluk kullanıldı",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Hata Mesajını Aç",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "İsteğe bağlı",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "Az",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "Daha",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Tüm {coin} emirleri iptal edilecek",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Emir oluşturuldu",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Emir başarıyla oluşturuldu",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Adres",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "İptal",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "Ucuz: CEX + %{delta}",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "Pahalı: CEX + %{delta}",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "için",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "CEX'de",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "en az",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Fiyat",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Al",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Seç",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Satışlar",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Ayrıntıları tek dokunuşla açın ve Uzun dokunuşla sipariş et'i seçin",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Harca",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Detaylar",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% tamamlandı",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Emir eşleşti",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Emir eşleşiyor",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "emirler",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Açık",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "Geçmiş",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "({coin}) miktarı",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "({coin}) fiyatı",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "Toplam ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Emir",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Bilinmeyen Türde Emir",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Üstüne yaz",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "Bu sizin kendi emriniz !",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Bakiyeden ödendi:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Alınan miktardan ödendi:",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Ödendi",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "Parolanız en az 12 karakterden oluşurken en az; bir büyük harf, bir küçük harf ve bir sembol içermelidir.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Öde",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "Bu işlemi kabul ediyor musunuz ?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "Adrese",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "Miktar:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Koin:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "İptal",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Ödeme Talep Edildi",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} aktif değil. Lütfen aktifleştirip öyle deneyiniz.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Emrinizi girin",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "Tam seste oynat",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Lütfen bir Koin Ekleyiniz",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Yeniden denemek için lütfen uygulamayı yeniden başlatın ya da aşağıdaki düğmeye basınız.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Portföy",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Komodo tarafından geliştirilmiştir",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "fiyat",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Gizli Kelime",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Gizli Kelimeler",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Onaylar",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Özel koruma seçenekleri kullan.",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "Kapalı",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "Açık",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Dikkat ! Bu takas dPoW koruması altında değildir.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Açık Adres",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "QR Kod Tarayıcı",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "Gizli kelimelerimi kaydediyor musunuz ?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "Komodo Wallet'ı hangi cihazlarda kullanabilirim ?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "{appName}'te alım satım yapmanın diğer DEX'lerdekinden ne gibi farkları vardır ?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "Takas işlemleri ne kadar sürmektedir ?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "Takas işlemi boyunca çevrimiçi olmam mı gerekir ?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "{appName}'te işlem ücretleri nasıl hesaplanmaktadır ?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "Kullanıcılara destek sunuyor musunuz ?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "Uygulamanın kullanılamadığı ülkeler var mı ?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "Komodo Wallet'ın arkasında kimler var ?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "{appName} üzerinde kendi beyaz etiketli değişimimi geliştirmem mümkün mü?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "Bu yeni bir dönem! 'AtomicDEX' olan ismimizi resmi olarak 'Komodo Wallet' olarak değiştirdik.",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "AL",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Al",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Çevrimdışı bir şekilde saklamanızı öneririz.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Devre dışı bırak",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Talep Edilen Alım Satım",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "TEMİZLE",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Geri Yükleme Formu",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "GERİ YÜKLE",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Tüm koinleri aktifleştirmeyi tekrar deniyor..",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Hepsini aktifleştirmeyi tekrar dene",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Ödülünüzü alın",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Vazgeç",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "İşlem sürmekte",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "işleniyor",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXO miktarı 10 KMD'den az",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Henüz 1 saat geçmedi",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 saat",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "Tamam",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Ödül durumu:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "KMD aktif kullanıcı ödülleri hakkında daha fazla bilgi edinin",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Al",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "Başarılı ! {amount} KMD geldi.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "İtibari para",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "KMD Ödülleri",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Durum",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Kalan zaman",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Ödül bilgisi:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO amt,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} gün",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}sa {minutes}dk",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}dk",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "Ödül bilgisi",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Rusça",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Birleştirilmiş kaydet",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "Devam etmek için aşağı kaydırın...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Bir koin ara",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Tüm AVAX tokenlerini seç",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Tüm BEP tokenlerini seç",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Hepsini seç Cosmos Ağı",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Tüm ERC tokenlerini seç",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Tüm ETC tokenlerini seç",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Tüm Fantom tokenlerini seç",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Tüm HecoChain tokenlerini seç",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Tüm Harmony tokenlerini seç",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Tüm İris Ağını seç",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Tüm Kucoin tokenlerini seç",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Tüm Moonriver tokenlerini seç",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Tüm Polygon tokenlerini seç",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Tüm QRC tokenlerini seç",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Tüm SmartBCH tokenlerini seç",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Tüm SLP belirteçlerini seçin",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Tüm SmartChain koinlerini seç",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Tüm test koinlerini seç",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Tüm Ubiq koinlerini seç",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Tüm UTXO koinlerini seç",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Tüm ZHTLC paralarını seç",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Kayan Yazı Ara",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "s",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Güvenlik",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "Gizli Kelimeler",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Yeni Gizli Kelimeleriniz",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "{amount} adet emri görmek için tıklayın",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "İşlem Geçmişini Görüntüle",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Koin seçin",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Portföyünüze eklemek istediğiniz koinleri seçin.",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Koin etkinleştir:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "ALMAK istediğiniz koini seçin",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "SATMAK istediğiniz koini seçin",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Seçili emir:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Dosya seç",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Dili Seç",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Ödeme Yönteminizi Seçin",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Sat",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan satmak üzeresiniz",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "GÖNDER",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Silmek istediğine emin misin",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "cüzdan?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Eğer eminseniz",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "daha sonra cüzdanınızı kurtarabilmeniz için",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "gizli kelimelerinizi kaydedin.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Diller",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Ayarlar",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "PAROLA BELİRLE",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "Paylaş",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "{coinName} adresim:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Adresi Göster",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Detayları Göster",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "{maxCount} siparişten {count} tanesi gösteriliyor.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "EMİRLERİMİ GÖSTER",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Parola ile giriş yap",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "Parolayı mı unuttunuz ? Gizli kelimelerinizle giriş yapın.",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Basit",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Aktifleştir",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Lütfen alınacak {coin} adetini girin",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Satın al",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Kapat",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "Maksimum aktif jeton sayısı {maxCoins}'dir. Lütfen bazılarını devre dışı bırakın.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} koini aktif değil !",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Al",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Lütfen satmak için {coin} miktarı girin",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Sat",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Gönder",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Daha az göster",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Daha fazla göster",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "{coin} aktifleştirilemedi",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Geç",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Kapat",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Ses",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Lütfen bir mp3 ya da waw dosyası seçin. {description}'de ses dosyalarını oynatacağız.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "{description}'de oynatıldı.",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Sesler",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Anladım, bunu tekrar gösterme",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Ses",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Ses seçenekleri",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "Takas boyunca ve açık bir yapıcı emriniz varken bazı sesli bilgilendirmeler duyacaksınız.\nPürüzsüz bir takas için her iki tarafın da işlem boyunca çevrimiçi olması gerekmektedir ve sesli bildirimler buna yardımcı olmaktadır.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Kendi özelleştirilmiş sesli bildirimlerinizi uygulamanın ayarlar bölümünden etkinleştirebileceğinizi unutmayın.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "İspanyolca",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Takası Başlat",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Adım",
-    "@step": {
-        "type": "text"
-    },
-    "success": "Başarılı !",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Destek",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Herhangi bir sorunuz varsa veyahut {appName} uygulamasıyla ile ilgili teknik bir hata bulduğunuzu düşünüyorsanız bunu ekibimize bildirebilir ve destek alabilirsiniz.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "takas",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Mevcut",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "TAKAS DETAYLARINI ONAYLA",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "Yaklaşık",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "Takas başarısız",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Lütfen önce {coin} ve kontör bakiyesini etkinleştirin",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük. {amount} {coin} gerekli.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Takas devam ediyor",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "İşlem detayları",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "Takas başladı",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Başarılı Takas",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Toplam",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "Takas UUID",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Temayı Değiştir",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ZHTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Alıcı Emri",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Alıcı Emri",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Zaman Aşımı",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "PAROLA OLUŞTUR",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Emir seçildi",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "Alıcı",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "Adrese:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "Var",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "varlıklar etkinleştirildi. Atkif edilebilecek koin limiti:",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": "Yenilerini eklemeden önce lütfen eskilerden birkaçını kaldırın",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Çok fazla koin aktifleştirildi",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Toplam Masraflar",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "ALIM SATIM",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "TAKAS TAMAMLANDI !",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "ALIM SATIM DETAYLARI",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Alım satım işlem giderleri hesaplanamadı",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "Alım satım işlem gideri:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Alım Satım Modu:",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "İşlem Adresi",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "İşlem Gizli",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Bu işlem olası bir kimlik avı girişimi nedeniyle gizlendi.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "Bazı yeni koinler etkileştirilemedi ise uygulamayı tekrar başlatmayı deneyiniz.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Türkçe",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Blok",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Onaylar",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "ONAYLANDI",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Ücret",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "İşlem ücreti",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "İşlem numarası",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Kalan işlem: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Çok fazla istek.\nİşlem geçmişi istekleri sınırı aşıldı.\nLütfen daha sonra tekrar deneyiniz.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "onaylanmamış",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Ukrayna",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "kilidi aç",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Fonların Kilidini Açın",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "{amnt} fonun kilidi başarıyla kaldırıldı - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "harcanamaz",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Yeni sürüm mevcut",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Güncellemeler kontrol ediliyor..",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "{version} sürümünü kullanmaktasınız.",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Yeni sürüm mevcut. Lütfen güncelleyiniz.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "Güncel {version} sürümü mevcut. Lütfen güncelleyiniz.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Güncelleme mevcut",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Şimdilik atla",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "Komodo Wallet güncellemeleri",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Güncelle",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Son sürüm yüklü",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "Taranan ödeme talebi için",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "yeterli bakiye yok.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Yetersiz bakiye",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Değer:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "sürüm",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Tarayıcı",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Gizli ve Özel Kelimeler",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Hacim",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "Bu cüzdan adı zaten kullanımda",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "Cüzdan adı en fazla 40 karakter içerebilir",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Sadece cüzdan",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "Dikkat !",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Tamam",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Dikkat ! Bu kayıt defteri özel durumlarda, başarısız takaslardan kalan koinlerin harcanmasına sebep olabilecek hassas bilgiler içerebilir.",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "{coinAbbr} koinini etkinleştiremedik.",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "{coinAbbr} koinini etkinleştiremedik.\nLütfen uygulamayı yeniden başlatıp tekrar deneyiniz.",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "Komodo Wallet mobil yerleşik üçüncü nesil DEX işlevselliği ve daha fazla özellikleri ile yeni nesil bir çoklu koin cüzdanıdır.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "HADİ AYARLAYALIM !",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "HOŞ GELDİNİZ",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "cüzdan",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "Tamamlandığında portföy ekranına yönlendirileceksiniz.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Bu biraz zaman alacak ve uygulamanın ön planda tutulması gerekiyor.\nEtkinleştirme devam ederken uygulamayı sonlandırmak sorunlara yol açabilir.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Çek",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "{appName}'in kameraya erişimi engellenmiş.\nQR kod taramasını yapabilmek için lütfen telefon ayarlarınızdan kamera erişimine izin veriniz.",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Erişim Engellendi",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Çekimi Onayla",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "{amount} adet {coinName} ÇEK",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "QR kodlu bir ödemeyi",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "taramaya çalışıyorsunuz",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "fakat çekim ekranındasınız",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Yanlış koin",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "Parola eşleşmiyor. Lütfen tekrar deneyin.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Evet",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Gönderiyorsunuz:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "mevcut bir siparişle eşleşmeye çalışan yeni bir siparişiniz var",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "devam eden aktif bir takasınız var",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "yeni siparişlerin eşleşebileceği bir siparişiniz var",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "Cüzdanınız",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "{amount} adet {coin} alacaksınız",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Alacağınız:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "tr",
+  "accepteula": "EULA'yı Kabul Et",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "ŞARTLARI ve KOŞULLARI Kabul Et",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Biyometrik korumayı etkinleştir",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "PIN korumasını etkinleştir",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "{protocolName} paraları etkinleştirilsin mi?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "{coinName} etkinleştiriliyor",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName} Aktivasyonu",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} Etkinleştirme Devam Ediyor",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Aktif",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Koin etkinleştir",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} başarıyla etkinleştirildi !",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Adres Ekle",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Adres defteri",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "Adres defteri boş",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Yalnızca {title} adresli kişiler gösteriliyor",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Adres Defteri",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "{abbr} etkinleştirilmediği için {abbr} adresine para gönderemezsiniz. Lütfen portföye gidiniz.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Bir şey bulunamadı",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Koin Seçin",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Alıcı adresi",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Gelişmiş",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "Hepsi",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Kişisel kelimeleri kullan",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "Cüzdanınız geçmiş işlemleri gösterecektir. Tüm bloklar indirilip taranacağından bu, önemli miktarda depolama alanı ve zaman alacaktır.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "Zaten mevcut",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Tutar",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Satılacak Tutar",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "Hayır ! Komodo Wallet, gözetimsiz bir cüzdandır. Özel kelimeleriniz, gizli kelimeleriniz ve PIN kodunuz dahil hiçbir hassas bilgiyi kaydetmiyoruz. Bu bilgiler sadece kullanıcının cihazında tutulmaktadır ve başka bir yere gitmez. Bu sayede koin ve tokenlerinizin tüm kontrolü sizdedir.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName}, hem Android hem de iPhone'da mobil cihazlar için ve <a href=\"https://komodoplatform.com/\">Windows, Mac ve Linux işletim sistemlerinde</a> masaüstü için kullanılabilir.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Diğer DEX cüzdanlar genellikle aynı miktar koin ile tek bir alım satım emri vermeye izin verir, ara token kullanır, en önemlisi de tek bir blokzincirin koinlerinin alım satımına olanak sağlar.\n\n{appName} ise birbirinden farklı iki blokzincir ağı arasında ara token kullanmadan doğrudan takas yapmaya imkân sağlar. {appName} 'te aynı miktar koin ile birden fazla alım satım emri verebilirsiniz. Mesela 0.1 BTC ile KMD, QTUM ve VRSC için ayrı ayrı alım emirleri verebilirsiniz ve bunlardan birinin tamamlanması halinde diğerleri kendiliğinden iptal olmuş olurlar.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Her bir takasın tamamlanma sürecini etkileyen birkaç etken vardır. Takas edilen koinlerin bağlı olduğu blokzincirlerin blok çıkarım zamanları (Bitcoin en yavaşıdır) bunda etkilidir. Bunun yanında kullanıcılar, takas öncesinde güvenlik seçeneklerini özelleştirebilir. Mesela bir KMD takasına başlamadan evvel Komodo Wallet'da işlem için 3 onayın yeterli olduğu seçeneği işaretlediğinizde takas süresi <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">noterizasyon</a> eklenmeyeceğinden kısalacaktır.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Evet, takas boyunca uygulamanız açık ve internetinizin de (anlık kesintilerde bir sıkıntı yoktur) bağlı olması gerekmektedir. Aksi halde; eğer yapıcı emri (maker) veren siz iseniz takasın iptal olma durumu, alıcı emri (taker) veren iseniz de koinlerinizi kaybetme riski ortaya çıkar. Komodo Wallet protokolünde takası yapan her iki tarafın da işlem boyunca çevrimiçi olması ve takasın başarılı olması için gereklidir.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "{appName}'te alım satım yaparken bilinmesi gereken iki tür işlem ücreti vardır.\n\n1. {appName}, alıcı emirlerinden işlem başına yaklaşık olarak %0.13 (takriben 777'nin 1'i kadar, fakat bu da 0.0001'den az olmamak kaydıyla) işlem ücreti alırken, yapıcı emirlerinden herhangi bir ücret alınmamaktadır.\n\n2. Hem yapıcı hem de alıcı emir sahiplerinin ödemesi gerekli olan ve takasın gerçekleştiği blokzincirlerin standart ağ işlem ücretleri.\n\nAğ işlem ücretleri, takas yapmak istediğiniz paritelerin kendi işleyişlerine göre değişiklik göstermektedir.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "Evet! {appName}, <a href=\"{link}\">{appCompanyShort} {name}</a> aracılığıyla destek sunar. Ekip ve topluluk her zaman yardımcı olmaktan mutluluk duyar!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "Hayır ! {appName} tamamıyla merkeziyetsizdir ve kullanıcıların uygulamaya erişimi başkaları tarafından sınırlandırılamaz.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName}, {appCompanyShort} takımı tarafından geliştirilmiştir. {appCompanyShort}, koin takası, Geciktirilmiş İş Kanıtı (dPoW), birlikte çalışabilen çoklu zincir mimarisi gibi yenilikçi blokzincir çözümleri geliştiren köklü bir platformdur.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "Kesinlikle! Daha fazla ayrıntı için <a href=\"https://developers.komodoplatform.com/\">geliştirici belgelerimizi</a> okuyabilir veya ortaklık sorularınız için bizimle iletişime geçebilirsiniz. Belirli bir teknik sorunuz mu var? {appName} geliştirici topluluğu her zaman yardıma hazır!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Alkış",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "EMİN MİSİNİZ?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "Takas başarısız oldu",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "takas tamamlanmak üzere",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "Doğrula",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Tekrar aktivasyon işlemi bittiğinde doğrudan portföy sayfasına yönlendirileceksiniz.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "maksimum hacim",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "geri",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Yedekle",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "{coinName1}/{coinName2} temel alınarak",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "Telefonunuzun bataryası güvenli bir takası tamamlayamayacak ({batteryLevelCritical}%) kadar düşük. Lütfen önce şarja takıp sonra tekrar deneyiniz.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "Telefonunuzun bataryası %{batteryLevelLow}'den daha az. Lütfen telefonunuzu şarj ediniz.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Telefonunuz batarya tasarruf modunda. Lütfen bu modu devre dışı bırakın ya da başvuru uygulamasını arka plana KOYMAYIN. Aksi halde uygulama, işletim sisteminiz tarafından kapatılabilir ve devam etmekte olan takasınız varsa başarısız olabilir.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "Mevcut en iyi fiyat",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Komodo Üzerinde Yapılmıştır",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Komodo Üzerinde Yapılmıştır",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Al",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "Eşleşme olmazsa Yapıcı Emrine çevir",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Takas işlendi, lütfen bekleyiniz.",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "Emir eşleşmesi devam ediyor, lütfen {seconde} saniye kadar bekleyiniz.",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan almak üzeresiniz.",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "Kamuflajlı PIN ve Biyometrik koruma aynı anda etkinleştirilemez.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Kamuflajlı PIN ve Biyometrik Koruma Çakışması",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Kamuflajlı PIN kodunuzu değiştirin",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Kamuflajlı PIN kodu oluşturun",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Uygulamanın kilidini Kamuflaj PIN'i ile açarsanız, sahte bir DÜŞÜK bakiye gösterilecek ve Kamuflaj PIN'i yapılandırma seçeneği ayarlarda GÖRÜNMEYECEK",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "Geçersiz Kamuflajlı PIN",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Kamuflajlı PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "Kamuflajlı PIN bulunamadı",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Kapalı",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "Açık",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "Kamuflajlı PIN kaydedildi",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Kamuflajlı PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Yeni bir kamuflajlı PIN girin",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Kamuflajlı PIN Kurulumu",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Kamuflajlı PIN Kurulumu",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "İptal",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Etkinleştirmeyi İptal Et",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "İptal",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Emri İptal Et",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Bir hata oluştu, lütfen daha sonra tekrar deneyiniz.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Tamam",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "Ön tanımlı bir koindir. Ön tanımlı koinler kaldırılamaz",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "Kaldırılamaz",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "Bu oynatılamıyor",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEX rasyosu",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "CEX verisi",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Bu simgeyle işaretlenen piyasa verileri (fiyatlar, çizelgeler vb.) üçüncü taraf kaynaklardan (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "CEX Oranı",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "PIN kodunu değiştir",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Güncellemeleri kontrol et",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Ödeme",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "Gizli kelimeleri kontrol edin",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "DEVAM",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "GERİ DÖN VE KONTROL ET",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "{index} kelimesini giriniz.",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "Gizli kelimeleriniz çok önemlidir, bu yüzden onları doğru kaydettiğinizden emin olmak istiyoruz. Cüzdanınızı istediğiniz zaman kolayca geri yükleyebilmeniz için gizli kelimeleriniz hakkında size şimdi üç farklı soru soracağız.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "Gizli kelimeleriniz arasından {index} olanı hangisidir ?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "GİZLİ KELİMELERİZİ BİR KEZ DAHA KONTROL EDİNİZ",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Çince",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "talep et",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "KMD ödülünüzü alın",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Görmek için tıklayın",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "Panoya kopyalandı",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "Panoya kopyala",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Kapat",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Hata mesajını kapat",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Ön izlemeyi kapat",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Kod:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Maksimum varlık sayısını seçtiniz",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "{protocolName} parası etkinleştirildi",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName} parası başarıyla etkinleştirildi",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "{protocolName} parası etkinleştirilmedi",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Temizle",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "Aktif koin yok",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Koin Seç",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "Yakında...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "TX detayları yakında !",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "Detaylar yakında !",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "komisyon ücreti",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "ortalama ile karşılaştırıldığında 24 saatlik CEX fiyatı",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "CEX ile kıyaslanınca",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "Cüzdanınız ayarlanıyor, lütfen bekleyiniz..",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "Onayla",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Kamuflajlı PIN'i Onaylayın",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "Emri iptal etmek istediğinizden emin misiniz ?",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "Aşağıdaki düğmeye tıklayarak 'EULA' ve 'Kullanım Şartları'nı okumuş ve kabul etmiş sayılırsınız",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Parolayı onayla",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "PIN kodunu onayla",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "Gizli Kelimeleri Onayla",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Bağlanıyor..",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "İptal",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Kişiyi Sil",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "Sil",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "{name} kişisini silmek istediğinizden emin misiniz ?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Vazgeç",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Düzenle",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Çık",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Değişiklikleri kaydetme ?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "Kişi bulunamadı",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Kaydet",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Kişi detayları",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "İsim",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Sözleşme",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Dönüştür",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "URL başlatılamadı",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "İçeri alınamıyor",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "Ticaret",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "CÜZDAN OLUŞTUR",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Kişi Ekle",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "PIN Kodu Oluştur",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Kur",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Kur",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Mevcut değer:",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Özelleştirilmiş gider",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "Özelleştirilmiş giderleri yalnızca ne yaptığınızdan emin olduğunuzda kullanın !",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Özelleştirilmiş gizli kelime kullanımı yeterince güvenli olmayabilir ve uygulama tarafından oluşturulan BIP39 uyumlu gizli kelimeler ya da özel anahtara (WIF) kıyasla daha kolay kırılabilmektedir. Riskleri kabul edip ne yaptığınızdan emin olduğunuzu tasdiklemek için aşağıdaki kutucuğa \"{iUnderstand}\" yazınız.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Tarih",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Cüzdan deşifre ediliyor",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Sil",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Devre dışı bırakmayı onayla",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "Kaldırmak istiyor musunuz",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "portföyünüzden mi? Eşleşmeyen tüm siparişler iptal edilecektir.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " ayrıca devre dışı bırakılacak",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Cüzdanı Sil",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Cüzdan siliniyor..",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "{coinName} işlem ücretini alın",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "{coinName} işlem ücretini gönder",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "işlem ücreti gönder işlem ücreti",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "işlem ücreti",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "detaylar",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Almanca",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Geliştirici",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "Bu koin DEX'te yoktur",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Ekran Görüntülerini/Önizlemeyi Devre Dışı Bırak",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Yasal Uyarı ve Kullanım Şartları",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Bitti",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Uygulamayı kapatmayın. Daha fazla bilgi için dokunun...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "Tekrar sorma",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "Parola istemiyorum",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo dPoW Koruması",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Süre",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Kişiyi Düzenle",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "{abbr} adresini girin",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "Parola şifreleme kısmı boş kalamaz",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "Parola kısmı boş kalamaz",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "Kişi adı boş kalamaz",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "Cüzdan adı boş kalamaz",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Yine de {remas} özelliğini etkinleştirebilirsiniz, Seçilen: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Etkinleştirme ilerlemesiyle ilgili güncellemeleri almak için lütfen bildirimleri etkinleştirin.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Test Koinlerini Aktifleştir",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "Var",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "koininiz zaten ekli ve daha fazla etkinleştirmeye çalışıyorsunuz",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "Etkinleştirilebilir maksimum coin sayısı:",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": "Yenilerini eklemeden önce lütfen eskilerinden birkaçını kaldırın.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Çok fazla sayıda koin etkinleştirmeye çalışıyorsunuz",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Cüzdan şifreleniyor",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "İngilizce",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Yeni PIN kodunu giriniz",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Eski PIN kodunu giriniz",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Lütfen devam etmek için parolanızı giriniz",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "PIN Kodunuzu giriniz",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Gizli kelimelerinizi giriniz",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Önce satış miktarını girmelisiniz",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "Yeterli bakiye yok",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "Geçerli bir adres değil",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Segwiit adresler henüz desteklenmemektir",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "Yeteri kadar gaz ücreti yok, en az {gas} Gwei gerekli",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Hata, lütfen tekrar deneyiniz",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Hata, lütfen daha sonra deneyiniz",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "Değer çok yüksek ya da çok düşük",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "Lütfen veri giriniz",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Tahmini Toplam Değer",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Örnek: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Ucuz",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Pahalı",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "CEX'de",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Takas rasyosu:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "TAKAS",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Dışa Aktar",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Kişiler",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Lütfen şifrelenmiş dosyaya aktarılacak öğeleri seçiniz.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Dışa Aktar",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Notlar",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "Öğeler dışa başarıyla aktarıldı.",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Takaslar",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Dışa Aktar",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Başarısız",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Sahte bakiye tutarı:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Sıkça Sorulan Sorular",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Hata",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "{coin} musluğuna talep gönderiliyor..",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "MUSLUK",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Başarılı",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "Talep zaman aşımına uğradı",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Geri Bildirim Gönder",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Haberler",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Bir şey yok",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} haberleri",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Daha fazlası için..",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Bülten",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Haber Bülteni",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "Haber güncellemeleri alınamıyor",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "Haber güncellemeleri alınamıyor",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Haber bülteni güncellendi",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Zaten güncel",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "Ücretler en fazla {value} olmalıdır",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Hepsi",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Filtre",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Filtreleri temizle",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Başarısız",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "den itibaren",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Yapıcı Emir",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Coin al",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Coin sat",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Durum",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Başarılı",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Alıcı Emir",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "e kadar",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Alıcı/Yapıcı",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Parmak izi",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Bitiriliyor, lütfen bekleyin",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "QR Kodu Bulundu",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Fransızca",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "Gönderici",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "Genel anahtarınızla ilişkili etkinleştirme sonrasında gelecekte yapılacak işlemleri senkronize edeceğiz. Bu en hızlı seçenektir ve en az depolama alanını kaplar.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} gideri",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "Gaz ücreti limiti",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Lütfen {coin} koinini aktifleştirin.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "Gaz ücreti",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "Normal PIN koruması aktif değil.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen PIN korumasını aktifleştirin.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Önemli: Devam etmeden önce gizli kelimelerinizi güvenli bir şekilde yedekleyin !",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "İşlem alınıyor, lütfen bekleyin",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Portföye git",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei en fazla {value} olmalıdır",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Yardım",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Yardım ve Destek",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Bakiyeleri gizle",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Parolayı Onayla",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Parola Oluştur",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Mevcut parola",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Parolanızı girin",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Gizli kelimelerinizi girin",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Cüzdanınızı adlandırın",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Parola",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "geçmiş",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "sa",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Macarca",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "İçeri Al",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Geçersiz şifre ya da hatalı dosya",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "İçeri alınacaklar:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Dosya bulunamadı",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Geçersiz takas bilgisi. Lütfen takas durumunu gösteren geçerli bir JSON dosyası ekleyin.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "İçeri Al",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Lütfen içeri alınacak şifrelenmiş dosyayı seçin.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Açılıyor..",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Lütfen içeri alınacak düz metin takas dosyasını seçin.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "İptal",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "Tamam",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Parola",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Tek Takas İçeri Al",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Takas İçeri Al",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Bazı öğeler atlandı.",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "Öğeler başarıyla içeri alındı.",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "Takas içeri alma başarısız oldu.",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Json dosyası çözülürken hata oluştu.",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "İçeri Al",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Gelen {coinName} txs koruma ayarları",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Güvenlı bir parola kullanın ve onu, uygulamayı kullandığınız cihazda saklamayın.",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "Takas talebi geri alınamaz ve bu nihai bir işlemdir !",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "Bu işlem 60 dakikaya kadar sürebilir. Uygulamayı KAPATMAYINIZ !",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Cüzdanınızın güvenlik tehditlerine karşı şifrelenebilmesi için bir parola ayarlamalısınız.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} bakiyesi, alım satım işlem ücretlerini karşılamaya yetmiyor.",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "Bu işlem için gereken en az hacim şu kadardır",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Yetersiz hacim",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Yenile",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "İnternet Bağlantısı Yeniden Sağlandı",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Geçersiz {coin} adresi",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "Takasa devam edilemiyor",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Detaylar",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} mevcut değil :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "Anladım",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Japonca",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Koreli",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Diller",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Son İşlemler",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Yasal",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "Daha az",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗Dikkat! {coinName} piyasasının 24 saatlik işlem hacmi 10 bin dolardan az!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "Sınır en fazla {value} olmalıdır",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Yükleniyor..",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Emir defteri yükleniyor...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "Ekran kilitli",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "Lütfen doğrulayın !",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "Giriş",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Çıkış",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Kapanışta Çıkış Yap",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Çıkış Ayarları",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "Çıkmak istediğinizden emin misiniz ?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "dakikalar",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "bir emir girin",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Yapıcı Emri",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Emri iptal et",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "de oluşturuldu",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Almak",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "Emir ID",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Bu emirle herhangi bir takas başlamadı",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Fiyat",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Sat",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "Bu emirle takas başladı",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Yapıcı Emri detayları",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Yapıcı Emri",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Pazar",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "Tablo",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Derinlik",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "Soru bulunamadı",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "Teklif bulunamadı",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "EMİR DEFTERİ",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Emir Detayları",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "FİYAT",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Lütfen koinleri seçiniz",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Piyasalar",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "PİYASALAR",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "Parolalar uyuşmalı",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Değiştir",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Normal PIN ve Kamuflajlı PIN kodlarınız aynı.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen Kamuflajlı PIN kodunuzu değiştiriniz.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "Geçersiz PIN",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "MAKSİMUM",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Maksimum Emir Hacmi",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Haberler",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "GÖZAT",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "BÜLTENE GÖZAT",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "Yazar:",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "KAYDEDİLMİŞ BİR MAKALENİZ YOK",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "KAYDEDİLDİ",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Hafıza",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Birleştir",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Birleştirilmiş değer:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "ms",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "DK",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Uyarı: iOS'ta uygulamanın simge durumuna küçültülmesi etkinleştirme sürecini sonlandıracaktır.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "En düşük emir hacmi",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "dk",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "{coinName} için yapılabilecek en düşük satış hacmi: {number}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "{coinName} için yapılabilecek en düşük alım hacmi: {number}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "En düşük emir için: {buyCoin} {buyAmount}\n({sellCoin} {sellAmount})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "{coinName} için en düşük satım miktarı: {number}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "{minValue} {coin}'den büyük olmalı",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Satış miktarından düşük olmalı",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Gereken en düşük hacim",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "hacim",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Lütfen artık hücresel veri kullandığınızı ve {appName} P2P ağına katılımınızın internet trafiğini tükettiğini unutmayın. Hücresel veri planınız maliyetliyse bir WiFi ağı kullanmak daha iyidir.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Daha fazla bilgi",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "Daha Fazla",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Önce {coin}'i etkinleştirin ve bakiyeyi tamamlayın",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Miktar",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Koin",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Sat",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "İptal",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Onayla",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "{number} Sipariş oluştur:",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Oluştur",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Emir",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Emirler",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "tutar",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "İptal",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Lütfen almak istediğiniz itibari para miktarını giriniz:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Otomatik doldur",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Devam etmeden önce lütfen hataları gideriniz",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Geçersiz miktar",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Geçersiz satış miktarı",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "İşlem masrafını ödemeye yetecek {coin} yok. En az {fee} {coin} olmalı.",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin} bakiyesi yetersiz",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "En fazla satış miktarı:",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "En az alım miktarı:",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "En satış miktarı:",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Al:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Sat:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Çoklu",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Alınacak Miktar",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "CEX/Ücret",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Ağ ücreti",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "yeni hesap",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Yeni Hesap",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Haber akışı",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Yeni değer:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "sonraki",
+  "@next": {
+    "type": "text"
+  },
+  "no": "Hayır",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "Şimdilik bir haber yok. Lütfen daha sonra tekrar deneyiniz.",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "Koin bulunamadı",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Fon yok",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "Fon mevcut değil. Lütfen para yatırın.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "İnternet Bağlantısı Yok",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "Bir öğe seçilmedi",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "Bir öğe seçilmedi",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "Eşleşen sipariş bulunamadı",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Hiçbiri",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "Girilen değer rakam olmalı",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Uygun bir {coinName} emri bulunmuyor - bir emir girmeyi deneyin veya daha sonra yeniden kontrol edin.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Emir oluşturmak için tıklayın",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "Emir yok, lütfen ticarete gidin.",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "Alınabilecek bir ödül yok",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "Alabileceğiniz bir ödül mevcut değil - 1 saat sonra yeniden deneyin.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "Böyle bir koin yok",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "Geçmiş yok.",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "İşlem için yeteri kadar {coin} yok !",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "Takas masrafını karşılayacak bakiye bulunmuyor - daha küçük tutar deneyin",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Eşleşmiş bir emir tekrardan iptal edilemez.",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Not Ekle",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Not",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Bir şey bulunamadı",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "{sell}/{buy} takası başarıyla tamamlandı",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Takas tamamlandı",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy} takası başarısız oldu",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Takas başarısız",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy} takası başladı",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Yeni takas başladı",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Takas durumu değişti",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy} takas zaman aşımına uğradı",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Takas zaman aşımına uğradı",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "{coin} işlemi aldınız!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Gelen işlem",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "İşlem Yok",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} Varlıklar",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "Resmi basın açıklaması",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Tamam",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Sil",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Eski kayıtlar",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Boşluk kullanıldı",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Hata Mesajını Aç",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "İsteğe bağlı",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "Az",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "Daha",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Tüm {coin} emirleri iptal edilecek",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Emir oluşturuldu",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Emir başarıyla oluşturuldu",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Adres",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "İptal",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "Ucuz: CEX + %{delta}",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "Pahalı: CEX + %{delta}",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "için",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "CEX'de",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "en az",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Fiyat",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Al",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Seç",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Satışlar",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Ayrıntıları tek dokunuşla açın ve Uzun dokunuşla sipariş et'i seçin",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Harca",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Detaylar",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% tamamlandı",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Emir eşleşti",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Emir eşleşiyor",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "emirler",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Açık",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "Geçmiş",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "({coin}) miktarı",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "({coin}) fiyatı",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "Toplam ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Emir",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Bilinmeyen Türde Emir",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Üstüne yaz",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "Bu sizin kendi emriniz !",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Bakiyeden ödendi:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Alınan miktardan ödendi:",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Ödendi",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "Parolanız en az 12 karakterden oluşurken en az; bir büyük harf, bir küçük harf ve bir sembol içermelidir.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "Cüzdanınız, belirtilen tarihten sonra yaptığınız geçmiş işlemleri gösterecektir.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Öde",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "Bu işlemi kabul ediyor musunuz ?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "Adrese",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "Miktar:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Koin:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "İptal",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Ödeme Talep Edildi",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} aktif değil. Lütfen aktifleştirip öyle deneyiniz.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Emrinizi girin",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "Tam seste oynat",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Lütfen bir Koin Ekleyiniz",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Yeniden denemek için lütfen uygulamayı yeniden başlatın ya da aşağıdaki düğmeye basınız.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Portföy",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Komodo tarafından geliştirilmiştir",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "fiyat",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Gizli Kelime",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Gizli Kelimeler",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Onaylar",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Özel koruma seçenekleri kullan.",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "Kapalı",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "Açık",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Dikkat ! Bu takas dPoW koruması altında değildir.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Açık Adres",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "QR Kod Tarayıcı",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "Gizli kelimelerimi kaydediyor musunuz ?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "Komodo Wallet'ı hangi cihazlarda kullanabilirim ?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "{appName}'te alım satım yapmanın diğer DEX'lerdekinden ne gibi farkları vardır ?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "Takas işlemleri ne kadar sürmektedir ?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "Takas işlemi boyunca çevrimiçi olmam mı gerekir ?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "{appName}'te işlem ücretleri nasıl hesaplanmaktadır ?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Kullanıcılara destek sunuyor musunuz ?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "Uygulamanın kullanılamadığı ülkeler var mı ?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "Komodo Wallet'ın arkasında kimler var ?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "{appName} üzerinde kendi beyaz etiketli değişimimi geliştirmem mümkün mü?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "Bu yeni bir dönem! 'AtomicDEX' olan ismimizi resmi olarak 'Komodo Wallet' olarak değiştirdik.",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "AL",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Al",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Çevrimdışı bir şekilde saklamanızı öneririz.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Devre dışı bırak",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Talep Edilen Alım Satım",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "TEMİZLE",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Geri Yükleme Formu",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "GERİ YÜKLE",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Tüm koinleri aktifleştirmeyi tekrar deniyor..",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Hepsini aktifleştirmeyi tekrar dene",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Ödülünüzü alın",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Vazgeç",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "İşlem sürmekte",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "işleniyor",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXO miktarı 10 KMD'den az",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Henüz 1 saat geçmedi",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 saat",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "Tamam",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Ödül durumu:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "KMD aktif kullanıcı ödülleri hakkında daha fazla bilgi edinin",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Al",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "Başarılı ! {amount} KMD geldi.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "İtibari para",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "KMD Ödülleri",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Durum",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Kalan zaman",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Ödül bilgisi:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO amt,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} gün",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}sa {minutes}dk",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}dk",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Ödül bilgisi",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Rusça",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Birleştirilmiş kaydet",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "Devam etmek için aşağı kaydırın...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Bir koin ara",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Tüm AVAX tokenlerini seç",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Tüm BEP tokenlerini seç",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Hepsini seç Cosmos Ağı",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Tüm ERC tokenlerini seç",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Tüm ETC tokenlerini seç",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Tüm Fantom tokenlerini seç",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Tüm HecoChain tokenlerini seç",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Tüm Harmony tokenlerini seç",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Tüm İris Ağını seç",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Tüm Kucoin tokenlerini seç",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Tüm Moonriver tokenlerini seç",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Tüm Polygon tokenlerini seç",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Tüm QRC tokenlerini seç",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Tüm SmartBCH tokenlerini seç",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Tüm SLP belirteçlerini seçin",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Tüm SmartChain koinlerini seç",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Tüm test koinlerini seç",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Tüm Ubiq koinlerini seç",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Tüm UTXO koinlerini seç",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Tüm ZHTLC paralarını seç",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Kayan Yazı Ara",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "s",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Güvenlik",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "Gizli Kelimeler",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Yeni Gizli Kelimeleriniz",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "{amount} adet emri görmek için tıklayın",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "İşlem Geçmişini Görüntüle",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Koin seçin",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Portföyünüze eklemek istediğiniz koinleri seçin.",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Koin etkinleştir:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "ALMAK istediğiniz koini seçin",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "SATMAK istediğiniz koini seçin",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Bir Tarih Seçin",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Seçili emir:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Dosya seç",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Dili Seç",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Ödeme Yönteminizi Seçin",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Sat",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan satmak üzeresiniz",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "GÖNDER",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Silmek istediğine emin misin",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "cüzdan?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Eğer eminseniz",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "daha sonra cüzdanınızı kurtarabilmeniz için",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "gizli kelimelerinizi kaydedin.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Diller",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Ayarlar",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "PAROLA BELİRLE",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "Paylaş",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "{coinName} adresim:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "Geçmişteki {coin} işlemleri taransın mı?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Adresi Göster",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Detayları Göster",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "{maxCount} siparişten {count} tanesi gösteriliyor.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "EMİRLERİMİ GÖSTER",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Parola ile giriş yap",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "Parolayı mı unuttunuz ? Gizli kelimelerinizle giriş yapın.",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Basit",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Aktifleştir",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Lütfen alınacak {coin} adetini girin",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Satın al",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Kapat",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "Maksimum aktif jeton sayısı {maxCoins}'dir. Lütfen bazılarını devre dışı bırakın.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} koini aktif değil !",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Al",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Lütfen satmak için {coin} miktarı girin",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Sat",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Gönder",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Daha az göster",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Daha fazla göster",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "{coin} aktifleştirilemedi",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Geç",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Kapat",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Ses",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Lütfen bir mp3 ya da waw dosyası seçin. {description}'de ses dosyalarını oynatacağız.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "{description}'de oynatıldı.",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Sesler",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Anladım, bunu tekrar gösterme",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Ses",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Ses seçenekleri",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "Takas boyunca ve açık bir yapıcı emriniz varken bazı sesli bilgilendirmeler duyacaksınız.\nPürüzsüz bir takas için her iki tarafın da işlem boyunca çevrimiçi olması gerekmektedir ve sesli bildirimler buna yardımcı olmaktadır.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Kendi özelleştirilmiş sesli bildirimlerinizi uygulamanın ayarlar bölümünden etkinleştirebileceğinizi unutmayın.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "İspanyolca",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Başlangıç tarihi",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Takası Başlat",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Adım",
+  "@step": {
+    "type": "text"
+  },
+  "success": "Başarılı !",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Destek",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Herhangi bir sorunuz varsa veyahut {appName} uygulamasıyla ile ilgili teknik bir hata bulduğunuzu düşünüyorsanız bunu ekibimize bildirebilir ve destek alabilirsiniz.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "takas",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Mevcut",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "TAKAS DETAYLARINI ONAYLA",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "Yaklaşık",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "Takas başarısız",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Lütfen önce {coin} ve kontör bakiyesini etkinleştirin",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük. {amount} {coin} gerekli.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Takas devam ediyor",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "İşlem detayları",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "Takas başladı",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Başarılı Takas",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Toplam",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "Takas UUID",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Temayı Değiştir",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Belirtilen tarihten itibaren senkronizasyon",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Fidan aktivasyonundan senkronizasyon",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Yeni işlemleri senkronize et",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "Hangi {name} işlemlerini senkronize etmek istiyorsunuz?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Alıcı Emri",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Alıcı Emri",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Zaman Aşımı",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "PAROLA OLUŞTUR",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Emir seçildi",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "Alıcı",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "Adrese:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "Var",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "varlıklar etkinleştirildi. Atkif edilebilecek koin limiti:",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": "Yenilerini eklemeden önce lütfen eskilerden birkaçını kaldırın",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Çok fazla koin aktifleştirildi",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Toplam Masraflar",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "ALIM SATIM",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "TAKAS TAMAMLANDI !",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "ALIM SATIM DETAYLARI",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Alım satım işlem giderleri hesaplanamadı",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "Alım satım işlem gideri:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Alım Satım Modu:",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "İşlem Adresi",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "İşlem Gizli",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Bu işlem olası bir kimlik avı girişimi nedeniyle gizlendi.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "Bazı yeni koinler etkileştirilemedi ise uygulamayı tekrar başlatmayı deneyiniz.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Türkçe",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Blok",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Onaylar",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "ONAYLANDI",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Ücret",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "İşlem ücreti",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "İşlem numarası",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Kalan işlem: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Çok fazla istek.\nİşlem geçmişi istekleri sınırı aşıldı.\nLütfen daha sonra tekrar deneyiniz.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "onaylanmamış",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Ukrayna",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "kilidi aç",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Fonların Kilidini Açın",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "{amnt} fonun kilidi başarıyla kaldırıldı - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "harcanamaz",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Yeni sürüm mevcut",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Güncellemeler kontrol ediliyor..",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "{version} sürümünü kullanmaktasınız.",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Yeni sürüm mevcut. Lütfen güncelleyiniz.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "Güncel {version} sürümü mevcut. Lütfen güncelleyiniz.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Güncelleme mevcut",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Şimdilik atla",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "Komodo Wallet güncellemeleri",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Güncelle",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Son sürüm yüklü",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "Taranan ödeme talebi için",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "yeterli bakiye yok.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Yetersiz bakiye",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Değer:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "sürüm",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Tarayıcı",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Gizli ve Özel Kelimeler",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Hacim",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "Bu cüzdan adı zaten kullanımda",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "Cüzdan adı en fazla 40 karakter içerebilir",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Sadece cüzdan",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "Dikkat !",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Tamam",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Dikkat ! Bu kayıt defteri özel durumlarda, başarısız takaslardan kalan koinlerin harcanmasına sebep olabilecek hassas bilgiler içerebilir.",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "{coinAbbr} koinini etkinleştiremedik.",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "{coinAbbr} koinini etkinleştiremedik.\nLütfen uygulamayı yeniden başlatıp tekrar deneyiniz.",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "Komodo Wallet mobil yerleşik üçüncü nesil DEX işlevselliği ve daha fazla özellikleri ile yeni nesil bir çoklu koin cüzdanıdır.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "HADİ AYARLAYALIM !",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "HOŞ GELDİNİZ",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "cüzdan",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "Tamamlandığında portföy ekranına yönlendirileceksiniz.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Bu biraz zaman alacak ve uygulamanın ön planda tutulması gerekiyor.\nEtkinleştirme devam ederken uygulamayı sonlandırmak sorunlara yol açabilir.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Çek",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "{appName}'in kameraya erişimi engellenmiş.\nQR kod taramasını yapabilmek için lütfen telefon ayarlarınızdan kamera erişimine izin veriniz.",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Erişim Engellendi",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Çekimi Onayla",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "{amount} adet {coinName} ÇEK",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "QR kodlu bir ödemeyi",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "taramaya çalışıyorsunuz",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "fakat çekim ekranındasınız",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Yanlış koin",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "Parola eşleşmiyor. Lütfen tekrar deneyin.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Evet",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Gönderiyorsunuz:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "mevcut bir siparişle eşleşmeye çalışan yeni bir siparişiniz var",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "devam eden aktif bir takasınız var",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "yeni siparişlerin eşleşebileceği bir siparişiniz var",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "Cüzdanınız",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "{amount} adet {coin} alacaksınız",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Alacağınız:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -3609,6 +3609,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "{coinAbbr} aktivasyonu iptal edilemedi",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} mevcut değil :(",
     "@isUnavailable": {
         "type": "text",
@@ -5448,6 +5458,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "Coin aktivasyonu iptal edildi",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "{coin} başarıyla etkinleştirildi",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "{coin} aktivasyonu iptal edildi",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Lütfen tüm özel jeton aktivasyon isteklerini kabul edin veya jetonların seçimini kaldırın.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "Etkinleştirmeyi İptal Et",
     "@cancelActivation": {

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,3726 +1,5528 @@
 {
-  "@@locale": "tr",
-  "accepteula": "EULA'yı Kabul Et",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "ŞARTLARI ve KOŞULLARI Kabul Et",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Biyometrik korumayı etkinleştir",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "PIN korumasını etkinleştir",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "{protocolName} paraları etkinleştirilsin mi?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Lütfen artık hücresel veri kullandığınızı ve {appName} P2P ağına katılımınızın internet trafiğini tükettiğini unutmayın. Hücresel veri planınız maliyetliyse bir WiFi ağı kullanmak daha iyidir.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Erişim Engellendi",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "{appName}'in kameraya erişimi engellenmiş.\nQR kod taramasını yapabilmek için lütfen telefon ayarlarınızdan kamera erişimine izin veriniz.",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "HOŞ GELDİNİZ",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "cüzdan",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "Komodo Wallet mobil yerleşik üçüncü nesil DEX işlevselliği ve daha fazla özellikleri ile yeni nesil bir çoklu koin cüzdanıdır.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "HADİ AYARLAYALIM !",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "Komodo Wallet güncellemeleri",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "{version} sürümünü kullanmaktasınız.",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Güncellemeler kontrol ediliyor..",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Son sürüm yüklü",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Yeni sürüm mevcut",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Güncelle",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Şimdilik atla",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Güncelleme mevcut",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Yeni sürüm mevcut. Lütfen güncelleyiniz.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "Güncel {version} sürümü mevcut. Lütfen güncelleyiniz.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Yardım",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Yardım ve Destek",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Sıkça Sorulan Sorular",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Destek",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Herhangi bir sorunuz varsa veyahut {appName} uygulamasıyla ile ilgili teknik bir hata bulduğunuzu düşünüyorsanız bunu ekibimize bildirebilir ve destek alabilirsiniz.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "Gizli kelimelerimi kaydediyor musunuz ?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "Hayır ! Komodo Wallet, gözetimsiz bir cüzdandır. Özel kelimeleriniz, gizli kelimeleriniz ve PIN kodunuz dahil hiçbir hassas bilgiyi kaydetmiyoruz. Bu bilgiler sadece kullanıcının cihazında tutulmaktadır ve başka bir yere gitmez. Bu sayede koin ve tokenlerinizin tüm kontrolü sizdedir.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "{appName}'te alım satım yapmanın diğer DEX'lerdekinden ne gibi farkları vardır ?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Diğer DEX cüzdanlar genellikle aynı miktar koin ile tek bir alım satım emri vermeye izin verir, ara token kullanır, en önemlisi de tek bir blokzincirin koinlerinin alım satımına olanak sağlar.\n\n{appName} ise birbirinden farklı iki blokzincir ağı arasında ara token kullanmadan doğrudan takas yapmaya imkân sağlar. {appName} 'te aynı miktar koin ile birden fazla alım satım emri verebilirsiniz. Mesela 0.1 BTC ile KMD, QTUM ve VRSC için ayrı ayrı alım emirleri verebilirsiniz ve bunlardan birinin tamamlanması halinde diğerleri kendiliğinden iptal olmuş olurlar.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "Takas işlemleri ne kadar sürmektedir ?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Her bir takasın tamamlanma sürecini etkileyen birkaç etken vardır. Takas edilen koinlerin bağlı olduğu blokzincirlerin blok çıkarım zamanları (Bitcoin en yavaşıdır) bunda etkilidir. Bunun yanında kullanıcılar, takas öncesinde güvenlik seçeneklerini özelleştirebilir. Mesela bir KMD takasına başlamadan evvel Komodo Wallet'da işlem için 3 onayın yeterli olduğu seçeneği işaretlediğinizde takas süresi <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">noterizasyon</a> eklenmeyeceğinden kısalacaktır.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "Takas işlemi boyunca çevrimiçi olmam mı gerekir ?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Evet, takas boyunca uygulamanız açık ve internetinizin de (anlık kesintilerde bir sıkıntı yoktur) bağlı olması gerekmektedir. Aksi halde; eğer yapıcı emri (maker) veren siz iseniz takasın iptal olma durumu, alıcı emri (taker) veren iseniz de koinlerinizi kaybetme riski ortaya çıkar. Komodo Wallet protokolünde takası yapan her iki tarafın da işlem boyunca çevrimiçi olması ve takasın başarılı olması için gereklidir.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "{appName}'te işlem ücretleri nasıl hesaplanmaktadır ?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "{appName}'te alım satım yaparken bilinmesi gereken iki tür işlem ücreti vardır.\n\n1. {appName}, alıcı emirlerinden işlem başına yaklaşık olarak %0.13 (takriben 777'nin 1'i kadar, fakat bu da 0.0001'den az olmamak kaydıyla) işlem ücreti alırken, yapıcı emirlerinden herhangi bir ücret alınmamaktadır.\n\n2. Hem yapıcı hem de alıcı emir sahiplerinin ödemesi gerekli olan ve takasın gerçekleştiği blokzincirlerin standart ağ işlem ücretleri.\n\nAğ işlem ücretleri, takas yapmak istediğiniz paritelerin kendi işleyişlerine göre değişiklik göstermektedir.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "Kullanıcılara destek sunuyor musunuz ?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "Evet! {appName}, <a href=\"{link}\">{appCompanyShort} {name}</a> aracılığıyla destek sunar. Ekip ve topluluk her zaman yardımcı olmaktan mutluluk duyar!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "Uygulamanın kullanılamadığı ülkeler var mı ?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "Hayır ! {appName} tamamıyla merkeziyetsizdir ve kullanıcıların uygulamaya erişimi başkaları tarafından sınırlandırılamaz.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "Komodo Wallet'ın arkasında kimler var ?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName}, {appCompanyShort} takımı tarafından geliştirilmiştir. {appCompanyShort}, koin takası, Geciktirilmiş İş Kanıtı (dPoW), birlikte çalışabilen çoklu zincir mimarisi gibi yenilikçi blokzincir çözümleri geliştiren köklü bir platformdur.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "{appName} üzerinde kendi beyaz etiketli değişimimi geliştirmem mümkün mü?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "Kesinlikle! Daha fazla ayrıntı için <a href=\"https://developers.komodoplatform.com/\">geliştirici belgelerimizi</a> okuyabilir veya ortaklık sorularınız için bizimle iletişime geçebilirsiniz. Belirli bir teknik sorunuz mu var? {appName} geliştirici topluluğu her zaman yardıma hazır!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "Komodo Wallet'ı hangi cihazlarda kullanabilirim ?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName}, hem Android hem de iPhone'da mobil cihazlar için ve <a href=\"https://komodoplatform.com/\">Windows, Mac ve Linux işletim sistemlerinde</a> masaüstü için kullanılabilir.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Bülten",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Haber Bülteni",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Daha fazlası için..",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Bir şey yok",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Haber bülteni güncellendi",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Kapat",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Haberler",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Süre",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "Haber güncellemeleri alınamıyor",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "Haber güncellemeleri alınamıyor",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Zaten güncel",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Tarih",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} haberleri",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "PIN Kodu Oluştur",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "PIN Kodunuzu giriniz",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "Giriş",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "yeni hesap",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Yeni Hesap",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} başarıyla etkinleştirildi !",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Bağlanıyor..",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Koin etkinleştir",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} Varlıklar",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Gizli kelimelerinizi giriniz",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Örnek: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "Onayla",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan almak üzeresiniz.",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "Telefonunuzun bataryası güvenli bir takası tamamlayamayacak ({batteryLevelCritical}%) kadar düşük. Lütfen önce şarja takıp sonra tekrar deneyiniz.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "Telefonunuzun bataryası %{batteryLevelLow}'den daha az. Lütfen telefonunuzu şarj ediniz.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "Telefonunuz batarya tasarruf modunda. Lütfen bu modu devre dışı bırakın ya da başvuru uygulamasını arka plana KOYMAYIN. Aksi halde uygulama, işletim sisteminiz tarafından kapatılabilir ve devam etmekte olan takasınız varsa başarısız olabilir.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan satmak üzeresiniz",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Al",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Sat",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "{coinName} adresim:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Çek",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "Değer çok yüksek ya da çok düşük",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Tutar",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Alıcı adresi",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "{amount} adet {coinName} ÇEK",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Çekimi Onayla",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Kapat",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "Gizli Kelimeleri Onayla",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Yeni Gizli Kelimeleriniz",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Önemli: Devam etmeden önce gizli kelimelerinizi güvenli bir şekilde yedekleyin !",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Çevrimdışı bir şekilde saklamanızı öneririz.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "sonraki",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "PIN kodunu onayla",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Kamuflajlı PIN Kurulumu",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Kamuflajlı PIN'i Onaylayın",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Hata, lütfen tekrar deneyiniz",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Ayarlar",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Güvenlik",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "PIN korumasını etkinleştir",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Ekran Görüntülerini/Önizlemeyi Devre Dışı Bırak",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "Ekran kilitli",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "PIN kodunu değiştir",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Çıkış",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "MAKSİMUM",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "DK",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Toplam Masraflar",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Bakiyeden ödendi:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Alım Satım Modu:",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Geç",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Birleştir",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Üstüne yaz",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Mevcut değer:",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Yeni değer:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Birleştirilmiş değer:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Birleştirilmiş kaydet",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "Zaten mevcut",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Basit",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Gelişmiş",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Alınan miktardan ödendi:",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Satılacak Tutar",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Alacağınız:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "SATMAK istediğiniz koini seçin",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "ALMAK istediğiniz koini seçin",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "takas",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Takas işlendi, lütfen bekleyiniz.",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "Emir eşleşmesi devam ediyor, lütfen {seconde} saniye kadar bekleyiniz.",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Ağ ücreti",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "komisyon ücreti",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Portföy",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Ödeme",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Tahmini Toplam Değer",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Ödeme Yönteminizi Seçin",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Hacim",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Emrinizi girin",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "Yakında...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Pazar",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Gönderiyorsunuz:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Kod:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Değer:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Ödendi",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "Lütfen veri giriniz",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "Yeterli bakiye yok",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Gwei en fazla {value} olmalıdır",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "Ücretler en fazla {value} olmalıdır",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "Sınır en fazla {value} olmalıdır",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "Geçerli bir adres değil",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Segwiit adresler henüz desteklenmemektir",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "Adrese:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "AL",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "GÖNDER",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Açık Adres",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "geri",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "İptal",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "detaylar",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Evet",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "Hayır",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Eşleşmiş bir emir tekrardan iptal edilemez.",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "Tekrar sorma",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Emri İptal Et",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "Emri iptal etmek istediğinizden emin misiniz ?",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "harcanamaz",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "TX detayları yakında !",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "geçmiş",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "Ticaret",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "Detaylar yakında !",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Emir eşleşiyor",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Emir eşleşti",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Takas devam ediyor",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Başarılı Takas",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Zaman Aşımı",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Dönüştür",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "Takas başarısız",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Hata, lütfen daha sonra deneyiniz",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Son İşlemler",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "İşlem alınıyor, lütfen bekleyin",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Bitiriliyor, lütfen bekleyin",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Geri Bildirim Gönder",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Emir defteri yükleniyor...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "talep et",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "KMD ödülünüzü alın",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "Başarılı !",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "Alabileceğiniz bir ödül mevcut değil - 1 saat sonra yeniden deneyin.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Yükleniyor..",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Kalan işlem: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} bakiyesi, alım satım işlem ücretlerini karşılamaya yetmiyor.",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Haberler",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Haber akışı",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "Panoya kopyalandı",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "Gönderici",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "Alıcı",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "ONAYLANDI",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "onaylanmamış",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Blok",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Onaylar",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Ücret",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "İşlem numarası",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Hafıza",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "Geçmiş yok.",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "ALIM SATIM",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "TEMİZLE",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Geri Yükleme Formu",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "TAKAS TAMAMLANDI !",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Adım",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "ALIM SATIM DETAYLARI",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Talep Edilen Alım Satım",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "Takas UUID",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "GÖZAT",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "KAYDEDİLDİ",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaNotSavedDescription": "KAYDEDİLMİŞ BİR MAKALENİZ YOK",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "BÜLTENE GÖZAT",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "Yazar:",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "Lütfen doğrulayın !",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "İşlem Yok",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Bitti",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Koin etkinleştir:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Portföyünüze eklemek istediğiniz koinleri seçin.",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "Şimdilik bir haber yok. Lütfen daha sonra tekrar deneyiniz.",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "Takas talebi geri alınamaz ve bu nihai bir işlemdir !",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "Bu işlem 60 dakikaya kadar sürebilir. Uygulamayı KAPATMAYINIZ !",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "TAKAS DETAYLARINI ONAYLA",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Gereken en düşük hacim",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "hacim",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "Girilen değer rakam olmalı",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Satış miktarından düşük olmalı",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "{minValue} {coin}'den büyük olmalı",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "Gizli kelimeleri kontrol edin",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "GİZLİ KELİMELERİZİ BİR KEZ DAHA KONTROL EDİNİZ",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "Gizli kelimeleriniz çok önemlidir, bu yüzden onları doğru kaydettiğinizden emin olmak istiyoruz. Cüzdanınızı istediğiniz zaman kolayca geri yükleyebilmeniz için gizli kelimeleriniz hakkında size şimdi üç farklı soru soracağız.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "Gizli kelimeleriniz arasından {index} olanı hangisidir ?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "{index} kelimesini giriniz.",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "DEVAM",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "GERİ DÖN VE KONTROL ET",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Tarayıcı",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Biyometrik korumayı etkinleştir",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Kişisel kelimeleri kullan",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "Dikkat !",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "Anladım",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Özelleştirilmiş gizli kelime kullanımı yeterince güvenli olmayabilir ve uygulama tarafından oluşturulan BIP39 uyumlu gizli kelimeler ya da özel anahtara (WIF) kıyasla daha kolay kırılabilmektedir. Riskleri kabul edip ne yaptığınızdan emin olduğunuzu tasdiklemek için aşağıdaki kutucuğa \"{iUnderstand}\" yazınız.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Parolanızı girin",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "Cüzdanınız",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "Parolayı mı unuttunuz ? Gizli kelimelerinizle giriş yapın.",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Parola ile giriş yap",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Gizli kelimelerinizi girin",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "Parola eşleşmiyor. Lütfen tekrar deneyin.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Cüzdanınızı adlandırın",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Cüzdanınızın güvenlik tehditlerine karşı şifrelenebilmesi için bir parola ayarlamalısınız.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Parolayı onayla",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "Parola istemiyorum",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "EMİN MİSİNİZ?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Güvenlı bir parola kullanın ve onu, uygulamayı kullandığınız cihazda saklamayın.",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "PAROLA BELİRLE",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "CÜZDAN OLUŞTUR",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "GERİ YÜKLE",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Parola",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "Parolanız en az 12 karakterden oluşurken en az; bir büyük harf, bir küçük harf ve bir sembol içermelidir.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Parola Oluştur",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Parolayı Onayla",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Mevcut parola",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Çıkış Ayarları",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Kapanışta Çıkış Yap",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Cüzdanı Sil",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Sil",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Silmek istediğine emin misin",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "cüzdan?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Eğer eminseniz",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "daha sonra cüzdanınızı kurtarabilmeniz için",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "gizli kelimelerinizi kaydedin.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Yedekle",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "sürüm",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Gizli ve Özel Kelimeler",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "Gizli Kelimeler",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Gizli Kelimeler",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Gizli Kelime",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Lütfen devam etmek için parolanızı giriniz",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "Panoya kopyala",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "kilidi aç",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "{amnt} fonun kilidi başarıyla kaldırıldı - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Fonların Kilidini Açın",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "Emir yok, lütfen ticarete gidin.",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Uygun bir {coinName} emri bulunmuyor - bir emir girmeyi deneyin veya daha sonra yeniden kontrol edin.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "Mevcut en iyi fiyat",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Al",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "bir emir girin",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "TAKAS",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "emirler",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Koin seçin",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗Dikkat! {coinName} piyasasının 24 saatlik işlem hacmi 10 bin dolardan az!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Dili Seç",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Fon yok",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "Fon mevcut değil. Lütfen para yatırın.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Portföye git",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Emir oluşturmak için tıklayın",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Yetersiz hacim",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "Bu işlem için gereken en az hacim şu kadardır",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Emir oluşturuldu",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Emir başarıyla oluşturuldu",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "EMİRLERİMİ GÖSTER",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "{coinName} için yapılabilecek en düşük satış hacmi: {number}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "PAROLA OLUŞTUR",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "{coinName} için yapılabilecek en düşük alım hacmi: {number}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "{coinName} için en düşük satım miktarı: {number}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "En düşük emir için: {buyCoin} {buyAmount}\n({sellCoin} {sellAmount})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Önce satış miktarını girmelisiniz",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Cüzdan şifreleniyor",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Cüzdan deşifre ediliyor",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "Takas masrafını karşılayacak bakiye bulunmuyor - daha küçük tutar deneyin",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "İnternet Bağlantısı Yok",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Komodo Üzerinde Yapılmıştır",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Lütfen bir Koin Ekleyiniz",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "İnternet Bağlantısı Yeniden Sağlandı",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Yenile",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Yasal",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Yasal Uyarı ve Kullanım Şartları",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "EULA'yı Kabul Et",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "ŞARTLARI ve KOŞULLARI Kabul Et",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "Aşağıdaki düğmeye tıklayarak 'EULA' ve 'Kullanım Şartları'nı okumuş ve kabul etmiş sayılırsınız",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} gideri",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "İşlem için yeteri kadar {coin} yok !",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Lütfen {coin} koinini aktifleştirin.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "{amount} adet {coin} alacaksınız",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "{amount} adet emri görmek için tıklayın",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Görmek için tıklayın",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "fiyat",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "maksimum hacim",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "Cüzdanınız ayarlanıyor, lütfen bekleyiniz..",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Emir seçildi",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "İşlem ücreti",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "Alım satım işlem gideri:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük. {amount} {coin} gerekli.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "Takasa devam edilemiyor",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Detayları Göster",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Takas rasyosu:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Seçili emir:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "En düşük emir hacmi",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Maksimum Emir Hacmi",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Detaylar",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Lütfen önce {coin} ve kontör bakiyesini etkinleştirin",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Alım satım işlem giderleri hesaplanamadı",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Devre dışı bırak",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Sadece cüzdan",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "Cüzdan adı boş kalamaz",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "Cüzdan adı en fazla 40 karakter içerebilir",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "Bu cüzdan adı zaten kullanımda",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "Bu koin DEX'te yoktur",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Bir koin ara",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Tüm SmartChain koinlerini seç",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Tüm test koinlerini seç",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Tüm ERC tokenlerini seç",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Tüm SLP belirteçlerini seçin",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Hepsini seç Cosmos Ağı",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Tüm İris Ağını seç",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Tüm Kucoin tokenlerini seç",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Tüm Harmony tokenlerini seç",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Tüm ETC tokenlerini seç",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Tüm SmartBCH tokenlerini seç",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Tüm AVAX tokenlerini seç",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Tüm Ubiq koinlerini seç",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Tüm BEP tokenlerini seç",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Tüm Polygon tokenlerini seç",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Tüm QRC tokenlerini seç",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Tüm HecoChain tokenlerini seç",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Tüm ZHTLC paralarını seç",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Tüm Fantom tokenlerini seç",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Tüm Moonriver tokenlerini seç",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Özelleştirilmiş gider",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "Gaz ücreti limiti",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "Gaz ücreti",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "Özelleştirilmiş giderleri yalnızca ne yaptığınızdan emin olduğunuzda kullanın !",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Tüm UTXO koinlerini seç",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Komodo Üzerinde Yapılmıştır",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Komodo tarafından geliştirilmiştir",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "Yeteri kadar gaz ücreti yok, en az {gas} Gwei gerekli",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Tüm {coin} emirleri iptal edilecek",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Devre dışı bırakmayı onayla",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "Kaldırmak istiyor musunuz",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "portföyünüzden mi? Eşleşmeyen tüm siparişler iptal edilecektir.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " ayrıca devre dışı bırakılacak",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "Kaldırılamaz",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "Ön tanımlı bir koindir. Ön tanımlı koinler kaldırılamaz",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Tamam",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "Paylaş",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Dikkat ! Bu kayıt defteri özel durumlarda, başarısız takaslardan kalan koinlerin harcanmasına sebep olabilecek hassas bilgiler içerebilir.",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Eski PIN kodunu giriniz",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Yeni PIN kodunu giriniz",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "Doğrula",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Diller",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "İngilizce",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Fransızca",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Almanca",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Çince",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Rusça",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Japonca",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Türkçe",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Macarca",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "İspanyolca",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Koreli",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Ukrayna",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "MUSLUK",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Başarılı",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Hata",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "Talep zaman aşımına uğradı",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "{coin} musluğuna talep gönderiliyor..",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "İsteğe bağlı",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Ses",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "Tam seste oynat",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Alıcı Emri",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "mevcut bir siparişle eşleşmeye çalışan yeni bir siparişiniz var",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Yapıcı Emri",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "yeni siparişlerin eşleşebileceği bir siparişiniz var",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Aktif",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "devam eden aktif bir takasınız var",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Başarısız",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "Takas başarısız oldu",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Alkış",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "takas tamamlanmak üzere",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "Bu oynatılamıyor",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Lütfen bir mp3 ya da waw dosyası seçin. {description}'de ses dosyalarını oynatacağız.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "{description}'de oynatıldı.",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Sesler",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "Takas boyunca ve açık bir yapıcı emriniz varken bazı sesli bilgilendirmeler duyacaksınız.\nPürüzsüz bir takas için her iki tarafın da işlem boyunca çevrimiçi olması gerekmektedir ve sesli bildirimler buna yardımcı olmaktadır.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Kendi özelleştirilmiş sesli bildirimlerinizi uygulamanın ayarlar bölümünden etkinleştirebileceğinizi unutmayın.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Anladım, bunu tekrar gösterme",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Ses seçenekleri",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Ses",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Piyasalar",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "PİYASALAR",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "FİYAT",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "EMİR DEFTERİ",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "Tablo",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Derinlik",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Fiyat",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Satışlar",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "için",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "en az",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Adres",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "Ucuz: CEX + %{delta}",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "Pahalı: CEX + %{delta}",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "CEX'de",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Al",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Harca",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "Bu sizin kendi emriniz !",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Lütfen koinleri seçiniz",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Koin Seç",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "Aktif koin yok",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Temizle",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "({coin}) fiyatı",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "({coin}) miktarı",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "Toplam ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "Teklif bulunamadı",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "Soru bulunamadı",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Emir Detayları",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Bir hata oluştu, lütfen daha sonra tekrar deneyiniz.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Ödül bilgisi",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "KMD aktif kullanıcı ödülleri hakkında daha fazla bilgi edinin",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Vazgeç",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Al",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "Alınabilecek bir ödül yok",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Ödül bilgisi:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO amt,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "KMD Ödülleri",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "İtibari para",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Kalan zaman",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Durum",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Ödül durumu:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "Tamam",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} gün",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}sa {minutes}dk",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}dk",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "Başarılı ! {amount} KMD geldi.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXO miktarı 10 KMD'den az",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "işleniyor",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "İşlem sürmekte",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 saat",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Henüz 1 saat geçmedi",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Ödülünüzü alın",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "İşlem Geçmişini Görüntüle",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Tüm koinleri aktifleştirmeyi tekrar deniyor..",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "Tamamlandığında portföy ekranına yönlendirileceksiniz.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "Bazı yeni koinler etkileştirilemedi ise uygulamayı tekrar başlatmayı deneyiniz.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "{coinAbbr} koinini etkinleştiremedik.",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Yeniden denemek için lütfen uygulamayı yeniden başlatın ya da aşağıdaki düğmeye basınız.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Hepsini aktifleştirmeyi tekrar dene",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Tekrar aktivasyon işlemi bittiğinde doğrudan portföy sayfasına yönlendirileceksiniz.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "{coinAbbr} koinini etkinleştiremedik.\nLütfen uygulamayı yeniden başlatıp tekrar deneyiniz.",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} mevcut değil :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Çoklu",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Devam etmeden önce lütfen hataları gideriniz",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Oluştur",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Emir",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Emirler",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Koin",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Sat:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Sat",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Miktar",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Al:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "CEX/Ücret",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Alınacak Miktar",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Lütfen almak istediğiniz itibari para miktarını giriniz:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "İptal",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Otomatik doldur",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "tutar",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "İşlem masrafını ödemeye yetecek {coin} yok. En az {fee} {coin} olmalı.",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "{number} Sipariş oluştur:",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "İptal",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Onayla",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Geçersiz satış miktarı",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "En fazla satış miktarı:",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "En satış miktarı:",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Geçersiz miktar",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "Geçersiz {coin} adresi",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "Önce {coin}'i etkinleştirin ve bakiyeyi tamamlayın",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin} bakiyesi yetersiz",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "En az alım miktarı:",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Adres defteri",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Adres Defteri",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Kişi detayları",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "Adres defteri boş",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Yalnızca {title} adresli kişiler gösteriliyor",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Kişi Ekle",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "İsim",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Kişiyi Düzenle",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "İptal",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Kaydet",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Vazgeç",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Çık",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Değişiklikleri kaydetme ?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Adres Ekle",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Koin Seçin",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Kayan Yazı Ara",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Kişiyi Sil",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "{name} kişisini silmek istediğinizden emin misiniz ?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "Sil",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "Kişi bulunamadı",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Düzenle",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Bir şey bulunamadı",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "Böyle bir koin yok",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "{abbr} etkinleştirilmediği için {abbr} adresine para gönderemezsiniz. Lütfen portföye gidiniz.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Tamam",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "Kişi adı boş kalamaz",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "{abbr} adresini girin",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Kamuflajlı PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Kamuflajlı PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "Açık",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Kapalı",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "Geçersiz PIN",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Değiştir",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Uygulamanın kilidini Kamuflaj PIN'i ile açarsanız, sahte bir DÜŞÜK bakiye gösterilecek ve Kamuflaj PIN'i yapılandırma seçeneği ayarlarda GÖRÜNMEYECEK",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Normal PIN ve Kamuflajlı PIN kodlarınız aynı.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen Kamuflajlı PIN kodunuzu değiştiriniz.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "Kamuflajlı PIN ve Biyometrik koruma aynı anda etkinleştirilemez.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Kamuflajlı PIN ve Biyometrik Koruma Çakışması",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "Normal PIN koruması aktif değil.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen PIN korumasını aktifleştirin.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Sahte bakiye tutarı:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "Kamuflajlı PIN bulunamadı",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Kamuflajlı PIN kodu oluşturun",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "Kamuflajlı PIN kaydedildi",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "Geçersiz Kamuflajlı PIN",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Kamuflajlı PIN kodunuzu değiştirin",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Kamuflajlı PIN Kurulumu",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Yeni bir kamuflajlı PIN girin",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "Açık",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "Kapalı",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Onaylar",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo dPoW Koruması",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Özel koruma seçenekleri kullan.",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Dikkat ! Bu takas dPoW koruması altında değildir.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "Eşleşme olmazsa Yapıcı Emrine çevir",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEX rasyosu",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Ucuz",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Pahalı",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "CEX'de",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "CEX ile kıyaslanınca",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "ortalama ile karşılaştırıldığında 24 saatlik CEX fiyatı",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Açık",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "Geçmiş",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Detaylar",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Ayrıntıları tek dokunuşla açın ve Uzun dokunuşla sipariş et'i seçin",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "İptal",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Seç",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "Eşleşen sipariş bulunamadı",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Yapıcı Emri",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Alıcı Emri",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Mevcut",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "Yaklaşık",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "Takas başladı",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Toplam",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "İşlem detayları",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Hata mesajını kapat",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Hata Mesajını Aç",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Gelen işlem",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "{coin} işlemi aldınız!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "Takas tamamlandı",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "{sell}/{buy} takası başarıyla tamamlandı",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "Takas başarısız",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy} takası başarısız oldu",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Takas zaman aşımına uğradı",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy} takas zaman aşımına uğradı",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Takas durumu değişti",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Yeni takas başladı",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy} takası başladı",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Diller",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Kur",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Bakiyeleri gizle",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Temayı Değiştir",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "CEX verisi",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Bu simgeyle işaretlenen piyasa verileri (fiyatlar, çizelgeler vb.) üçüncü taraf kaynaklardan (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Güncellemeleri kontrol et",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "Çıkmak istediğinizden emin misiniz ?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Kur",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Çok fazla istek.\nİşlem geçmişi istekleri sınırı aşıldı.\nLütfen daha sonra tekrar deneyiniz.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "ms",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "s",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "dk",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "dakikalar",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "sa",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "Daha Fazla",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "Daha az",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Eski kayıtlar",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Sil",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Cüzdan siliniyor..",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Boşluk kullanıldı",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Tamam",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Ön izlemeyi kapat",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "İptal",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "Devam etmek için aşağı kaydırın...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Geliştirici",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Test Koinlerini Aktifleştir",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Yapıcı Emri detayları",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Sat",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Almak",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Fiyat",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Emri iptal et",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "Emir ID",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "de oluşturuldu",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Bu emirle herhangi bir takas başlamadı",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "Bu emirle takas başladı",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% tamamlandı",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Not",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Not Ekle",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "İçeri Al",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Tek Takas İçeri Al",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Dışa Aktar",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "İçeri Al",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Takas İçeri Al",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Dışa Aktar",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Lütfen şifrelenmiş dosyaya aktarılacak öğeleri seçiniz.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Lütfen içeri alınacak şifrelenmiş dosyayı seçin.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Lütfen içeri alınacak düz metin takas dosyasını seçin.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Açılıyor..",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "İçeri alınacaklar:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Notlar",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Kişiler",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Takaslar",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Bir şey bulunamadı",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Dışa Aktar",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "İçeri Al",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "Parola şifreleme kısmı boş kalamaz",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "Parola kısmı boş kalamaz",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "Parolalar uyuşmalı",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "Bir öğe seçilmedi",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "Bir öğe seçilmedi",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Dosya seç",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Dosya bulunamadı",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Parmak izi",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Parola",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "İptal",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "Tamam",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "Öğeler dışa başarıyla aktarıldı.",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "Öğeler başarıyla içeri alındı.",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Geçersiz şifre ya da hatalı dosya",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Json dosyası çözülürken hata oluştu.",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Emir",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Bilinmeyen Türde Emir",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "İçeri alınamıyor",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Bazı öğeler atlandı.",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "Takas içeri alma başarısız oldu.",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Geçersiz takas bilgisi. Lütfen takas durumunu gösteren geçerli bir JSON dosyası ekleyin.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "{coinName} etkinleştiriliyor",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "Uygulamayı kapatmayın. Daha fazla bilgi için dokunun...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName} Aktivasyonu",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "{protocolName} parası etkinleştirildi",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "{protocolName} parası etkinleştirilmedi",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName} parası başarıyla etkinleştirildi",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} Etkinleştirme Devam Ediyor",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "{protocolName} paraları etkinleştirilsin mi?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Daha fazla bilgi",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Adresi Göster",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Bu işlem olası bir kimlik avı girişimi nedeniyle gizlendi.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "İşlem Adresi",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "İşlem Gizli",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "URL başlatılamadı",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Bu biraz zaman alacak ve uygulamanın ön planda tutulması gerekiyor.\nEtkinleştirme devam ederken uygulamayı sonlandırmak sorunlara yol açabilir.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Uyarı: iOS'ta uygulamanın simge durumuna küçültülmesi etkinleştirme sürecini sonlandıracaktır.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Etkinleştirme ilerlemesiyle ilgili güncellemeleri almak için lütfen bildirimleri etkinleştirin.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "QR Kod Tarayıcı",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "QR Kodu Bulundu",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Sözleşme",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Takası Başlat",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Hiçbiri",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "CEX Oranı",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Gelen {coinName} txs koruma ayarları",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "{maxCount} siparişten {count} tanesi gösteriliyor.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "Az",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "Daha",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "{coinName1}/{coinName2} temel alınarak",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "işlem ücreti gönder işlem ücreti",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "işlem ücreti",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "{coinName} işlem ücretini gönder",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "{coinName} işlem ücretini alın",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Filtre",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Durum",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Hepsi",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Başarılı",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Başarısız",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "den itibaren",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "e kadar",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Alıcı/Yapıcı",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Yapıcı Emir",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "Hepsi",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Alıcı Emir",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Coin sat",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Coin al",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Filtreleri temizle",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Yetersiz bakiye",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "Taranan ödeme talebi için",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "yeterli bakiye yok.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Çok fazla sayıda koin etkinleştirmeye çalışıyorsunuz",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "Var",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "koininiz zaten ekli ve daha fazla etkinleştirmeye çalışıyorsunuz",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "Etkinleştirilebilir maksimum coin sayısı:",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": "Yenilerini eklemeden önce lütfen eskilerinden birkaçını kaldırın.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Maksimum varlık sayısını seçtiniz",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Çok fazla koin aktifleştirildi",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "Var",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "varlıklar etkinleştirildi. Atkif edilebilecek koin limiti:",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": "Yenilerini eklemeden önce lütfen eskilerden birkaçını kaldırın",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Ödeme Talep Edildi",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Koin:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "Adrese",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "Miktar:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "Bu işlemi kabul ediyor musunuz ?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Öde",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "İptal",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} aktif değil. Lütfen aktifleştirip öyle deneyiniz.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Yanlış koin",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "QR kodlu bir ödemeyi",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "taramaya çalışıyorsunuz",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "fakat çekim ekranındasınız",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Sat",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Satın al",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Al",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Gönder",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Kapat",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Aktifleştir",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "Maksimum aktif jeton sayısı {maxCoins}'dir. Lütfen bazılarını devre dışı bırakın.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "{coin} aktifleştirilemedi",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} koini aktif değil !",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Lütfen alınacak {coin} adetini girin",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Lütfen satmak için {coin} miktarı girin",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Daha az göster",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Daha fazla göster",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "Koin bulunamadı",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "Bu yeni bir dönem! 'AtomicDEX' olan ismimizi resmi olarak 'Komodo Wallet' olarak değiştirdik.",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "Resmi basın açıklaması",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "Geçmişteki {coin} işlemleri taransın mı?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "Etkinleştirmeyi İptal Et",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "Hangi {name} işlemlerini senkronize etmek istiyorsunuz?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "Yeni işlemleri senkronize et",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Belirtilen tarihten itibaren senkronizasyon",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Fidan aktivasyonundan senkronizasyon",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Bir Tarih Seçin",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Başlangıç tarihi",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "Genel anahtarınızla ilişkili etkinleştirme sonrasında gelecekte yapılacak işlemleri senkronize edeceğiz. Bu en hızlı seçenektir ve en az depolama alanını kaplar.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "Cüzdanınız geçmiş işlemleri gösterecektir. Tüm bloklar indirilip taranacağından bu, önemli miktarda depolama alanı ve zaman alacaktır.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "Cüzdanınız, belirtilen tarihten sonra yaptığınız geçmiş işlemleri gösterecektir.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "{coinName} etkinleştiriliyor",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} Aktivasyonu",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} Etkinleştirme Devam Ediyor",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Aktif",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Koin etkinleştir",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} başarıyla etkinleştirildi !",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Adres Ekle",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Adres defteri",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "Adres defteri boş",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Yalnızca {title} adresli kişiler gösteriliyor",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Adres Defteri",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "{abbr} etkinleştirilmediği için {abbr} adresine para gönderemezsiniz. Lütfen portföye gidiniz.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Bir şey bulunamadı",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Koin Seçin",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Alıcı adresi",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Gelişmiş",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "Hepsi",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Kişisel kelimeleri kullan",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "Cüzdanınız geçmiş işlemleri gösterecektir. Tüm bloklar indirilip taranacağından bu, önemli miktarda depolama alanı ve zaman alacaktır.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "Zaten mevcut",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Tutar",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Satılacak Tutar",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "Hayır ! Komodo Wallet, gözetimsiz bir cüzdandır. Özel kelimeleriniz, gizli kelimeleriniz ve PIN kodunuz dahil hiçbir hassas bilgiyi kaydetmiyoruz. Bu bilgiler sadece kullanıcının cihazında tutulmaktadır ve başka bir yere gitmez. Bu sayede koin ve tokenlerinizin tüm kontrolü sizdedir.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName}, hem Android hem de iPhone'da mobil cihazlar için ve <a href=\"https://komodoplatform.com/\">Windows, Mac ve Linux işletim sistemlerinde</a> masaüstü için kullanılabilir.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Diğer DEX cüzdanlar genellikle aynı miktar koin ile tek bir alım satım emri vermeye izin verir, ara token kullanır, en önemlisi de tek bir blokzincirin koinlerinin alım satımına olanak sağlar.\n\n{appName} ise birbirinden farklı iki blokzincir ağı arasında ara token kullanmadan doğrudan takas yapmaya imkân sağlar. {appName} 'te aynı miktar koin ile birden fazla alım satım emri verebilirsiniz. Mesela 0.1 BTC ile KMD, QTUM ve VRSC için ayrı ayrı alım emirleri verebilirsiniz ve bunlardan birinin tamamlanması halinde diğerleri kendiliğinden iptal olmuş olurlar.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Her bir takasın tamamlanma sürecini etkileyen birkaç etken vardır. Takas edilen koinlerin bağlı olduğu blokzincirlerin blok çıkarım zamanları (Bitcoin en yavaşıdır) bunda etkilidir. Bunun yanında kullanıcılar, takas öncesinde güvenlik seçeneklerini özelleştirebilir. Mesela bir KMD takasına başlamadan evvel Komodo Wallet'da işlem için 3 onayın yeterli olduğu seçeneği işaretlediğinizde takas süresi <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">noterizasyon</a> eklenmeyeceğinden kısalacaktır.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Evet, takas boyunca uygulamanız açık ve internetinizin de (anlık kesintilerde bir sıkıntı yoktur) bağlı olması gerekmektedir. Aksi halde; eğer yapıcı emri (maker) veren siz iseniz takasın iptal olma durumu, alıcı emri (taker) veren iseniz de koinlerinizi kaybetme riski ortaya çıkar. Komodo Wallet protokolünde takası yapan her iki tarafın da işlem boyunca çevrimiçi olması ve takasın başarılı olması için gereklidir.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "{appName}'te alım satım yaparken bilinmesi gereken iki tür işlem ücreti vardır.\n\n1. {appName}, alıcı emirlerinden işlem başına yaklaşık olarak %0.13 (takriben 777'nin 1'i kadar, fakat bu da 0.0001'den az olmamak kaydıyla) işlem ücreti alırken, yapıcı emirlerinden herhangi bir ücret alınmamaktadır.\n\n2. Hem yapıcı hem de alıcı emir sahiplerinin ödemesi gerekli olan ve takasın gerçekleştiği blokzincirlerin standart ağ işlem ücretleri.\n\nAğ işlem ücretleri, takas yapmak istediğiniz paritelerin kendi işleyişlerine göre değişiklik göstermektedir.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "Evet! {appName}, <a href=\"{link}\">{appCompanyShort} {name}</a> aracılığıyla destek sunar. Ekip ve topluluk her zaman yardımcı olmaktan mutluluk duyar!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "Hayır ! {appName} tamamıyla merkeziyetsizdir ve kullanıcıların uygulamaya erişimi başkaları tarafından sınırlandırılamaz.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName}, {appCompanyShort} takımı tarafından geliştirilmiştir. {appCompanyShort}, koin takası, Geciktirilmiş İş Kanıtı (dPoW), birlikte çalışabilen çoklu zincir mimarisi gibi yenilikçi blokzincir çözümleri geliştiren köklü bir platformdur.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "Kesinlikle! Daha fazla ayrıntı için <a href=\"https://developers.komodoplatform.com/\">geliştirici belgelerimizi</a> okuyabilir veya ortaklık sorularınız için bizimle iletişime geçebilirsiniz. Belirli bir teknik sorunuz mu var? {appName} geliştirici topluluğu her zaman yardıma hazır!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Alkış",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "EMİN MİSİNİZ?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "Takas başarısız oldu",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "takas tamamlanmak üzere",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "Doğrula",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Tekrar aktivasyon işlemi bittiğinde doğrudan portföy sayfasına yönlendirileceksiniz.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "maksimum hacim",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "geri",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Yedekle",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "{coinName1}/{coinName2} temel alınarak",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "Telefonunuzun bataryası güvenli bir takası tamamlayamayacak ({batteryLevelCritical}%) kadar düşük. Lütfen önce şarja takıp sonra tekrar deneyiniz.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "Telefonunuzun bataryası %{batteryLevelLow}'den daha az. Lütfen telefonunuzu şarj ediniz.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "Telefonunuz batarya tasarruf modunda. Lütfen bu modu devre dışı bırakın ya da başvuru uygulamasını arka plana KOYMAYIN. Aksi halde uygulama, işletim sisteminiz tarafından kapatılabilir ve devam etmekte olan takasınız varsa başarısız olabilir.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Mevcut en iyi fiyat",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Komodo Üzerinde Yapılmıştır",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Komodo Üzerinde Yapılmıştır",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Al",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Eşleşme olmazsa Yapıcı Emrine çevir",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Takas işlendi, lütfen bekleyiniz.",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Emir eşleşmesi devam ediyor, lütfen {seconde} saniye kadar bekleyiniz.",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan almak üzeresiniz.",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Kamuflajlı PIN ve Biyometrik koruma aynı anda etkinleştirilemez.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Kamuflajlı PIN ve Biyometrik Koruma Çakışması",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Kamuflajlı PIN kodunuzu değiştirin",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Kamuflajlı PIN kodu oluşturun",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Uygulamanın kilidini Kamuflaj PIN'i ile açarsanız, sahte bir DÜŞÜK bakiye gösterilecek ve Kamuflaj PIN'i yapılandırma seçeneği ayarlarda GÖRÜNMEYECEK",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "Geçersiz Kamuflajlı PIN",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Kamuflajlı PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Kamuflajlı PIN bulunamadı",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Kapalı",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "Açık",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Kamuflajlı PIN kaydedildi",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Kamuflajlı PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Yeni bir kamuflajlı PIN girin",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Kamuflajlı PIN Kurulumu",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Kamuflajlı PIN Kurulumu",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "İptal",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Etkinleştirmeyi İptal Et",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "İptal",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Emri İptal Et",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Bir hata oluştu, lütfen daha sonra tekrar deneyiniz.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Tamam",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "Ön tanımlı bir koindir. Ön tanımlı koinler kaldırılamaz",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Kaldırılamaz",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Bu oynatılamıyor",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEX rasyosu",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEX verisi",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Bu simgeyle işaretlenen piyasa verileri (fiyatlar, çizelgeler vb.) üçüncü taraf kaynaklardan (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEX Oranı",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "PIN kodunu değiştir",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Güncellemeleri kontrol et",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Ödeme",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Gizli kelimeleri kontrol edin",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "DEVAM",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "GERİ DÖN VE KONTROL ET",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "{index} kelimesini giriniz.",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "Gizli kelimeleriniz çok önemlidir, bu yüzden onları doğru kaydettiğinizden emin olmak istiyoruz. Cüzdanınızı istediğiniz zaman kolayca geri yükleyebilmeniz için gizli kelimeleriniz hakkında size şimdi üç farklı soru soracağız.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "Gizli kelimeleriniz arasından {index} olanı hangisidir ?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "GİZLİ KELİMELERİZİ BİR KEZ DAHA KONTROL EDİNİZ",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Çince",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "talep et",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "KMD ödülünüzü alın",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Görmek için tıklayın",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Panoya kopyalandı",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Panoya kopyala",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Kapat",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Hata mesajını kapat",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Ön izlemeyi kapat",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Kod:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Maksimum varlık sayısını seçtiniz",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName} parası etkinleştirildi",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName} parası başarıyla etkinleştirildi",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "{protocolName} parası etkinleştirilmedi",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Temizle",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "Aktif koin yok",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Koin Seç",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Yakında...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "TX detayları yakında !",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "Detaylar yakında !",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "komisyon ücreti",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "ortalama ile karşılaştırıldığında 24 saatlik CEX fiyatı",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "CEX ile kıyaslanınca",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Cüzdanınız ayarlanıyor, lütfen bekleyiniz..",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Onayla",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Kamuflajlı PIN'i Onaylayın",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Emri iptal etmek istediğinizden emin misiniz ?",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "Aşağıdaki düğmeye tıklayarak 'EULA' ve 'Kullanım Şartları'nı okumuş ve kabul etmiş sayılırsınız",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Parolayı onayla",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "PIN kodunu onayla",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Gizli Kelimeleri Onayla",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Bağlanıyor..",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "İptal",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Kişiyi Sil",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Sil",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "{name} kişisini silmek istediğinizden emin misiniz ?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Vazgeç",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Düzenle",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Çık",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Değişiklikleri kaydetme ?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "Kişi bulunamadı",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Kaydet",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Kişi detayları",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "İsim",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Sözleşme",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Dönüştür",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "URL başlatılamadı",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "İçeri alınamıyor",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "Ticaret",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "CÜZDAN OLUŞTUR",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Kişi Ekle",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "PIN Kodu Oluştur",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Kur",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Kur",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Mevcut değer:",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Özelleştirilmiş gider",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "Özelleştirilmiş giderleri yalnızca ne yaptığınızdan emin olduğunuzda kullanın !",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Özelleştirilmiş gizli kelime kullanımı yeterince güvenli olmayabilir ve uygulama tarafından oluşturulan BIP39 uyumlu gizli kelimeler ya da özel anahtara (WIF) kıyasla daha kolay kırılabilmektedir. Riskleri kabul edip ne yaptığınızdan emin olduğunuzu tasdiklemek için aşağıdaki kutucuğa \"{iUnderstand}\" yazınız.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Tarih",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Cüzdan deşifre ediliyor",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Sil",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Devre dışı bırakmayı onayla",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "Kaldırmak istiyor musunuz",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "portföyünüzden mi? Eşleşmeyen tüm siparişler iptal edilecektir.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " ayrıca devre dışı bırakılacak",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Cüzdanı Sil",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Cüzdan siliniyor..",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "{coinName} işlem ücretini alın",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "{coinName} işlem ücretini gönder",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "işlem ücreti gönder işlem ücreti",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "işlem ücreti",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "detaylar",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Almanca",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Geliştirici",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "Bu koin DEX'te yoktur",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Ekran Görüntülerini/Önizlemeyi Devre Dışı Bırak",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Yasal Uyarı ve Kullanım Şartları",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Bitti",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Uygulamayı kapatmayın. Daha fazla bilgi için dokunun...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Tekrar sorma",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "Parola istemiyorum",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW Koruması",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Süre",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Kişiyi Düzenle",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "{abbr} adresini girin",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "Parola şifreleme kısmı boş kalamaz",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "Parola kısmı boş kalamaz",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Kişi adı boş kalamaz",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "Cüzdan adı boş kalamaz",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Yine de {remas} özelliğini etkinleştirebilirsiniz, Seçilen: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Etkinleştirme ilerlemesiyle ilgili güncellemeleri almak için lütfen bildirimleri etkinleştirin.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Test Koinlerini Aktifleştir",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "Var",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "koininiz zaten ekli ve daha fazla etkinleştirmeye çalışıyorsunuz",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "Etkinleştirilebilir maksimum coin sayısı:",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": "Yenilerini eklemeden önce lütfen eskilerinden birkaçını kaldırın.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Çok fazla sayıda koin etkinleştirmeye çalışıyorsunuz",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Cüzdan şifreleniyor",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "İngilizce",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Yeni PIN kodunu giriniz",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Eski PIN kodunu giriniz",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Lütfen devam etmek için parolanızı giriniz",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "PIN Kodunuzu giriniz",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Gizli kelimelerinizi giriniz",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Önce satış miktarını girmelisiniz",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Yeterli bakiye yok",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Geçerli bir adres değil",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Segwiit adresler henüz desteklenmemektir",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Yeteri kadar gaz ücreti yok, en az {gas} Gwei gerekli",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Hata, lütfen tekrar deneyiniz",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Hata, lütfen daha sonra deneyiniz",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "Değer çok yüksek ya da çok düşük",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Lütfen veri giriniz",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Tahmini Toplam Değer",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Örnek: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Ucuz",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Pahalı",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "CEX'de",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Takas rasyosu:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "TAKAS",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Dışa Aktar",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Kişiler",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Lütfen şifrelenmiş dosyaya aktarılacak öğeleri seçiniz.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Dışa Aktar",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Notlar",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Öğeler dışa başarıyla aktarıldı.",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Takaslar",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Dışa Aktar",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Başarısız",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Sahte bakiye tutarı:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Sıkça Sorulan Sorular",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Hata",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "{coin} musluğuna talep gönderiliyor..",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "MUSLUK",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Başarılı",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "Talep zaman aşımına uğradı",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Geri Bildirim Gönder",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Haberler",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Bir şey yok",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} haberleri",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Daha fazlası için..",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Bülten",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Haber Bülteni",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Haber güncellemeleri alınamıyor",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Haber güncellemeleri alınamıyor",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Haber bülteni güncellendi",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Zaten güncel",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Ücretler en fazla {value} olmalıdır",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Hepsi",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Filtre",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Filtreleri temizle",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Başarısız",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "den itibaren",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Yapıcı Emir",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Coin al",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Coin sat",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Durum",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Başarılı",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Alıcı Emir",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "e kadar",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Alıcı/Yapıcı",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Parmak izi",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Bitiriliyor, lütfen bekleyin",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "QR Kodu Bulundu",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Fransızca",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "Gönderici",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "Genel anahtarınızla ilişkili etkinleştirme sonrasında gelecekte yapılacak işlemleri senkronize edeceğiz. Bu en hızlı seçenektir ve en az depolama alanını kaplar.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} gideri",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "Gaz ücreti limiti",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Lütfen {coin} koinini aktifleştirin.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "Gaz ücreti",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "Normal PIN koruması aktif değil.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen PIN korumasını aktifleştirin.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Önemli: Devam etmeden önce gizli kelimelerinizi güvenli bir şekilde yedekleyin !",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "İşlem alınıyor, lütfen bekleyin",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Portföye git",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei en fazla {value} olmalıdır",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Yardım",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Yardım ve Destek",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Bakiyeleri gizle",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Parolayı Onayla",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Parola Oluştur",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Mevcut parola",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Parolanızı girin",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Gizli kelimelerinizi girin",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Cüzdanınızı adlandırın",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Parola",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "geçmiş",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "sa",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Macarca",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "İçeri Al",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Geçersiz şifre ya da hatalı dosya",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "İçeri alınacaklar:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Dosya bulunamadı",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Geçersiz takas bilgisi. Lütfen takas durumunu gösteren geçerli bir JSON dosyası ekleyin.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "İçeri Al",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Lütfen içeri alınacak şifrelenmiş dosyayı seçin.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Açılıyor..",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Lütfen içeri alınacak düz metin takas dosyasını seçin.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "İptal",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "Tamam",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Parola",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Tek Takas İçeri Al",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Takas İçeri Al",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Bazı öğeler atlandı.",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Öğeler başarıyla içeri alındı.",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Takas içeri alma başarısız oldu.",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Json dosyası çözülürken hata oluştu.",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "İçeri Al",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Gelen {coinName} txs koruma ayarları",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Güvenlı bir parola kullanın ve onu, uygulamayı kullandığınız cihazda saklamayın.",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "Takas talebi geri alınamaz ve bu nihai bir işlemdir !",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "Bu işlem 60 dakikaya kadar sürebilir. Uygulamayı KAPATMAYINIZ !",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Cüzdanınızın güvenlik tehditlerine karşı şifrelenebilmesi için bir parola ayarlamalısınız.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} bakiyesi, alım satım işlem ücretlerini karşılamaya yetmiyor.",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "Bu işlem için gereken en az hacim şu kadardır",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Yetersiz hacim",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Yenile",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "İnternet Bağlantısı Yeniden Sağlandı",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Geçersiz {coin} adresi",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "Takasa devam edilemiyor",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Detaylar",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} mevcut değil :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "Anladım",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Japonca",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Koreli",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Diller",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Son İşlemler",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Yasal",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Daha az",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Dikkat! {coinName} piyasasının 24 saatlik işlem hacmi 10 bin dolardan az!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "Sınır en fazla {value} olmalıdır",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Yükleniyor..",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Emir defteri yükleniyor...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "Ekran kilitli",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "Lütfen doğrulayın !",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "Giriş",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Çıkış",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Kapanışta Çıkış Yap",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Çıkış Ayarları",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "Çıkmak istediğinizden emin misiniz ?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "dakikalar",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "bir emir girin",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Yapıcı Emri",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Emri iptal et",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "de oluşturuldu",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Almak",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "Emir ID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Bu emirle herhangi bir takas başlamadı",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Fiyat",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Sat",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Bu emirle takas başladı",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Yapıcı Emri detayları",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Yapıcı Emri",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Pazar",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Tablo",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Derinlik",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "Soru bulunamadı",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "Teklif bulunamadı",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "EMİR DEFTERİ",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Emir Detayları",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "FİYAT",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Lütfen koinleri seçiniz",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Piyasalar",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "PİYASALAR",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Parolalar uyuşmalı",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Değiştir",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Normal PIN ve Kamuflajlı PIN kodlarınız aynı.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen Kamuflajlı PIN kodunuzu değiştiriniz.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "Geçersiz PIN",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "MAKSİMUM",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Maksimum Emir Hacmi",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Haberler",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "GÖZAT",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "BÜLTENE GÖZAT",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "Yazar:",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "KAYDEDİLMİŞ BİR MAKALENİZ YOK",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "KAYDEDİLDİ",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Hafıza",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Birleştir",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Birleştirilmiş değer:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "ms",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "DK",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Uyarı: iOS'ta uygulamanın simge durumuna küçültülmesi etkinleştirme sürecini sonlandıracaktır.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "En düşük emir hacmi",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "dk",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "{coinName} için yapılabilecek en düşük satış hacmi: {number}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "{coinName} için yapılabilecek en düşük alım hacmi: {number}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "En düşük emir için: {buyCoin} {buyAmount}\n({sellCoin} {sellAmount})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "{coinName} için en düşük satım miktarı: {number}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "{minValue} {coin}'den büyük olmalı",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Satış miktarından düşük olmalı",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Gereken en düşük hacim",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "hacim",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Lütfen artık hücresel veri kullandığınızı ve {appName} P2P ağına katılımınızın internet trafiğini tükettiğini unutmayın. Hücresel veri planınız maliyetliyse bir WiFi ağı kullanmak daha iyidir.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Daha fazla bilgi",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "Daha Fazla",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Önce {coin}'i etkinleştirin ve bakiyeyi tamamlayın",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Miktar",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Koin",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Sat",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "İptal",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Onayla",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "{number} Sipariş oluştur:",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Oluştur",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Emir",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Emirler",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "tutar",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "İptal",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Lütfen almak istediğiniz itibari para miktarını giriniz:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Otomatik doldur",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Devam etmeden önce lütfen hataları gideriniz",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Geçersiz miktar",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Geçersiz satış miktarı",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "İşlem masrafını ödemeye yetecek {coin} yok. En az {fee} {coin} olmalı.",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin} bakiyesi yetersiz",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "En fazla satış miktarı:",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "En az alım miktarı:",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "En satış miktarı:",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Al:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Sat:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Çoklu",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Alınacak Miktar",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "CEX/Ücret",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Ağ ücreti",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "yeni hesap",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Yeni Hesap",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Haber akışı",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Yeni değer:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "sonraki",
-  "@next": {
-    "type": "text"
-  },
-  "no": "Hayır",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "Şimdilik bir haber yok. Lütfen daha sonra tekrar deneyiniz.",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "Koin bulunamadı",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Fon yok",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "Fon mevcut değil. Lütfen para yatırın.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "İnternet Bağlantısı Yok",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "Bir öğe seçilmedi",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "Bir öğe seçilmedi",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "Eşleşen sipariş bulunamadı",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Hiçbiri",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "Girilen değer rakam olmalı",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Uygun bir {coinName} emri bulunmuyor - bir emir girmeyi deneyin veya daha sonra yeniden kontrol edin.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Emir oluşturmak için tıklayın",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "Emir yok, lütfen ticarete gidin.",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "Alınabilecek bir ödül yok",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "Alabileceğiniz bir ödül mevcut değil - 1 saat sonra yeniden deneyin.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "Böyle bir koin yok",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "Geçmiş yok.",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "İşlem için yeteri kadar {coin} yok !",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "Takas masrafını karşılayacak bakiye bulunmuyor - daha küçük tutar deneyin",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Eşleşmiş bir emir tekrardan iptal edilemez.",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Not Ekle",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Not",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Bir şey bulunamadı",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "{sell}/{buy} takası başarıyla tamamlandı",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Takas tamamlandı",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy} takası başarısız oldu",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Takas başarısız",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy} takası başladı",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Yeni takas başladı",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Takas durumu değişti",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy} takas zaman aşımına uğradı",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Takas zaman aşımına uğradı",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "{coin} işlemi aldınız!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Gelen işlem",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "İşlem Yok",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} Varlıklar",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Resmi basın açıklaması",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Tamam",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Sil",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Eski kayıtlar",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Boşluk kullanıldı",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Hata Mesajını Aç",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "İsteğe bağlı",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "Az",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "Daha",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Tüm {coin} emirleri iptal edilecek",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Emir oluşturuldu",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Emir başarıyla oluşturuldu",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Adres",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "İptal",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Ucuz: CEX + %{delta}",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Pahalı: CEX + %{delta}",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "için",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "CEX'de",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "en az",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Fiyat",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Al",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Seç",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Satışlar",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Ayrıntıları tek dokunuşla açın ve Uzun dokunuşla sipariş et'i seçin",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Harca",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Detaylar",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% tamamlandı",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Emir eşleşti",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Emir eşleşiyor",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "emirler",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Açık",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "Geçmiş",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "({coin}) miktarı",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "({coin}) fiyatı",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Toplam ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Emir",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Bilinmeyen Türde Emir",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Üstüne yaz",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "Bu sizin kendi emriniz !",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Bakiyeden ödendi:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Alınan miktardan ödendi:",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Ödendi",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "Parolanız en az 12 karakterden oluşurken en az; bir büyük harf, bir küçük harf ve bir sembol içermelidir.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "Cüzdanınız, belirtilen tarihten sonra yaptığınız geçmiş işlemleri gösterecektir.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Öde",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Bu işlemi kabul ediyor musunuz ?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "Adrese",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "Miktar:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Koin:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "İptal",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Ödeme Talep Edildi",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} aktif değil. Lütfen aktifleştirip öyle deneyiniz.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Emrinizi girin",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "Tam seste oynat",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Lütfen bir Koin Ekleyiniz",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Yeniden denemek için lütfen uygulamayı yeniden başlatın ya da aşağıdaki düğmeye basınız.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Portföy",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Komodo tarafından geliştirilmiştir",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "fiyat",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Gizli Kelime",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Gizli Kelimeler",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Onaylar",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Özel koruma seçenekleri kullan.",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "Kapalı",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "Açık",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Dikkat ! Bu takas dPoW koruması altında değildir.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Açık Adres",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "QR Kod Tarayıcı",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Gizli kelimelerimi kaydediyor musunuz ?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "Komodo Wallet'ı hangi cihazlarda kullanabilirim ?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "{appName}'te alım satım yapmanın diğer DEX'lerdekinden ne gibi farkları vardır ?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "Takas işlemleri ne kadar sürmektedir ?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "Takas işlemi boyunca çevrimiçi olmam mı gerekir ?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "{appName}'te işlem ücretleri nasıl hesaplanmaktadır ?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Kullanıcılara destek sunuyor musunuz ?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Uygulamanın kullanılamadığı ülkeler var mı ?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Komodo Wallet'ın arkasında kimler var ?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "{appName} üzerinde kendi beyaz etiketli değişimimi geliştirmem mümkün mü?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "Bu yeni bir dönem! 'AtomicDEX' olan ismimizi resmi olarak 'Komodo Wallet' olarak değiştirdik.",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "AL",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Al",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Çevrimdışı bir şekilde saklamanızı öneririz.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Devre dışı bırak",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Talep Edilen Alım Satım",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "TEMİZLE",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Geri Yükleme Formu",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "GERİ YÜKLE",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Tüm koinleri aktifleştirmeyi tekrar deniyor..",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Hepsini aktifleştirmeyi tekrar dene",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Ödülünüzü alın",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Vazgeç",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "İşlem sürmekte",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "işleniyor",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO miktarı 10 KMD'den az",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Henüz 1 saat geçmedi",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 saat",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "Tamam",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Ödül durumu:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "KMD aktif kullanıcı ödülleri hakkında daha fazla bilgi edinin",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Al",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Başarılı ! {amount} KMD geldi.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "İtibari para",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "KMD Ödülleri",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Durum",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Kalan zaman",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Ödül bilgisi:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO amt,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} gün",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}sa {minutes}dk",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}dk",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Ödül bilgisi",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Rusça",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Birleştirilmiş kaydet",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Devam etmek için aşağı kaydırın...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Bir koin ara",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Tüm AVAX tokenlerini seç",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Tüm BEP tokenlerini seç",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Hepsini seç Cosmos Ağı",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Tüm ERC tokenlerini seç",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Tüm ETC tokenlerini seç",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Tüm Fantom tokenlerini seç",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Tüm HecoChain tokenlerini seç",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Tüm Harmony tokenlerini seç",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Tüm İris Ağını seç",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Tüm Kucoin tokenlerini seç",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Tüm Moonriver tokenlerini seç",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Tüm Polygon tokenlerini seç",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Tüm QRC tokenlerini seç",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Tüm SmartBCH tokenlerini seç",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Tüm SLP belirteçlerini seçin",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Tüm SmartChain koinlerini seç",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Tüm test koinlerini seç",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Tüm Ubiq koinlerini seç",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Tüm UTXO koinlerini seç",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Tüm ZHTLC paralarını seç",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Kayan Yazı Ara",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "s",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Güvenlik",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Gizli Kelimeler",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Yeni Gizli Kelimeleriniz",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "{amount} adet emri görmek için tıklayın",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "İşlem Geçmişini Görüntüle",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Koin seçin",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Portföyünüze eklemek istediğiniz koinleri seçin.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Koin etkinleştir:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "ALMAK istediğiniz koini seçin",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "SATMAK istediğiniz koini seçin",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Bir Tarih Seçin",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Seçili emir:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Dosya seç",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Dili Seç",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Ödeme Yönteminizi Seçin",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Sat",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Dikkat ! Test koinlerini herhangi bir değer olmadan satmak üzeresiniz",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "GÖNDER",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Silmek istediğine emin misin",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "cüzdan?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Eğer eminseniz",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "daha sonra cüzdanınızı kurtarabilmeniz için",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "gizli kelimelerinizi kaydedin.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Diller",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Ayarlar",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "PAROLA BELİRLE",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Paylaş",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "{coinName} adresim:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "Geçmişteki {coin} işlemleri taransın mı?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Adresi Göster",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Detayları Göster",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "{maxCount} siparişten {count} tanesi gösteriliyor.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "EMİRLERİMİ GÖSTER",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Parola ile giriş yap",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Parolayı mı unuttunuz ? Gizli kelimelerinizle giriş yapın.",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Basit",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Aktifleştir",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Lütfen alınacak {coin} adetini girin",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Satın al",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Kapat",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "Maksimum aktif jeton sayısı {maxCoins}'dir. Lütfen bazılarını devre dışı bırakın.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} koini aktif değil !",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Al",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Lütfen satmak için {coin} miktarı girin",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Sat",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Gönder",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Daha az göster",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Daha fazla göster",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "{coin} aktifleştirilemedi",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Geç",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Kapat",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Ses",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Lütfen bir mp3 ya da waw dosyası seçin. {description}'de ses dosyalarını oynatacağız.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "{description}'de oynatıldı.",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Sesler",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Anladım, bunu tekrar gösterme",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Ses",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Ses seçenekleri",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "Takas boyunca ve açık bir yapıcı emriniz varken bazı sesli bilgilendirmeler duyacaksınız.\nPürüzsüz bir takas için her iki tarafın da işlem boyunca çevrimiçi olması gerekmektedir ve sesli bildirimler buna yardımcı olmaktadır.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Kendi özelleştirilmiş sesli bildirimlerinizi uygulamanın ayarlar bölümünden etkinleştirebileceğinizi unutmayın.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "İspanyolca",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Başlangıç tarihi",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Takası Başlat",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Adım",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Başarılı !",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Destek",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Herhangi bir sorunuz varsa veyahut {appName} uygulamasıyla ile ilgili teknik bir hata bulduğunuzu düşünüyorsanız bunu ekibimize bildirebilir ve destek alabilirsiniz.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "takas",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Mevcut",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "TAKAS DETAYLARINI ONAYLA",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Yaklaşık",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Takas başarısız",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Lütfen önce {coin} ve kontör bakiyesini etkinleştirin",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "{coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük. {amount} {coin} gerekli.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Takas devam ediyor",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "İşlem detayları",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "Takas başladı",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Başarılı Takas",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Toplam",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "Takas UUID",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Temayı Değiştir",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Belirtilen tarihten itibaren senkronizasyon",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Fidan aktivasyonundan senkronizasyon",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Yeni işlemleri senkronize et",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "Hangi {name} işlemlerini senkronize etmek istiyorsunuz?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Alıcı Emri",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Alıcı Emri",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Zaman Aşımı",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "PAROLA OLUŞTUR",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Emir seçildi",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "Alıcı",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "Adrese:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "Var",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "varlıklar etkinleştirildi. Atkif edilebilecek koin limiti:",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": "Yenilerini eklemeden önce lütfen eskilerden birkaçını kaldırın",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Çok fazla koin aktifleştirildi",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Toplam Masraflar",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "ALIM SATIM",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "TAKAS TAMAMLANDI !",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "ALIM SATIM DETAYLARI",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Alım satım işlem giderleri hesaplanamadı",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "Alım satım işlem gideri:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Alım Satım Modu:",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "İşlem Adresi",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "İşlem Gizli",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Bu işlem olası bir kimlik avı girişimi nedeniyle gizlendi.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "Bazı yeni koinler etkileştirilemedi ise uygulamayı tekrar başlatmayı deneyiniz.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Türkçe",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Blok",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Onaylar",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "ONAYLANDI",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Ücret",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "İşlem ücreti",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "İşlem numarası",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Kalan işlem: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Çok fazla istek.\nİşlem geçmişi istekleri sınırı aşıldı.\nLütfen daha sonra tekrar deneyiniz.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "onaylanmamış",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Ukrayna",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "kilidi aç",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Fonların Kilidini Açın",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "{amnt} fonun kilidi başarıyla kaldırıldı - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "harcanamaz",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Yeni sürüm mevcut",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Güncellemeler kontrol ediliyor..",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "{version} sürümünü kullanmaktasınız.",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Yeni sürüm mevcut. Lütfen güncelleyiniz.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Güncel {version} sürümü mevcut. Lütfen güncelleyiniz.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Güncelleme mevcut",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Şimdilik atla",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "Komodo Wallet güncellemeleri",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Güncelle",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Son sürüm yüklü",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Taranan ödeme talebi için",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "yeterli bakiye yok.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Yetersiz bakiye",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Değer:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "sürüm",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Tarayıcı",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Gizli ve Özel Kelimeler",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Hacim",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "Bu cüzdan adı zaten kullanımda",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "Cüzdan adı en fazla 40 karakter içerebilir",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Sadece cüzdan",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "Dikkat !",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Tamam",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Dikkat ! Bu kayıt defteri özel durumlarda, başarısız takaslardan kalan koinlerin harcanmasına sebep olabilecek hassas bilgiler içerebilir.",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "{coinAbbr} koinini etkinleştiremedik.",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "{coinAbbr} koinini etkinleştiremedik.\nLütfen uygulamayı yeniden başlatıp tekrar deneyiniz.",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "Komodo Wallet mobil yerleşik üçüncü nesil DEX işlevselliği ve daha fazla özellikleri ile yeni nesil bir çoklu koin cüzdanıdır.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "HADİ AYARLAYALIM !",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "HOŞ GELDİNİZ",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "cüzdan",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "Tamamlandığında portföy ekranına yönlendirileceksiniz.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Bu biraz zaman alacak ve uygulamanın ön planda tutulması gerekiyor.\nEtkinleştirme devam ederken uygulamayı sonlandırmak sorunlara yol açabilir.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Çek",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "{appName}'in kameraya erişimi engellenmiş.\nQR kod taramasını yapabilmek için lütfen telefon ayarlarınızdan kamera erişimine izin veriniz.",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Erişim Engellendi",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Çekimi Onayla",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "{amount} adet {coinName} ÇEK",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "QR kodlu bir ödemeyi",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "taramaya çalışıyorsunuz",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "fakat çekim ekranındasınız",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Yanlış koin",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "Parola eşleşmiyor. Lütfen tekrar deneyin.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Evet",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Gönderiyorsunuz:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "mevcut bir siparişle eşleşmeye çalışan yeni bir siparişiniz var",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "devam eden aktif bir takasınız var",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "yeni siparişlerin eşleşebileceği bir siparişiniz var",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "Cüzdanınız",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "{amount} adet {coin} alacaksınız",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Alacağınız:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1,3726 +1,5518 @@
 {
-  "@@locale": "uk",
-  "accepteula": "Прийняти EULA",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "Прийміть ПОЛОЖЕННЯ та УМОВИ",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "Активуйте біометричний захист",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "Увімкніть захист PIN-кодом",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "Активувати монети {protocolName}?",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "Зауважте, що зараз ви використовуєте мобільні дані та участь у мережі {appName} P2P споживає інтернет-трафік. Краще використовувати мережу WiFi, якщо ваш тарифний план стільникового зв’язку є дорогим.",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "Доступ заборонено",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "Ви раніше забороняли {appName} доступ до камери. Будь ласка, вручну змініть дозвіл камери в налаштуваннях телефону, щоб продовжити сканування QR-коду",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "ЛАСКАВО ПРОСИМО",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "гаманця",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} mobile — це мультимонетний гаманець нового покоління з вбудованою функцією DEX третього покоління та більше.",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "ДАВАЙТЕ НАЛАШТОВУВАТИ!",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:\n\n",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)\n\n",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER\n\n",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE\n\n",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS\n\n",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE\n\n",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP\n\n",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS\n\n",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING\n\n",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY\n\n",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS\n\n",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER\n\n",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY\n\n",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS\n\n",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION\n\n",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET\n\n",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE\n\n",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION\n\n",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS\n\n",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS\n\n",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.\n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application.\nYour access to this application does not itself create an adviser-client relationship between You and us.\nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us.\nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free.\nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies).\n\n",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}.\nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application.\nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights.\nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information;\n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages.\nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You.\nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from:\n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses;\n(b) server failure or data loss;\n(c) corrupted or otherwise non-performing Wallets or Wallet files;\n(d) unauthorized access to applications;\n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}.\nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination.\nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination.\n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time.\n\n",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data).\nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "Оновлення {appName}",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "Ви використовуєте версію {version}",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "Перевірка оновлень...",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "Вже актуально",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "Доступна нова версія",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "Оновлення",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "Пропустити поки що",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "Доступне оновлення",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "Доступна нова версія. Будь ласка, оновіть.",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "Доступна версія {version}. Будь ласка, оновіть.",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "Допомога",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "Допомога та підтримка",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "Часто задавані питання",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "Підтримка",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "Якщо у вас виникли запитання або ви вважаєте, що виявили технічну проблему з додатком {appName}, ви можете повідомити про це та отримати підтримку від нашої команди.",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "Ви зберігаєте мої особисті ключі?",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "Ні! {appName} не зберігє. Ми ніколи не зберігаємо жодних конфіденційних даних, враховуючи ваші насінні ключі, початкові фрази або PIN-код. Ці дані зберігаються лише на пристрої користувача і ніколи не залишають його. Ви повністю контролюєте свої активи.",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "Чим торгівля в {appName} відрізняється від торгівлі в інших DEX?",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "Інші DEX, як правило, дозволяють лише торгувати активами, які базуються на одній мережі блокчейну, використовують проксі-токени та дозволяють розміщувати лише одне замовлення з тими самими коштами.\n\n{appName} дає вам змогу безпосередньо торгувати між двома різними блокчейн-мережами без проксі-токенів. Ви також можете розмістити кілька замовлень з однаковими коштами. Наприклад, ви можете продати 0,1 BTC за KMD, QTUM або VRSC — перше заповнене замовлення автоматично скасовує всі інші замовлення.",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "Скільки часу займає кожна атомарна заміна?",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "Кілька факторів визначають час обробки для кожного обміну. Час блокування торгових активів залежить від кожної мережі (біткойн зазвичай найповільніший). Крім того, користувач може налаштувати параметри безпеки. Наприклад, ви можете попросити {appName} вважати транзакцію KMD остаточною лише після 3 підтверджень, що скорочує час обміну порівняно з очікуванням <a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">нотаріальне засвідчення</a>.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "Чи потрібно мені бути онлайн під час обміну?",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "Так. Ви повинні залишатися підключеними до Інтернету та запустити програму, щоб успішно завершити кожну атомарну заміну (дуже короткі перерви в з’єднанні зазвичай не впливають). В іншому випадку існує ризик скасування угоди, якщо ви мейкер, і ризик втрати коштів, якщо ви тейкер. Протокол атомарного обміну вимагає, щоб обидва учасники залишалися онлайн і контролювали задіяні блокчейни, щоб процес залишався атомарним.",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "Як розраховуються комісії за {appName}?",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "Під час торгівлі в {appName} слід враховувати дві категорії комісій.\n\n1. {appName} стягує приблизно 0,13% (1/777 об’єму торгів, але не менше 0,0001) як комісію за торгівлю замовленням-тейкерам, а замовлення-виконавці не мають комісії.\n\n2. Як виробники, так і приймачі повинні будуть сплачувати звичайні мережеві збори залученим блокчейнам під час здійснення транзакцій атомарного свопу.\n\nПлата мережі може значно відрізнятися залежно від вибраної торгової пари.",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "Чи забезпечуєте ви підтримку користувачів?",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "Так! {appName} пропонує підтримку через <a href=\"{link}\">{appCompanyShort} {name}</a>. Команда та спільнота завжди раді допомогти!",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "Чи є у вас обмеження по країні?",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "Ні! {appName} повністю децентралізовано. Неможливо обмежити доступ користувача сторонніми особами.",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "Хто стоїть за {appName}?",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} розроблено командою {appCompanyShort}. {appCompanyShort} — це один із найпопулярніших блокчейн-проектів, який працює над інноваційними рішеннями, такими як атомарні свопи, відкладене підтвердження роботи та взаємодіюча багатоланцюгова архітектура.",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "Чи можна розробити власну біржу white-label у {appName}?",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "Абсолютно! Щоб дізнатися більше, прочитайте нашу <a href=\"https://developers.komodoplatform.com/\">документацію для розробників</a> або зв’яжіться з нами із запитами про партнерство. Є конкретне технічне запитання? Спільнота розробників {appName} завжди готова допомогти!",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "На яких пристроях я можу використовувати {appName}?",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName} доступний для мобільних пристроїв на Android і iPhone, а також для комп’ютерів в <a href=\"https://komodoplatform.com/\">операційних системах Windows, Mac і Linux</a>.",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Новини",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Стрічка новин",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "Детальніше...",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "Тут нічого",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Стрічку новин оновлено",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "Відхилити",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "Новини",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "Тривалість",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "Не вдалося отримати оновлення новин",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "Не вдалося продовжити оновлення новин",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "Вже актуально",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "Дата",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "Новини {appCompanyShort}",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "Створити PIN-код",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "Введіть свій PIN-код",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "логін",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "Новий акаунт",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "Новий акаунт",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "{name} успішно активовано!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "Підключення...",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "Активувати монету",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} активів",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "Введіть свою насінну фразу",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "Приклад: build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "Підтвердити",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "Попередження, ви можете купити тестові монети БЕЗ реальної вартості!",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "Заряд акумулятора має вирішальне значення ({batteryLevelCritical}%) для безпечної заміни. Будь ласка, зарядіть його та повторіть спробу.",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "Заряд акумулятора нижчий ніж {batteryLevelLow}%. Будь ласка, врахуйте зарядку телефону.",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "Ваш телефон у режимі економії заряду аккумулятора. Будь-ласка, вимкніть цей режим або НЕ переводьте програму у фоновий режим, інакше програма може бути закрита ОС і заміна не вдасться.",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "Увага! Ви готові продати тестові монети БЕЗ реальної вартості!",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "Купити",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "Продати",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "Моя адреса {coinName}:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "Відправити",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "Значення занадто високе або низьке",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "Сума",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "Адреса отримувача",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "ВІДПРАВИТИ {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "Підтвердити зняття",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "Щось пішло не так. Спробуйте ще раз пізніше.",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "Закрити",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "Підтвердьте насінну фразу",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "Ваша нова насінна фраза",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "Важливо: створіть резервну копію насінної фрази, перш ніж продовжити!",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "Ми рекомендуємо зберігати його офлайн.",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "далі",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "Підтвердьте PIN-код",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "Налаштування камуфляжного PIN-коду",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "Підтвердіть комуфляжний PIN-код",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "Помилка, спробуйте ще раз",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "Налаштування",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "Безпека",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "Увімкніть захист PIN-кодом",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "Вимкнути знімки екрана/попередній перегляд",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "Екран заблоковано",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "Змінити PIN-код",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "Вийти",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "МАКС",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "ХВ",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "Усього камісії:",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "Сплачується з баланасу:",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "Режим торгівлі",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "Пропустити",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "Зʼєднати",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "Перезаписати",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "Поточна ціна",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "Нове значення:",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "Об’єднане значення:",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "Зберегти обʼєднання",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "вже існує",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "Простий",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "Розвинутий",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "Сплатити з отриманої кількості",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "Сума для продажу",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "Ви отримаєте:",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "Виберіть монету, яку хочете ПРОДАТИ",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "Виберіть монету, яку хочете КУПИТИ",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "своп",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "Обмін видається, зачекайте будь-ласка!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "Збіг із замовленням триває, зачекайте {seconde} секунд!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "Плата за мережу",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "комісійна сплата",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "Портфоліо",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "Перевірити",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "Розрахункова загальна вартість",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "Виберіть спосіб оплати",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "Обсяги",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "Розмістіть своє замовлення",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "Незабаром...",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "Ринок",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "Ви надсилаєте:",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "Код:",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "Значення:",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "Сплачено з",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "Будь-ласка введіть дані",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "Не вистачає балансу",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Gwei має бути до {value}",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "Комісії мають бути до {value}",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "Обмеження має бути до {value}",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "Недійсна адреса",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "Адреси Segwit не підтримуються (поки що)",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "Адресувати:",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "ОТРИМАТИ",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "НАДІСЛАТИ",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "Pubkey",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "назад",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "Скасувати",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "деталі",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "Так",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "Hi",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "Примітка: зібране замовлення не можна скасувати знову",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "Більше не запитуйте",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "Відмінити замовлення",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "Ви впевнені, що бажаєте скасувати замовлення?",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "невитрачений",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "Деталі TX незабаром!",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "історія",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "торгівля",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "Подробиці незабаром!",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "Замовлення поєднується",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "Замовлення поєднане",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "Обмін триває",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "Обмін успішний",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "Час вийшов",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "Конвертувати",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "Помилка обміну",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "Помилка, спробуйте пізніше",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "Останні транзакції",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "Отримання трансакції, зачекайте",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "Закінчується, будь ласка, зачекайте",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "Поділитися файлом журналу",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "Завантаження книги замовлень...",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "Зібрати",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "Зібрати свою винагороду KMD?",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "Успішно!",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "Вимагати винагороду не можна. Повторіть спробу через 1 годину.",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "Завантаження...",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "Транзакцій залишилось: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr} балансу недостатньо для оплати комісії за торгівлю",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "Новини",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Стрічка новин",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "Скопійовано в буфер обміну",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "Від",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "До",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "ПІДТВЕРДЖЕНО",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "НЕПІДТВЕРДЖЕНО",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "Блоків",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "Підтвердження",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "Комісія",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "ID транзакції",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "Пам'ятка",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "Немає транзакцій",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "TRADE",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "ЗТЕРТИ",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "Скинути форму",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "ОБМІН ЗАВЕРШЕНО!",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "Крок",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "ДЕТАЛІ ТОРГІВЛІ",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "Запитана торгівля",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "Swap UUID",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "ОГЛЯД",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "ЗБЕРЕЖЕНО",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "Ви все ще можете ввімкнути {remains}, Вибрано: {selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "У ВАС НЕМАЄ ЗБЕРЕЖЕНИХ СТАТТЕЙ",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "ПЕРЕГЛЯНУТИ СТРІЧКУ",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "за",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "Будь ласка, авторизуйтеся!",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "Немає транзацкій",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "Готово",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "Активувати монети:",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "Виберіть монети, які ви хочете додати до свого портфоліо.",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "Немає новин - перевірте пізніше!",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "Запит на обмін не можна скасувати і є остаточною подією!",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "Обмін може тривати до 60 хвилин. НЕ закривайте додаток!",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "ПІДТВЕРДИТИ ДЕТАЛІ ОБМІНУ",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "Необхідний мінімальний обсяг",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "Використати довільний мінімальний обсяг",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "Значення має бути числовим",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "Має бути нижчою за суму продажу",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "Має бути більше ніж {minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "Перевірте насінну фразу",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕВІРИМО ВАШУ НАСІННУ ФРАЗУ",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "Ваша насінна фраза важлива, тому ми хочемо переконатися, що ви її запамʼятали. Ми задамо вам три різні запитання щодо насінної фрази, щоб переконатися, що ви зможете легко відновити свій гаманець, коли захочете.",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "Яке {index} слово у вашій насінній фразі?",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "Введіть {index} слово",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "ПРОДОВЖИТИ",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "ПОВЕРНІТИСЬ І ПЕРЕВІРИТИ ЗНОВУ",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "Провідник",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "Активуйте біометричний захист",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "Дозволити довільне насіння",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "УВАГА!",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "I understand",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "Довільна насінна фраза може бути менш безпечною та її легше зламати, ніж згенерована початкова фраза або закритий ключ (WIF), сумісна з BIP39. Щоб підтвердити, що ви розумієте ризик і знаєте, що робите, введіть \"${iUnderstand}\" у полі нижче.",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "Введіть ваш пароль",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "твій гаманець",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "Забули пароль? Відновити гаманець з насіння",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "Увійдіть за допомогою пароля",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "Введіть насінну фразу",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "Паролі не збігаються. Будь ласка спробуйте ще раз.",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "Назвіть свій гаманець",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "Ви повинні вказати пароль для шифрування гаманця з міркувань безпеки.",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "Підтвердьте пароль",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "Я не хочу пароль",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "ТИ ВПЕВНЕНИЙ?",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "Використовуйте надійний пароль і не зберігайте його ні на одному пристрої",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "ВСТАНОВИТИ ПАРОЛЬ",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "СТВОРИТИ ГАМАНЕЦЬ",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "ВІДНОВИТИ",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "Пароль",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "Пароль має містити щонайменше 12 символів, з літерою нижнього та верхнього регістру та одного спеціального символу.",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "Створити пароль",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "Підтвердьте пароль",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "Поточний пароль",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "Налаштування виходу",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "Вийти під час звороту",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "Видалити гаманець",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "Видалити",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "Ви впевнені, що хочете видалити",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "гаманець?",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "Якщо так, переконайтеся, що ви",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "запишіть свою насінну фразу.",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "Щоб у майбутньому відновити свій гаманець.",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "Резервне копіювання",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "версія",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "Насінний та приватні ключі",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "Фраза насіння",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "Приватні ключі",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "Приватний ключ",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "Щоб продовжити, введіть свій пароль.",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "Копіювати в буфер обміну",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "розблокувати",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "Успішно розблоковано {amnt} - TX: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "Розблокувати",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "Немає транзакцій, розпочніть торгівлю",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "Введіть суму {coinName}.",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "Курс обміну валют",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "Отримати",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "створити замовлення",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "ОБМІН",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "Замовлення",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "Виберіть монету",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗Обережно! Ринок для {coinName} має менше 10 тисяч доларів США за 24 години!",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "Виберіть мову",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "Немає коштів",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "Немає коштів - внесіть депозит.",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "Перейти до портфоліо",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "Натисніть, щоб створити замовлення",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "Недостатня кількість",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "Мінімальна кількість, необхідна для цього замовлення",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "Замовлення створено",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "Замовлення успішно створено",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "Показати мої угоди",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "Мінімальна сума для продажу становить {number} {coinName}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "СТВОРИТИ ПАРОЛЬ",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "Мінімальна сума для купівлі становить {number}{coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "Мінімальна сума для продажу становить {number}{coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "Мінімальна сума замовлення становить {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "Спочатку потрібно ввести суму продажу",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "Шифрування гаманця",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "Розшифровка гаманця",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "Недостатньо балансу для комісій - торгуйте на меншу суму",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "Немає підключення до Інтернету",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "Побудовано в Komodo",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "Будь ласка додайте монету",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "Підключення до Інтернету відновлено",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "Оновити",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "Юридичний",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "Disclaimer & ToS",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "Прийняти EULA",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "Прийміть ПОЛОЖЕННЯ та УМОВИ",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "Натискаючи кнопку нижче, ви підтверджуєте, що прочитали «Ліцензійну угоду» та «Умови використання» та приймаєте їх",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "Комісія {coin}",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "Недостатньо {coin} для транзакції!",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "Будь ласка, активуйте {coin}.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "Ви отримаєте {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "Натистіть щоб побачити {amount} угоди",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "Натисніть, щоб побачити ",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "ціна",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "максимальний обсяг",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "Налаштування вашого гаманця, зачекайте...",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "Обране замовлення",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "комісія за транзакцію:",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "комісія за торгівлю:",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "На балансі {coin} недостатньо для оплати комісії за трансакцію.",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "На балансі {coin} недостатньо для оплати комісії за трансакцію. Потрібно {coin} {amount}.",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "Неможливо продовжити обмін",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "Показати деталі",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "Курс обміну:",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "Виберіть угоду:",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "Мінімальна кількість замовлень:",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "Максимальная кількість замовлень:",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "Подробиці",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "Спочатку активуйте {coin} і поповніть баланс",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "Не вдалося розрахувати комісії за торгівлю",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "Вимкнути",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "Тільки гаманець",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "Ім’я гаманця не може бути пустим",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "Імʼя гаманця може мати максимум 40 символів",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "Імʼя гаманця вже використовується",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX недоступний для цієї монети",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "Пошук монети",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "Виберіть усі SmartChains",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "Виберіть усі тестові активи",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "Виберіть усі токени ERC",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "Виберіть усі токени SLP",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "Виберіть всю мережу Cosmos",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "Виберіть всю мережу Iris",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "Виберіть усі токени Kucoin",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "Виберіть усі жетони Harmony",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "Виберіть усі токени ETC",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "Виберіть усі токени SmartBCH",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "Виберіть усі токени Avax",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "Виберіть усі монети Ubiq",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "Виберіть усі токени BEP",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "Виберіть усі маркери Polygon",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "Виберіть усі токени QRC",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "Виберіть усі токени HecoChain",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "Виберіть усі монети ZHTLC",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "Виберіть усі токени Fantom",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "Виберіть усі жетони Moonriver",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "Довільна комісія ",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "Ліміт комісії",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "Ціна на комісію",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "Використовуйте довільні комісії, лише якщо знаєте, що робите!",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "Виберіть усі монети UTXO",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "Побудовано в Komodo",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "Powered by Komodo",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "Недостатньо газу  - використовуйте принаймні {gas} Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "Усі замовлення {coin} буде скасовано.",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "Підтвердити деактивацію",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "Ви хочете видалити ",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": " з вашого портфоліо? Усі незʼєднані замовлення будуть скасовані.",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " також буде деактивовано",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "Неможливо вимкнути",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": " є монетою за замовчуванням. Монети за замовчуванням не можна деактивувати.",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "Ок",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "Поділитись",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "Увага! В особливих випадках дані журналу містять конфіденційну інформацію, яка може бути використана для витрачання монет із невдалих обмінів!",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "Введіть свій старий PIN-код",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "Введіть новий PIN-код",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "автентифікувати",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "Мови",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "Англійська",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "Французька",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "Німецька",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "Китайська",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "Російська",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "Японська",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "Турецька",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "Угорська",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "Іспанська",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "Корейська",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "Український",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "FAUCET",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "Успіх",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "Помилка",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "Час запиту вичерпано",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "Надсилання запиту на FAUCET {coin}...",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "Додатково",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "Звук",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "Грати на повній гучності",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "Отримувач",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "у вас є нове замовлення, яке намагається узгодити з існуючим",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "Творець",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "у вас є замовлення, з яким можуть відповідати нові замовлення",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "Активні",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "у вас триває активний своп",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "Не вдалося",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "обмін не вдається",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "Оплески",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "обмін виконується до кінця",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "Не можу це програти",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "Будь ласка, виберіть файл mp3 або wav. Ми почнемо це, коли {description}.",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "Грає, коли {description}",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "Звуки",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "Ви почуєте звукові сповіщення під час процесу обміну та коли у вас буде розміщено активне замовлення відправника.\nПротокол атомарних свопів вимагає від учасників бути онлайн для успішної торгівлі, а звукові сповіщення допомагають досягти цього.",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "Зверніть увагу, що ви можете встановити власні звуки в налаштуваннях програми.",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "Зрозумів, більше не показуй",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "Налаштування звуку",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "Звук",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "Ринки",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "РИНКИ",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "ЦІНА",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "ОРДЕРБУК",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "Діаграма",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "Глибина",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "Ціна",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "Продає",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "для",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "мін",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "Адреса",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "Доцільно: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "Дорого: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "Ідентичний CEX",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "Отримати",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "Витратити",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "Це ваше замовлення!",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "Будь ласка, виберіть монети",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "Виберіть монету",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "Немає активних монет",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "Стерти",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "Ціна ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "Сума ({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "Усього ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "Заявок не знайдено",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "Запитів не знайдено",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "Деталі замовлення",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "Щось пішло не так. Спробуйте ще раз пізніше.",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "Інформація про нагороди",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "Докладніше про нагороди KMD для активних користувачів",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "Скасувати",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "Отримати",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "Немає винагород",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "Інформація про нагороди:",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO кіл,\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "Нагороди,\nKMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "Фіат",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "Часу залиш.",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "Статус",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "Статус нагород:",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "В порядку",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} дн.",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsSuccess": "Успіх! Отримано {amount} KMD.",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "Щось пішло не так. Будь-ласка спробуйте пізніше.",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10 KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "Сума UTXO менше 10 KMD",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "обробка",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "Трансакція триває",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1 години",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "Ще не минула одна година",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "Отримайте свої винагороди",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "Побачити історію транзакції",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "Знову активувати усі монетию..",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "Після завершення ви будете перенаправлені на сторінку портфоліо.",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "Якщо навіть після цього деякі монети все ще не активовані, спробуйте перезапустити програму.",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "Не вдалося активувати {coinAbbr}",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "Перезапустіть додаток, щоб повторити спробу, або натисніть кнопку нижче.",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "Знову активувати усі",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "Ви будете автоматично перенаправлені на сторінку портфоліо, коли завершиться процес повторної активації.",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "Не вдалося активувати {coinAbbr}. Будь-ласка спробуйте ще",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} недоступен :(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "Мульти",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "Перш ніж продовжити, виправте всі помилки",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "Створити",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "Замовлення",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "Замовлення",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "Монета",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "Продати:",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "Стрічка новин",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "Сума",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "Отримати:",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "Ціна/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "Отримати суму",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "Будь ласка, введіть фіатну суму, щоб отримати:",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "Скасувати",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "Автозаповнення",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "внесок",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "Недостатньо {coin} для оплати комісії. MIN баланс становить {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "Створіть замовлення ({number}):",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "Скасувати",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "Підтвердити",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "Недійсна сума продажу",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "Максимальна сума продажу становить",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "Мінімальна сума продажу становить",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "Недійсна сума",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "Недійсна адреса {coin}",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "Спочатку активуйте {coin} і поповніть баланс",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "Баланс {coin} замалий",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "Мінімальна сума отримання становить",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "Адресна книга",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "Адресна книга",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "Контактні дані",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "Адресна книга порожня",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "Показано лише контакти з адресами {title}",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "Створити контакт",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "Ім'я",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "Редагувати контакт",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "Скасувати",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "Зберегти",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "Відмінити",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "Вихід",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "Скасувати зміни?",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "Додати адресу",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "Виберіть монету",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "Шукати по тікету",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "Видалити контакт",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "Ви впевнені, що хочете видалити контакт {name}?",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "Видалити",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "Контакти не знайдено",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "Редагувати",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "Нічого не знайдено:(",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "Немає такої монети",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "Ви не можете відправити кошти на адресу {abbr}, оскільки {abbr} не активований. Будь ласка, перейдіть у портфоліо.",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "Ок",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "Ім’я контакта не може бути пустим",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "Ведіть {abbr} адресу",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "Камуфляжний PIN-код",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "Камуфляжий PIN-код",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "Увімкнено",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "Вимкнено",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "Недійсний PIN-код",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "Зміна",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "Якщо ви розблокуєте додаток за допомогою камуфляжного PIN-коду, буде показано ПІДРОБЛЕННИЙ НИЗЬКИЙ баланс, а параметр налаштування камуфляжного PIN-коду НЕ буде видно у налаштуваннях",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "Ваш загальний PIN-код і камуфляжний PIN-код однакові.\nРежим камуфляжу буде недоступний.\nБудь ласка, змініть PIN-код Camouflage.",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "Камуфляжний PIN-код і біозахист не можна ввімкнути одночасно.",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "Конфлікт камуфляжного PIN та Bio захисту.",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "Загальний захист PIN-кодом не активний.\nРежим камуфляжу буде недоступний.\nУвімкніть захист PIN-кодом.",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "Підроблена сума балансу:",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "Камуфляжний PIN-код не знайдено",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "Створіть камуфляжний PIN-код",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "Камуфляжний PIN-код збережено",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "Недійсний камуфляжний PIN-код",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "Змінити PIN-код камуфляжу",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "Налаштування камуфляжного PIN-коду",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "Введіть новий камуфляжний PIN-код",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "УВІМКНЕНО",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "ВИМКНЕНО",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "Підтвердження",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Безпека Komodo dPoW",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "Використовуйте довільні налаштування захисту",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "Попередження, цей атомарний своп не захищений з dPoW.",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "Перетворити на Адресант (Maker), якщо не збігається",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEXобмінний курс",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "Доцільно",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "Дорого",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "Ідентичний CEX",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "порівняно з CEX",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "порівняно із середнім Ціна 24 години CEX",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "Активні",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "Історія",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "Подробиці",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "Відкрийте «Деталі» одним дотиком і виберіть «Замовити довгим дотиком».",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "Скасувати",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "Вибрати",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "Відповідних замовлень не знайдено",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "Замовлення виробника",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "Замовлення покупця",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "Поточний",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "Оцінка",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "Розпочато",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "Всього",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "Деталі прогресу",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "Закрити повідомлення про помилку",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "Відкрийте повідомлення про помилку",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "Вхідна транзакція",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "Ви отримали {coin} трансакцію!",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "Обмін завершено",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "Обмін {sell}/{buy} успішно завершено",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "Помилка обміну",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "Не вдалося обміняти {sell}/{buy}",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "Час очікування обміну минув",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "Час очікування обміну {sell}/{buy} минув",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "Статус обміну змінено",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "Розпочато новий обмін",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "Розпочато обмін {sell}/{buy}",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "Мова",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "Валюта",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "Приховати баланси",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "Змінити тему",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "Дані CEX",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "Ринкові дані (ціни, діаграми, тощо), позначені цією піктограмою, походять із сторонніх джерел (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "Перевірити наявність оновлень",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "Ви впевнені, що бажаєте вийти зараз?",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "Валюта",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "Забагато запитів.\nПеревищено ліміт запитів історії транзакцій.\nБудь-ласка спробуйте пізніше.",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "мс",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "с",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "хв",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "хвилин",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "г",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "Більше",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "Менше",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "Старі журнало",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "Видалити",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "Видалення гаманця...",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "Використаний простір",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "Ок",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "Закрити попередній перегляд",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "Скасувати",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "Прокрутіть униз, щоб продовжити...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "Розробник",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "Увімкнути тестові монети",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "Деталі замовлення виробника",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "Продати",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "Отримати",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "Ціна",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "Відмінити замовлення",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "ID замовлення",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "Створено в",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "Жодні угоди не були розпочаті цим орденом",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "Обміни розпочато цим ордером",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}% заповнено",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "Примітка",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "Додайте примітку",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "Імпорт",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "Імпортувати єдиний Своп",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "Експорт",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "Імпорт",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "Імпорт Своп",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "Експорт",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "Виберіть елементи для експорту в зашифрований файл.",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "Виберіть зашифрований файл для імпорту.",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "Будь ласка, виберіть простий текстовий файл обміну для імпорту.",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "Відкриття...",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "Елементи для імпорту:",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "Примітки",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "Контакти",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "Обмін",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "Нічого не знайдено",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "Експорт",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "Імпорт",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "Пароль шифрування не може бути порожнім",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "Пароль не може бути порожнім",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "Паролі мають збігатися",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "Елементи не вибрано",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "Елементи не вибрано",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "Виберіть файл",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "Файл не знайдено",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "Відбиток пальця",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "Пароль",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "Скасувати",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "ОК",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "Елементи успішно експортовано:",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "Елементи успішно імпортовано:",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "Неправельний пароль або пошкоджені дані",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "Помилка декодування файлу json",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "Замовлення",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "Невідомий тип зумовлення",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "Не вдалося імпортувати:",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "Деякі елементи були пропущені",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "Не вдалося імпортувати обмін",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "Недійсні дані обміну. Надайте дійсний файл JSON статусу обміну.",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "Активація {coinName}",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "Не закривайте програму. Торкніться, щоб дізнатися більше...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "Активація {coinName}",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "Монети {protocolName} активовані",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "Монети {protocolName} не активовані",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "Монети {protocolName} успішно активовані",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "Виконується активація {protocolName}",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "Активувати монети {protocolName}?",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "Більше інформації",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "Показати адресу",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "Ця трансакція була прихована через можливу спробу фішингу.",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "Адреса транзакції",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "Транзакція прихована",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "Не вдалося запустити URL",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "Це займе деякий час, і програма має залишатися в активному режимі.\nЗакриття програми під час активації може призвести до проблем.",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "Попередження: згортання програми на iOS припинить процес активації.",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "Увімкніть сповіщення, щоб отримувати оновлення про хід активації.",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "Сканер QR-коду",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "Знайдено QR-код",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "Договір",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "Почати обмін",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "Жодного",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "Курс CEX",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "Налаштування захисту вхідних {coinName} txs",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "Показано {count} із {maxCount} замовлень.",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "менше",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "більше",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "на основі {coinName1}/{coinName2}",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "відправити плату за торгівлю плату за транзакцію",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "комісія за торгівлю",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "надіслати комісію за транзакцію {coinName}",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "отримати комісію за транзакцію {coinName}",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "Фільтр",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "Статус",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "Все",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "Успішний",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "Не вдалося",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "Від дати",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "До дати",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "Відправник/ Отримувач",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "Творець",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "Усі",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "Отримувач",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "Продати монету",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "Отримати монету",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "Очистити всі фільтри",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "Недостатній баланс",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "Недостатньо балансу для сканування",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "платіжний запит.",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "Спроба ввімкнути занадто багато ресурсів",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "Ти маєш",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "активів увімкнено та намагається ввімкнути",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "більше. Максимальний ліміт активованих активів становить",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": ". Будь-ласка, вимкніть деякі монети, перш ніж додавати нові.",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "Ви вибрали максимальну кількість ресурсів",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "Увімкнено забагато активів",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "Ти маєш",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "активовані активи. Максимальний ліміт активованих активів становить",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": ". Будь ласка, вимкніть деякі, перш ніж додавати нові.",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "Запит на оплату",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "Монета:",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "Адресувати",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "сума:",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "Ви приймаєте цю транзакцію?",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "Оплатити",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "Скасувати",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} не активний. Будь ласка, активуйте і спробуйте ще раз.",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "Неправильна монета",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "Ви намагаєтеся відсканувати платіжний QR-код для",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "але ви знаходитесь на",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "знімати екран",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "Продати",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "Купити",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "Отримати",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "Надіслати",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "Закрити",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "Активувати",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "Максимальна кількість активних монет становить {maxCoins}. Будь ласка, деактивуйте кілька монет.",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "Неможливо активувати {coin}",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin} не активований!",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "Будь ласка, введіть {coin} суму для купівлі",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "Будь ласка, введіть {coin} суму для продажу",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "Показати менше",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "Показати більше",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "Монет не знайдено",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "Це нова ера! Ми офіційно змінили назву з \"AtomicDEX\" на \"Komodo Wallet\"",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "Офіційний прес-реліз",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "Сканувати минулі транзакції {coin}?",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "Скасувати активацію",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "Ви впевнені, що бажаєте скасувати активацію?",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "Ви впевнені, що бажаєте скасувати активацію?",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "Які транзакції {name} ви хочете синхронізувати?",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "Синхронізувати нові транзакції",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "Синхронізувати з указаної дати",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "Синхронізація з активації саджанця",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "Виберіть дату",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "Дата початку",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "Ми будемо синхронізувати майбутні транзакції, здійснені після активації, пов’язаної з вашим відкритим ключем. Це найшвидший варіант, який займає найменшу кількість пам’яті.",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "У вашому гаманці відображатимуться всі минулі транзакції. Це займе багато пам’яті та часу, оскільки всі блоки будуть завантажені та відскановані.",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "Ваш гаманець відображатиме ваші минулі транзакції, здійснені після вказаної дати.",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "Активація {coinName}",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "Активація {coinName}",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "Виконується активація {protocolName}",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "Активні",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "Активувати монету",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "{name} успішно активовано!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "Додати адресу",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "Адресна книга",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "Адресна книга порожня",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "Показано лише контакти з адресами {title}",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "Адресна книга",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "Ви не можете відправити кошти на адресу {abbr}, оскільки {abbr} не активований. Будь ласка, перейдіть у портфоліо.",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "Нічого не знайдено:(",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "Виберіть монету",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "Адреса отримувача",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "Розвинутий",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "Усі",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "Дозволити довільне насіння",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "У вашому гаманці відображатимуться всі минулі транзакції. Це займе багато пам’яті та часу, оскільки всі блоки будуть завантажені та відскановані.",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "вже існує",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "Сума",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "Сума для продажу",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "Ні! {appName} не зберігє. Ми ніколи не зберігаємо жодних конфіденційних даних, враховуючи ваші насінні ключі, початкові фрази або PIN-код. Ці дані зберігаються лише на пристрої користувача і ніколи не залишають його. Ви повністю контролюєте свої активи.",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName} доступний для мобільних пристроїв на Android і iPhone, а також для комп’ютерів в <a href=\"https://komodoplatform.com/\">операційних системах Windows, Mac і Linux</a>.",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "Інші DEX, як правило, дозволяють лише торгувати активами, які базуються на одній мережі блокчейну, використовують проксі-токени та дозволяють розміщувати лише одне замовлення з тими самими коштами.\n\n{appName} дає вам змогу безпосередньо торгувати між двома різними блокчейн-мережами без проксі-токенів. Ви також можете розмістити кілька замовлень з однаковими коштами. Наприклад, ви можете продати 0,1 BTC за KMD, QTUM або VRSC — перше заповнене замовлення автоматично скасовує всі інші замовлення.",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "Кілька факторів визначають час обробки для кожного обміну. Час блокування торгових активів залежить від кожної мережі (біткойн зазвичай найповільніший). Крім того, користувач може налаштувати параметри безпеки. Наприклад, ви можете попросити {appName} вважати транзакцію KMD остаточною лише після 3 підтверджень, що скорочує час обміну порівняно з очікуванням <a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">нотаріальне засвідчення</a>.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "Так. Ви повинні залишатися підключеними до Інтернету та запустити програму, щоб успішно завершити кожну атомарну заміну (дуже короткі перерви в з’єднанні зазвичай не впливають). В іншому випадку існує ризик скасування угоди, якщо ви мейкер, і ризик втрати коштів, якщо ви тейкер. Протокол атомарного обміну вимагає, щоб обидва учасники залишалися онлайн і контролювали задіяні блокчейни, щоб процес залишався атомарним.",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "Під час торгівлі в {appName} слід враховувати дві категорії комісій.\n\n1. {appName} стягує приблизно 0,13% (1/777 об’єму торгів, але не менше 0,0001) як комісію за торгівлю замовленням-тейкерам, а замовлення-виконавці не мають комісії.\n\n2. Як виробники, так і приймачі повинні будуть сплачувати звичайні мережеві збори залученим блокчейнам під час здійснення транзакцій атомарного свопу.\n\nПлата мережі може значно відрізнятися залежно від вибраної торгової пари.",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "Так! {appName} пропонує підтримку через <a href=\"{link}\">{appCompanyShort} {name}</a>. Команда та спільнота завжди раді допомогти!",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "Ні! {appName} повністю децентралізовано. Неможливо обмежити доступ користувача сторонніми особами.",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} розроблено командою {appCompanyShort}. {appCompanyShort} — це один із найпопулярніших блокчейн-проектів, який працює над інноваційними рішеннями, такими як атомарні свопи, відкладене підтвердження роботи та взаємодіюча багатоланцюгова архітектура.",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "Абсолютно! Щоб дізнатися більше, прочитайте нашу <a href=\"https://developers.komodoplatform.com/\">документацію для розробників</a> або зв’яжіться з нами із запитами про партнерство. Є конкретне технічне запитання? Спільнота розробників {appName} завжди готова допомогти!",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "Оплески",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "ТИ ВПЕВНЕНИЙ?",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "обмін не вдається",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "обмін виконується до кінця",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "автентифікувати",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "Ви будете автоматично перенаправлені на сторінку портфоліо, коли завершиться процес повторної активації.",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "максимальний обсяг",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "назад",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "Резервне копіювання",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "на основі {coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "Заряд акумулятора має вирішальне значення ({batteryLevelCritical}%) для безпечної заміни. Будь ласка, зарядіть його та повторіть спробу.",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "Заряд акумулятора нижчий ніж {batteryLevelLow}%. Будь ласка, врахуйте зарядку телефону.",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "Ваш телефон у режимі економії заряду аккумулятора. Будь-ласка, вимкніть цей режим або НЕ переводьте програму у фоновий режим, інакше програма може бути закрита ОС і заміна не вдасться.",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "Курс обміну валют",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "Побудовано в Komodo",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "Побудовано в Komodo",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "Купити",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "Перетворити на Адресант (Maker), якщо не збігається",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "Обмін видається, зачекайте будь-ласка!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "Збіг із замовленням триває, зачекайте {seconde} секунд!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "Попередження, ви можете купити тестові монети БЕЗ реальної вартості!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "Камуфляжний PIN-код і біозахист не можна ввімкнути одночасно.",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "Конфлікт камуфляжного PIN та Bio захисту.",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "Змінити PIN-код камуфляжу",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "Створіть камуфляжний PIN-код",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "Якщо ви розблокуєте додаток за допомогою камуфляжного PIN-коду, буде показано ПІДРОБЛЕННИЙ НИЗЬКИЙ баланс, а параметр налаштування камуфляжного PIN-коду НЕ буде видно у налаштуваннях",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "Недійсний камуфляжний PIN-код",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "Камуфляжий PIN-код",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "Камуфляжний PIN-код не знайдено",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "Вимкнено",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "Увімкнено",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "Камуфляжний PIN-код збережено",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "Камуфляжний PIN-код",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "Введіть новий камуфляжний PIN-код",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "Налаштування камуфляжного PIN-коду",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "Налаштування камуфляжного PIN-коду",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "Скасувати",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "Скасувати активацію",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "Ви впевнені, що бажаєте скасувати активацію?",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "Скасувати",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "Відмінити замовлення",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "Щось пішло не так. Спробуйте ще раз пізніше.",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "Ок",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": " є монетою за замовчуванням. Монети за замовчуванням не можна деактивувати.",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "Неможливо вимкнути",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "Не можу це програти",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEXобмінний курс",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "Дані CEX",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "Ринкові дані (ціни, діаграми, тощо), позначені цією піктограмою, походять із сторонніх джерел (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "Курс CEX",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "Змінити PIN-код",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "Перевірити наявність оновлень",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "Перевірити",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "Перевірте насінну фразу",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "ПРОДОВЖИТИ",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "ПОВЕРНІТИСЬ І ПЕРЕВІРИТИ ЗНОВУ",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "Введіть {index} слово",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "Ваша насінна фраза важлива, тому ми хочемо переконатися, що ви її запамʼятали. Ми задамо вам три різні запитання щодо насінної фрази, щоб переконатися, що ви зможете легко відновити свій гаманець, коли захочете.",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "Яке {index} слово у вашій насінній фразі?",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕВІРИМО ВАШУ НАСІННУ ФРАЗУ",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "Китайська",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "Зібрати",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "Зібрати свою винагороду KMD?",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "Натисніть, щоб побачити ",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "Скопійовано в буфер обміну",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "Копіювати в буфер обміну",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "Закрити",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "Закрити повідомлення про помилку",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "Закрити попередній перегляд",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "Код:",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "Ви впевнені, що бажаєте скасувати активацію?",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "Ви вибрали максимальну кількість ресурсів",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "Монети {protocolName} активовані",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "Монети {protocolName} успішно активовані",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "Монети {protocolName} не активовані",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "Стерти",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "Немає активних монет",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "Виберіть монету",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "Незабаром...",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "Деталі TX незабаром!",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "Подробиці незабаром!",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "комісійна сплата",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "порівняно із середнім Ціна 24 години CEX",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "порівняно з CEX",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "Налаштування вашого гаманця, зачекайте...",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "Підтвердити",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "Підтвердіть комуфляжний PIN-код",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "Ви впевнені, що бажаєте скасувати замовлення?",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "Натискаючи кнопку нижче, ви підтверджуєте, що прочитали «Ліцензійну угоду» та «Умови використання» та приймаєте їх",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "Підтвердьте пароль",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "Підтвердьте PIN-код",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "Підтвердьте насінну фразу",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "Підключення...",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "Скасувати",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "Видалити контакт",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "Видалити",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "Ви впевнені, що хочете видалити контакт {name}?",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "Відмінити",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "Редагувати",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "Вихід",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "Скасувати зміни?",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "Контакти не знайдено",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "Зберегти",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "Контактні дані",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "Ім'я",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "Договір",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "Конвертувати",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "Не вдалося запустити URL",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "Не вдалося імпортувати:",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "торгівля",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "СТВОРИТИ ГАМАНЕЦЬ",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "Створити контакт",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "Створити PIN-код",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "Валюта",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "Валюта",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "Поточна ціна",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "Довільна комісія ",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "Використовуйте довільні комісії, лише якщо знаєте, що робите!",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "Довільна насінна фраза може бути менш безпечною та її легше зламати, ніж згенерована початкова фраза або закритий ключ (WIF), сумісна з BIP39. Щоб підтвердити, що ви розумієте ризик і знаєте, що робите, введіть \"${iUnderstand}\" у полі нижче.",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "Дата",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "Розшифровка гаманця",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "Видалити",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "Підтвердити деактивацію",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "Ви хочете видалити ",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": " з вашого портфоліо? Усі незʼєднані замовлення будуть скасовані.",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " також буде деактивовано",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "Видалити гаманець",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "Видалення гаманця...",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "отримати комісію за транзакцію {coinName}",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "надіслати комісію за транзакцію {coinName}",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "відправити плату за торгівлю плату за транзакцію",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "комісія за торгівлю",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "деталі",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "Німецька",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "Розробник",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX недоступний для цієї монети",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "Вимкнути знімки екрана/попередній перегляд",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "Disclaimer & ToS",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "Готово",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "Не закривайте програму. Торкніться, щоб дізнатися більше...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "Більше не запитуйте",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "Я не хочу пароль",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Безпека Komodo dPoW",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "Тривалість",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "Редагувати контакт",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "Ведіть {abbr} адресу",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "Пароль шифрування не може бути порожнім",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "Пароль не може бути порожнім",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "Ім’я контакта не може бути пустим",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "Ім’я гаманця не може бути пустим",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "Ви все ще можете ввімкнути {remains}, Вибрано: {selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "Увімкніть сповіщення, щоб отримувати оновлення про хід активації.",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "Увімкнути тестові монети",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "Ти маєш",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "активів увімкнено та намагається ввімкнути",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "більше. Максимальний ліміт активованих активів становить",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": ". Будь-ласка, вимкніть деякі монети, перш ніж додавати нові.",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "Спроба ввімкнути занадто багато ресурсів",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "Шифрування гаманця",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "Англійська",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "Введіть новий PIN-код",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "Введіть свій старий PIN-код",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "Щоб продовжити, введіть свій пароль.",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "Введіть свій PIN-код",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "Введіть свою насінну фразу",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "Спочатку потрібно ввести суму продажу",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "Не вистачає балансу",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "Недійсна адреса",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "Адреси Segwit не підтримуються (поки що)",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "Недостатньо газу  - використовуйте принаймні {gas} Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "Помилка, спробуйте ще раз",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "Помилка, спробуйте пізніше",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "Значення занадто високе або низьке",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "Будь-ласка введіть дані",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "Розрахункова загальна вартість",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}.\nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application.\nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights.\nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information;\n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages.\nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You.\nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from:\n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses;\n(b) server failure or data loss;\n(c) corrupted or otherwise non-performing Wallets or Wallet files;\n(d) unauthorized access to applications;\n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}.\nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination.\nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination.\n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time.\n\n",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data).\nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.\n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application.\nYour access to this application does not itself create an adviser-client relationship between You and us.\nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us.\nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free.\nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies).\n\n",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:\n\n",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY\n\n",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS\n\n",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER\n\n",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY\n\n",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS\n\n",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION\n\n",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET\n\n",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE\n\n",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION\n\n",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS\n\n",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)\n\n",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS\n\n",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER\n\n",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE\n\n",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS\n\n",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE\n\n",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP\n\n",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS\n\n",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING\n\n",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "Приклад: build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "Доцільно",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "Дорого",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "Ідентичний CEX",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "Курс обміну:",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "ОБМІН",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "Експорт",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "Контакти",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "Виберіть елементи для експорту в зашифрований файл.",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "Експорт",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "Примітки",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "Елементи успішно експортовано:",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "Обмін",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "Експорт",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "Не вдалося",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "Підроблена сума балансу:",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "Часто задавані питання",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "Помилка",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "Надсилання запиту на FAUCET {coin}...",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "FAUCET",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "Успіх",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "Час запиту вичерпано",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "Поділитися файлом журналу",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "Новини",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "Тут нічого",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "Новини {appCompanyShort}",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "Детальніше...",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Новини",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Стрічка новин",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "Не вдалося продовжити оновлення новин",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "Не вдалося отримати оновлення новин",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Стрічку новин оновлено",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "Вже актуально",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "Комісії мають бути до {value}",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "Все",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "Фільтр",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "Очистити всі фільтри",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "Не вдалося",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "Від дати",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "Творець",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "Отримати монету",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "Продати монету",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "Статус",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "Успішний",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "Отримувач",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "До дати",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "Відправник/ Отримувач",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "Відбиток пальця",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "Закінчується, будь ласка, зачекайте",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "Знайдено QR-код",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "Французька",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "Від",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "Ми будемо синхронізувати майбутні транзакції, здійснені після активації, пов’язаної з вашим відкритим ключем. Це найшвидший варіант, який займає найменшу кількість пам’яті.",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "Комісія {coin}",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "Ліміт комісії",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "Будь ласка, активуйте {coin}.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "Ціна на комісію",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "Загальний захист PIN-кодом не активний.\nРежим камуфляжу буде недоступний.\nУвімкніть захист PIN-кодом.",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "Важливо: створіть резервну копію насінної фрази, перш ніж продовжити!",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "Отримання трансакції, зачекайте",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "Перейти до портфоліо",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei має бути до {value}",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "Допомога",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "Допомога та підтримка",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "Приховати баланси",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "Підтвердьте пароль",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "Створити пароль",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "Поточний пароль",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "Введіть ваш пароль",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "Введіть насінну фразу",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "Назвіть свій гаманець",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "Пароль",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "історія",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "г",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "Угорська",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "Імпорт",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "Неправельний пароль або пошкоджені дані",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "Елементи для імпорту:",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "Файл не знайдено",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "Недійсні дані обміну. Надайте дійсний файл JSON статусу обміну.",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "Імпорт",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "Виберіть зашифрований файл для імпорту.",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "Відкриття...",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "Будь ласка, виберіть простий текстовий файл обміну для імпорту.",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "Скасувати",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "ОК",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "Пароль",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "Імпортувати єдиний Своп",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "Імпорт Своп",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "Деякі елементи були пропущені",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "Елементи успішно імпортовано:",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "Не вдалося імпортувати обмін",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "Помилка декодування файлу json",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "Імпорт",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "Налаштування захисту вхідних {coinName} txs",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "Використовуйте надійний пароль і не зберігайте його ні на одному пристрої",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "Запит на обмін не можна скасувати і є остаточною подією!",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "Обмін може тривати до 60 хвилин. НЕ закривайте додаток!",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "Ви повинні вказати пароль для шифрування гаманця з міркувань безпеки.",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr} балансу недостатньо для оплати комісії за торгівлю",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "Мінімальна кількість, необхідна для цього замовлення",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "Недостатня кількість",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "Оновити",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "Підключення до Інтернету відновлено",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "Недійсна адреса {coin}",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "Неможливо продовжити обмін",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "Подробиці",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} недоступен :(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "I understand",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "Японська",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "Корейська",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "Мова",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "Останні транзакції",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "Юридичний",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "Менше",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗Обережно! Ринок для {coinName} має менше 10 тисяч доларів США за 24 години!",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "Обмеження має бути до {value}",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "Завантаження...",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "Завантаження книги замовлень...",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "Екран заблоковано",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "Будь ласка, авторизуйтеся!",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "логін",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "Вийти",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "Вийти під час звороту",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "Налаштування виходу",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "Ви впевнені, що бажаєте вийти зараз?",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "хвилин",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "створити замовлення",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "Творець",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "Відмінити замовлення",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "Створено в",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "Отримати",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "ID замовлення",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "Жодні угоди не були розпочаті цим орденом",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "Ціна",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "Продати",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "Обміни розпочато цим ордером",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "Деталі замовлення виробника",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "Замовлення виробника",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "Ринок",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "Діаграма",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "Глибина",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "Запитів не знайдено",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "Заявок не знайдено",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "ОРДЕРБУК",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "Деталі замовлення",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "ЦІНА",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "Будь ласка, виберіть монети",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "Ринки",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "РИНКИ",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "Паролі мають збігатися",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "Зміна",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "Ваш загальний PIN-код і камуфляжний PIN-код однакові.\nРежим камуфляжу буде недоступний.\nБудь ласка, змініть PIN-код Camouflage.",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "Недійсний PIN-код",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "МАКС",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "Максимальная кількість замовлень:",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "Новини",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "ОГЛЯД",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "ПЕРЕГЛЯНУТИ СТРІЧКУ",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "за",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "У ВАС НЕМАЄ ЗБЕРЕЖЕНИХ СТАТТЕЙ",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "ЗБЕРЕЖЕНО",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "Пам'ятка",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "Зʼєднати",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "Об’єднане значення:",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "мс",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "ХВ",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "Попередження: згортання програми на iOS припинить процес активації.",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "Мінімальна кількість замовлень:",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "хв",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "Мінімальна сума для продажу становить {number} {coinName}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "Мінімальна сума для купівлі становить {number}{coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "Мінімальна сума замовлення становить {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "Мінімальна сума для продажу становить {number}{coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "Має бути більше ніж {minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "Має бути нижчою за суму продажу",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "Необхідний мінімальний обсяг",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "Використати довільний мінімальний обсяг",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "Зауважте, що зараз ви використовуєте мобільні дані та участь у мережі {appName} P2P споживає інтернет-трафік. Краще використовувати мережу WiFi, якщо ваш тарифний план стільникового зв’язку є дорогим.",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "Більше інформації",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "Більше",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "Спочатку активуйте {coin} і поповніть баланс",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "Сума",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "Монета",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "Стрічка новин",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "Скасувати",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "Підтвердити",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "Створіть замовлення ({number}):",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "Створити",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "Замовлення",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "Замовлення",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "внесок",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "Скасувати",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "Будь ласка, введіть фіатну суму, щоб отримати:",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "Автозаповнення",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "Перш ніж продовжити, виправте всі помилки",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "Недійсна сума",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "Недійсна сума продажу",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "Недостатньо {coin} для оплати комісії. MIN баланс становить {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "Баланс {coin} замалий",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "Максимальна сума продажу становить",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "Мінімальна сума отримання становить",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "Мінімальна сума продажу становить",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "Отримати:",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "Продати:",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "Мульти",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "Отримати суму",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "Ціна/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "Плата за мережу",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "Новий акаунт",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "Новий акаунт",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Стрічка новин",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "Нове значення:",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "далі",
-  "@next": {
-    "type": "text"
-  },
-  "no": "Hi",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "Немає новин - перевірте пізніше!",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "Монет не знайдено",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "Немає коштів",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "Немає коштів - внесіть депозит.",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "Немає підключення до Інтернету",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "Елементи не вибрано",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "Елементи не вибрано",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "Відповідних замовлень не знайдено",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "Жодного",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "Значення має бути числовим",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "Введіть суму {coinName}.",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "Натисніть, щоб створити замовлення",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "Немає транзакцій, розпочніть торгівлю",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "Немає винагород",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "Вимагати винагороду не можна. Повторіть спробу через 1 годину.",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "Немає такої монети",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "Немає транзакцій",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "Недостатньо {coin} для транзакції!",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "Недостатньо балансу для комісій - торгуйте на меншу суму",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "Примітка: зібране замовлення не можна скасувати знову",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "Додайте примітку",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "Примітка",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "Нічого не знайдено",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "Обмін {sell}/{buy} успішно завершено",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "Обмін завершено",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "Не вдалося обміняти {sell}/{buy}",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "Помилка обміну",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "Розпочато обмін {sell}/{buy}",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "Розпочато новий обмін",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "Статус обміну змінено",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "Час очікування обміну {sell}/{buy} минув",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "Час очікування обміну минув",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "Ви отримали {coin} трансакцію!",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "Вхідна транзакція",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "Немає транзацкій",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} активів",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "Офіційний прес-реліз",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "Ок",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "Видалити",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "Старі журнало",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "Використаний простір",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "Відкрийте повідомлення про помилку",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "Додатково",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "менше",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "більше",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "Усі замовлення {coin} буде скасовано.",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "Замовлення створено",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "Замовлення успішно створено",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "Адреса",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "Скасувати",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "Доцільно: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "Дорого: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "для",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "Ідентичний CEX",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "мін",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "Ціна",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "Отримати",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "Вибрати",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "Продає",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "Відкрийте «Деталі» одним дотиком і виберіть «Замовити довгим дотиком».",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "Витратити",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "Подробиці",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}% заповнено",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "Замовлення поєднане",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "Замовлення поєднується",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "Замовлення",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "Активні",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "Історія",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "Сума ({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "Ціна ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "Усього ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "Замовлення",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "Невідомий тип зумовлення",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "Перезаписати",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "Це ваше замовлення!",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "Сплачується з баланасу:",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "Сплатити з отриманої кількості",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "Сплачено з",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "Пароль має містити щонайменше 12 символів, з літерою нижнього та верхнього регістру та одного спеціального символу.",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "Ваш гаманець відображатиме ваші минулі транзакції, здійснені після вказаної дати.",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "Оплатити",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "Ви приймаєте цю транзакцію?",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "Адресувати",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "сума:",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "Монета:",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "Скасувати",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "Запит на оплату",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} не активний. Будь ласка, активуйте і спробуйте ще раз.",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "Розмістіть своє замовлення",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "Грати на повній гучності",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "Будь ласка додайте монету",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "Перезапустіть додаток, щоб повторити спробу, або натисніть кнопку нижче.",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "Портфоліо",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "Powered by Komodo",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "ціна",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "Приватний ключ",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "Приватні ключі",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "Підтвердження",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "Використовуйте довільні налаштування захисту",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "ВИМКНЕНО",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "УВІМКНЕНО",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "Попередження, цей атомарний своп не захищений з dPoW.",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "Pubkey",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "Сканер QR-коду",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "Ви зберігаєте мої особисті ключі?",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "На яких пристроях я можу використовувати {appName}?",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "Чим торгівля в {appName} відрізняється від торгівлі в інших DEX?",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "Скільки часу займає кожна атомарна заміна?",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "Чи потрібно мені бути онлайн під час обміну?",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "Як розраховуються комісії за {appName}?",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "Чи забезпечуєте ви підтримку користувачів?",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "Чи є у вас обмеження по країні?",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "Хто стоїть за {appName}?",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "Чи можна розробити власну біржу white-label у {appName}?",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "Це нова ера! Ми офіційно змінили назву з \"AtomicDEX\" на \"Komodo Wallet\"",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "ОТРИМАТИ",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "Отримати",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "Ми рекомендуємо зберігати його офлайн.",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "Вимкнути",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "Запитана торгівля",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "ЗТЕРТИ",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "Скинути форму",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "ВІДНОВИТИ",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "Знову активувати усі монетию..",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "Знову активувати усі",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "Отримайте свої винагороди",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "Скасувати",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "Щось пішло не так. Будь-ласка спробуйте пізніше.",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "Трансакція триває",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "обробка",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "Сума UTXO менше 10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10 KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "Ще не минула одна година",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1 години",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "В порядку",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "Статус нагород:",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "Докладніше про нагороди KMD для активних користувачів",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "Отримати",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "Успіх! Отримано {amount} KMD.",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "Фіат",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "Нагороди,\nKMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "Статус",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "Часу залиш.",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "Інформація про нагороди:",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO кіл,\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} дн.",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{гч} год {хвилин} хв",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{мм} хв",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "Інформація про нагороди",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "Російська",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "Зберегти обʼєднання",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "Прокрутіть униз, щоб продовжити...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "Пошук монети",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "Виберіть усі токени Avax",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "Виберіть усі токени BEP",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "Виберіть всю мережу Cosmos",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "Виберіть усі токени ERC",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "Виберіть усі токени ETC",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "Виберіть усі токени Fantom",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "Виберіть усі токени HecoChain",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "Виберіть усі жетони Harmony",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "Виберіть всю мережу Iris",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "Виберіть усі токени Kucoin",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "Виберіть усі жетони Moonriver",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "Виберіть усі маркери Polygon",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "Виберіть усі токени QRC",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "Виберіть усі токени SmartBCH",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "Виберіть усі токени SLP",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "Виберіть усі SmartChains",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "Виберіть усі тестові активи",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "Виберіть усі монети Ubiq",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "Виберіть усі монети UTXO",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "Виберіть усі монети ZHTLC",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "Шукати по тікету",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "с",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "Безпека",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "Фраза насіння",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "Ваша нова насінна фраза",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "Натистіть щоб побачити {amount} угоди",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "Побачити історію транзакції",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "Виберіть монету",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "Виберіть монети, які ви хочете додати до свого портфоліо.",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "Активувати монети:",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "Виберіть монету, яку хочете КУПИТИ",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "Виберіть монету, яку хочете ПРОДАТИ",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "Виберіть дату",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "Виберіть угоду:",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "Виберіть файл",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "Виберіть мову",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "Виберіть спосіб оплати",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "Продати",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "Увага! Ви готові продати тестові монети БЕЗ реальної вартості!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "НАДІСЛАТИ",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "Ви впевнені, що хочете видалити",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "гаманець?",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "Якщо так, переконайтеся, що ви",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "запишіть свою насінну фразу.",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "Щоб у майбутньому відновити свій гаманець.",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "Мови",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "Налаштування",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "ВСТАНОВИТИ ПАРОЛЬ",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "Поділитись",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "Моя адреса {coinName}:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "Сканувати минулі транзакції {coin}?",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "Показати адресу",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "Показати деталі",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "Показано {count} із {maxCount} замовлень.",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "Показати мої угоди",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "Увійдіть за допомогою пароля",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "Забули пароль? Відновити гаманець з насіння",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "Простий",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "Активувати",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "Будь ласка, введіть {coin} суму для купівлі",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "Купити",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "Закрити",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "Максимальна кількість активних монет становить {maxCoins}. Будь ласка, деактивуйте кілька монет.",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin} не активований!",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "Отримати",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "Будь ласка, введіть {coin} суму для продажу",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "Продати",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "Надіслати",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "Показати менше",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "Показати більше",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "Неможливо активувати {coin}",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "Пропустити",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "Відхилити",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "Звук",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "Будь ласка, виберіть файл mp3 або wav. Ми почнемо це, коли {description}.",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "Грає, коли {description}",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "Звуки",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "Зрозумів, більше не показуй",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "Звук",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "Налаштування звуку",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "Ви почуєте звукові сповіщення під час процесу обміну та коли у вас буде розміщено активне замовлення відправника.\nПротокол атомарних свопів вимагає від учасників бути онлайн для успішної торгівлі, а звукові сповіщення допомагають досягти цього.",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "Зверніть увагу, що ви можете встановити власні звуки в налаштуваннях програми.",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "Іспанська",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "Дата початку",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "Почати обмін",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "Крок",
-  "@step": {
-    "type": "text"
-  },
-  "success": "Успішно!",
-  "@success": {
-    "type": "text"
-  },
-  "support": "Підтримка",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "Якщо у вас виникли запитання або ви вважаєте, що виявили технічну проблему з додатком {appName}, ви можете повідомити про це та отримати підтримку від нашої команди.",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "своп",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "Поточний",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "ПІДТВЕРДИТИ ДЕТАЛІ ОБМІНУ",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "Оцінка",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "Помилка обміну",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "Спочатку активуйте {coin} і поповніть баланс",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "На балансі {coin} недостатньо для оплати комісії за трансакцію.",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "На балансі {coin} недостатньо для оплати комісії за трансакцію. Потрібно {coin} {amount}.",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "Обмін триває",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "Деталі прогресу",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "Розпочато",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "Обмін успішний",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "Всього",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "Swap UUID",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "Змінити тему",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "Синхронізувати з указаної дати",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "Синхронізація з активації саджанця",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "Синхронізувати нові транзакції",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "Які транзакції {name} ви хочете синхронізувати?",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "Отримувач",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "Замовлення покупця",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "Час вийшов",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "СТВОРИТИ ПАРОЛЬ",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "Обране замовлення",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "До",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "Адресувати:",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "Ти маєш",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "активовані активи. Максимальний ліміт активованих активів становить",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": ". Будь ласка, вимкніть деякі, перш ніж додавати нові.",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "Увімкнено забагато активів",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "Усього камісії:",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "TRADE",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "ОБМІН ЗАВЕРШЕНО!",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "ДЕТАЛІ ТОРГІВЛІ",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "Не вдалося розрахувати комісії за торгівлю",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "комісія за торгівлю:",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "Режим торгівлі",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "Адреса транзакції",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "Транзакція прихована",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "Ця трансакція була прихована через можливу спробу фішингу.",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "Якщо навіть після цього деякі монети все ще не активовані, спробуйте перезапустити програму.",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "Турецька",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "Блоків",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "Підтвердження",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "ПІДТВЕРДЖЕНО",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "Комісія",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "комісія за транзакцію:",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "ID транзакції",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "Транзакцій залишилось: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "Забагато запитів.\nПеревищено ліміт запитів історії транзакцій.\nБудь-ласка спробуйте пізніше.",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "НЕПІДТВЕРДЖЕНО",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "Український",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "розблокувати",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "Розблокувати",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "Успішно розблоковано {amnt} - TX: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "невитрачений",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "Доступна нова версія",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "Перевірка оновлень...",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "Ви використовуєте версію {version}",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "Доступна нова версія. Будь ласка, оновіть.",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "Доступна версія {version}. Будь ласка, оновіть.",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "Доступне оновлення",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "Пропустити поки що",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "Оновлення {appName}",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "Оновлення",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "Вже актуально",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "Недостатньо балансу для сканування",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "платіжний запит.",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "Недостатній баланс",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "Значення:",
-  "@value": {
-    "type": "text"
-  },
-  "version": "версія",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "Провідник",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "Насінний та приватні ключі",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "Обсяги",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "Імʼя гаманця вже використовується",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "Імʼя гаманця може мати максимум 40 символів",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "Тільки гаманець",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "УВАГА!",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "Ок",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "Увага! В особливих випадках дані журналу містять конфіденційну інформацію, яка може бути використана для витрачання монет із невдалих обмінів!",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "Не вдалося активувати {coinAbbr}",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "Не вдалося активувати {coinAbbr}. Будь-ласка спробуйте ще",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} mobile — це мультимонетний гаманець нового покоління з вбудованою функцією DEX третього покоління та більше.",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "ДАВАЙТЕ НАЛАШТОВУВАТИ!",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "ЛАСКАВО ПРОСИМО",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "гаманця",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "Після завершення ви будете перенаправлені на сторінку портфоліо.",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "Це займе деякий час, і програма має залишатися в активному режимі.\nЗакриття програми під час активації може призвести до проблем.",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "Відправити",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "Ви раніше забороняли {appName} доступ до камери. Будь ласка, вручну змініть дозвіл камери в налаштуваннях телефону, щоб продовжити сканування QR-коду",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "Доступ заборонено",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "Підтвердити зняття",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "Щось пішло не так. Спробуйте ще раз пізніше.",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "ВІДПРАВИТИ {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "Ви намагаєтеся відсканувати платіжний QR-код для",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "але ви знаходитесь на",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "знімати екран",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "Неправильна монета",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "Паролі не збігаються. Будь ласка спробуйте ще раз.",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "Так",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "Ви надсилаєте:",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "у вас є нове замовлення, яке намагається узгодити з існуючим",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "у вас триває активний своп",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "у вас є замовлення, з яким можуть відповідати нові замовлення",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "твій гаманець",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "Ви отримаєте {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "Ви отримаєте:",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1,3645 +1,3726 @@
 {
-    "accepteula": "Прийняти EULA",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "Прийміть ПОЛОЖЕННЯ та УМОВИ",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "Активуйте біометричний захист",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "Увімкніть захист PIN-кодом",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "Активувати монети {protocolName}?",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "Активація {coinName}",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "Активація {coinName}",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "Виконується активація {protocolName}",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "Активні",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "Активувати монету",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "{name} успішно активовано!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "Додати адресу",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "Адресна книга",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "Адресна книга порожня",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "Показано лише контакти з адресами {title}",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "Адресна книга",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "Ви не можете відправити кошти на адресу {abbr}, оскільки {abbr} не активований. Будь ласка, перейдіть у портфоліо.",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "Нічого не знайдено:(",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "Виберіть монету",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "Адреса отримувача",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "Розвинутий",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "Усі",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "Дозволити довільне насіння",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "вже існує",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "Сума",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "Сума для продажу",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "Ні! {appName} не зберігє. Ми ніколи не зберігаємо жодних конфіденційних даних, враховуючи ваші насінні ключі, початкові фрази або PIN-код. Ці дані зберігаються лише на пристрої користувача і ніколи не залишають його. Ви повністю контролюєте свої активи.",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName} доступний для мобільних пристроїв на Android і iPhone, а також для комп’ютерів в <a href=\"https://komodoplatform.com/\">операційних системах Windows, Mac і Linux</a>.",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "Інші DEX, як правило, дозволяють лише торгувати активами, які базуються на одній мережі блокчейну, використовують проксі-токени та дозволяють розміщувати лише одне замовлення з тими самими коштами.\n\n{appName} дає вам змогу безпосередньо торгувати між двома різними блокчейн-мережами без проксі-токенів. Ви також можете розмістити кілька замовлень з однаковими коштами. Наприклад, ви можете продати 0,1 BTC за KMD, QTUM або VRSC — перше заповнене замовлення автоматично скасовує всі інші замовлення.",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "Кілька факторів визначають час обробки для кожного обміну. Час блокування торгових активів залежить від кожної мережі (біткойн зазвичай найповільніший). Крім того, користувач може налаштувати параметри безпеки. Наприклад, ви можете попросити {appName} вважати транзакцію KMD остаточною лише після 3 підтверджень, що скорочує час обміну порівняно з очікуванням <a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">нотаріальне засвідчення</a>.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "Так. Ви повинні залишатися підключеними до Інтернету та запустити програму, щоб успішно завершити кожну атомарну заміну (дуже короткі перерви в з’єднанні зазвичай не впливають). В іншому випадку існує ризик скасування угоди, якщо ви мейкер, і ризик втрати коштів, якщо ви тейкер. Протокол атомарного обміну вимагає, щоб обидва учасники залишалися онлайн і контролювали задіяні блокчейни, щоб процес залишався атомарним.",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "Під час торгівлі в {appName} слід враховувати дві категорії комісій.\n\n1. {appName} стягує приблизно 0,13% (1/777 об’єму торгів, але не менше 0,0001) як комісію за торгівлю замовленням-тейкерам, а замовлення-виконавці не мають комісії.\n\n2. Як виробники, так і приймачі повинні будуть сплачувати звичайні мережеві збори залученим блокчейнам під час здійснення транзакцій атомарного свопу.\n\nПлата мережі може значно відрізнятися залежно від вибраної торгової пари.",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "Так! {appName} пропонує підтримку через <a href=\"{link}\">{appCompanyShort} {name}</a>. Команда та спільнота завжди раді допомогти!",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "Ні! {appName} повністю децентралізовано. Неможливо обмежити доступ користувача сторонніми особами.",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} розроблено командою {appCompanyShort}. {appCompanyShort} — це один із найпопулярніших блокчейн-проектів, який працює над інноваційними рішеннями, такими як атомарні свопи, відкладене підтвердження роботи та взаємодіюча багатоланцюгова архітектура.",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "Абсолютно! Щоб дізнатися більше, прочитайте нашу <a href=\"https://developers.komodoplatform.com/\">документацію для розробників</a> або зв’яжіться з нами із запитами про партнерство. Є конкретне технічне запитання? Спільнота розробників {appName} завжди готова допомогти!",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "Оплески",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "ТИ ВПЕВНЕНИЙ?",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "обмін не вдається",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "обмін виконується до кінця",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "автентифікувати",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "Ви будете автоматично перенаправлені на сторінку портфоліо, коли завершиться процес повторної активації.",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "максимальний обсяг",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "назад",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "Резервне копіювання",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "на основі {coinName1}/{coinName2}",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "Заряд акумулятора має вирішальне значення ({batteryLevelCritical}%) для безпечної заміни. Будь ласка, зарядіть його та повторіть спробу.",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "Заряд акумулятора нижчий ніж {batteryLevelLow}%. Будь ласка, врахуйте зарядку телефону.",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "Ваш телефон у режимі економії заряду аккумулятора. Будь-ласка, вимкніть цей режим або НЕ переводьте програму у фоновий режим, інакше програма може бути закрита ОС і заміна не вдасться.",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "Курс обміну валют",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "Побудовано в Komodo",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "Побудовано в Komodo",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "Купити",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "Перетворити на Адресант (Maker), якщо не збігається",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "Обмін видається, зачекайте будь-ласка!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "Збіг із замовленням триває, зачекайте {seconde} секунд!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "Попередження, ви можете купити тестові монети БЕЗ реальної вартості!",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "Камуфляжний PIN-код і біозахист не можна ввімкнути одночасно.",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "Конфлікт камуфляжного PIN та Bio захисту.",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "Змінити PIN-код камуфляжу",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "Створіть камуфляжний PIN-код",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "Якщо ви розблокуєте додаток за допомогою камуфляжного PIN-коду, буде показано ПІДРОБЛЕННИЙ НИЗЬКИЙ баланс, а параметр налаштування камуфляжного PIN-коду НЕ буде видно у налаштуваннях",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "Недійсний камуфляжний PIN-код",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "Камуфляжий PIN-код",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "Камуфляжний PIN-код не знайдено",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "Вимкнено",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "Увімкнено",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "Камуфляжний PIN-код збережено",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "Камуфляжний PIN-код",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "Введіть новий камуфляжний PIN-код",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "Налаштування камуфляжного PIN-коду",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "Налаштування камуфляжного PIN-коду",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "Скасувати",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "Скасувати",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "Відмінити замовлення",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "Щось пішло не так. Спробуйте ще раз пізніше.",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "Ок",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": " є монетою за замовчуванням. Монети за замовчуванням не можна деактивувати.",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "Неможливо вимкнути",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "Не можу це програти",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEXобмінний курс",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "Дані CEX",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "Ринкові дані (ціни, діаграми, тощо), позначені цією піктограмою, походять із сторонніх джерел (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "Курс CEX",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "Змінити PIN-код",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "Перевірити наявність оновлень",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "Перевірити",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "Перевірте насінну фразу",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "ПРОДОВЖИТИ",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "ПОВЕРНІТИСЬ І ПЕРЕВІРИТИ ЗНОВУ",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "Введіть {index} слово",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "Ваша насінна фраза важлива, тому ми хочемо переконатися, що ви її запамʼятали. Ми задамо вам три різні запитання щодо насінної фрази, щоб переконатися, що ви зможете легко відновити свій гаманець, коли захочете.",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "Яке {index} слово у вашій насінній фразі?",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕВІРИМО ВАШУ НАСІННУ ФРАЗУ",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "Китайська",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "Зібрати",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "Зібрати свою винагороду KMD?",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "Натисніть, щоб побачити ",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "Скопійовано в буфер обміну",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "Копіювати в буфер обміну",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "Закрити",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "Закрити повідомлення про помилку",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "Закрити попередній перегляд",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "Код:",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "Ви вибрали максимальну кількість ресурсів",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "Монети {protocolName} активовані",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "Монети {protocolName} успішно активовані",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "Монети {protocolName} не активовані",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "Стерти",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "Немає активних монет",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "Виберіть монету",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "Незабаром...",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "Деталі TX незабаром!",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "Подробиці незабаром!",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "комісійна сплата",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "порівняно із середнім Ціна 24 години CEX",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "порівняно з CEX",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "Налаштування вашого гаманця, зачекайте...",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "Підтвердити",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "Підтвердіть комуфляжний PIN-код",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "Ви впевнені, що бажаєте скасувати замовлення?",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "Натискаючи кнопку нижче, ви підтверджуєте, що прочитали «Ліцензійну угоду» та «Умови використання» та приймаєте їх",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "Підтвердьте пароль",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "Підтвердьте PIN-код",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "Підтвердьте насінну фразу",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "Підключення...",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "Скасувати",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "Видалити контакт",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "Видалити",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "Ви впевнені, що хочете видалити контакт {name}?",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "Відмінити",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "Редагувати",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "Вихід",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "Скасувати зміни?",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "Контакти не знайдено",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "Зберегти",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "Контактні дані",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "Ім'я",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "Договір",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "Конвертувати",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "Не вдалося запустити URL",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "Не вдалося імпортувати:",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "торгівля",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "СТВОРИТИ ГАМАНЕЦЬ",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "Створити контакт",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "Створити PIN-код",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "Валюта",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "Валюта",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "Поточна ціна",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "Довільна комісія ",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "Використовуйте довільні комісії, лише якщо знаєте, що робите!",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "Довільна насінна фраза може бути менш безпечною та її легше зламати, ніж згенерована початкова фраза або закритий ключ (WIF), сумісна з BIP39. Щоб підтвердити, що ви розумієте ризик і знаєте, що робите, введіть \"${iUnderstand}\" у полі нижче.",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "Дата",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "Розшифровка гаманця",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "Видалити",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "Підтвердити деактивацію",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "Ви хочете видалити ",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": " з вашого портфоліо? Усі незʼєднані замовлення будуть скасовані.",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " також буде деактивовано",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "Видалити гаманець",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "Видалення гаманця...",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "отримати комісію за транзакцію {coinName}",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "надіслати комісію за транзакцію {coinName}",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "відправити плату за торгівлю плату за транзакцію",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "комісія за торгівлю",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "деталі",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "Німецька",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "Розробник",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX недоступний для цієї монети",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "Вимкнути знімки екрана/попередній перегляд",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "Disclaimer & ToS",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "Готово",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "Не закривайте програму. Торкніться, щоб дізнатися більше...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "Більше не запитуйте",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "Я не хочу пароль",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Безпека Komodo dPoW",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "Тривалість",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "Редагувати контакт",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "Ведіть {abbr} адресу",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "Пароль шифрування не може бути порожнім",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "Пароль не може бути порожнім",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "Ім’я контакта не може бути пустим",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "Ім’я гаманця не може бути пустим",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "Ви все ще можете ввімкнути {remains}, Вибрано: {selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "Увімкніть сповіщення, щоб отримувати оновлення про хід активації.",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "Увімкнути тестові монети",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "Ти маєш",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "активів увімкнено та намагається ввімкнути",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "більше. Максимальний ліміт активованих активів становить",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": ". Будь-ласка, вимкніть деякі монети, перш ніж додавати нові.",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "Спроба ввімкнути занадто багато ресурсів",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "Шифрування гаманця",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "Англійська",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "Введіть новий PIN-код",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "Введіть свій старий PIN-код",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "Щоб продовжити, введіть свій пароль.",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "Введіть свій PIN-код",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "Введіть свою насінну фразу",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "Спочатку потрібно ввести суму продажу",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "Не вистачає балансу",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "Недійсна адреса",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "Адреси Segwit не підтримуються (поки що)",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "Недостатньо газу  - використовуйте принаймні {gas} Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "Помилка, спробуйте ще раз",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "Помилка, спробуйте пізніше",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "Значення занадто високе або низьке",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "Будь-ласка введіть дані",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "Розрахункова загальна вартість",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}.\nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application.\nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights.\nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information;\n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages.\nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You.\nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from:\n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses;\n(b) server failure or data loss;\n(c) corrupted or otherwise non-performing Wallets or Wallet files;\n(d) unauthorized access to applications;\n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}.\nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination.\nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination.\n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time.\n\n",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data).\nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.\n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application.\nYour access to this application does not itself create an adviser-client relationship between You and us.\nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us.\nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free.\nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies).\n\n",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:\n\n",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY\n\n",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS\n\n",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER\n\n",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY\n\n",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS\n\n",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION\n\n",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET\n\n",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE\n\n",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION\n\n",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS\n\n",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)\n\n",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS\n\n",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER\n\n",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE\n\n",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS\n\n",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE\n\n",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP\n\n",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS\n\n",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING\n\n",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "Приклад: build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "Доцільно",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "Дорого",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "Ідентичний CEX",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "Курс обміну:",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "ОБМІН",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "Експорт",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "Контакти",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "Виберіть елементи для експорту в зашифрований файл.",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "Експорт",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "Примітки",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "Елементи успішно експортовано:",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "Обмін",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "Експорт",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "Не вдалося",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "Підроблена сума балансу:",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "Часто задавані питання",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "Помилка",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "Надсилання запиту на FAUCET {coin}...",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "FAUCET",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "Успіх",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "Час запиту вичерпано",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "Поділитися файлом журналу",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "Новини",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "Тут нічого",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "Новини {appCompanyShort}",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "Детальніше...",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Новини",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Стрічка новин",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "Не вдалося продовжити оновлення новин",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "Не вдалося отримати оновлення новин",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Стрічку новин оновлено",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "Вже актуально",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "Комісії мають бути до {value}",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "Все",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "Фільтр",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "Очистити всі фільтри",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "Не вдалося",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "Від дати",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "Творець",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "Отримати монету",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "Продати монету",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "Статус",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "Успішний",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "Отримувач",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "До дати",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "Відправник/ Отримувач",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "Відбиток пальця",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "Закінчується, будь ласка, зачекайте",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "Знайдено QR-код",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "Французька",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "Від",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "Комісія {coin}",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "Ліміт комісії",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "Будь ласка, активуйте {coin}.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "Ціна на комісію",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "Загальний захист PIN-кодом не активний.\nРежим камуфляжу буде недоступний.\nУвімкніть захист PIN-кодом.",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "Важливо: створіть резервну копію насінної фрази, перш ніж продовжити!",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "Отримання трансакції, зачекайте",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "Перейти до портфоліо",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Gwei має бути до {value}",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "Допомога",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "Допомога та підтримка",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "Приховати баланси",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "Підтвердьте пароль",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "Створити пароль",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "Поточний пароль",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "Введіть ваш пароль",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "Введіть насінну фразу",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "Назвіть свій гаманець",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "Пароль",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "історія",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "г",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "Угорська",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "Імпорт",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "Неправельний пароль або пошкоджені дані",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "Елементи для імпорту:",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "Файл не знайдено",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "Недійсні дані обміну. Надайте дійсний файл JSON статусу обміну.",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "Імпорт",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "Виберіть зашифрований файл для імпорту.",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "Відкриття...",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "Будь ласка, виберіть простий текстовий файл обміну для імпорту.",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "Скасувати",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "ОК",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "Пароль",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "Імпортувати єдиний Своп",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "Імпорт Своп",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "Деякі елементи були пропущені",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "Елементи успішно імпортовано:",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "Не вдалося імпортувати обмін",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "Помилка декодування файлу json",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "Імпорт",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "Налаштування захисту вхідних {coinName} txs",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "Використовуйте надійний пароль і не зберігайте його ні на одному пристрої",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "Запит на обмін не можна скасувати і є остаточною подією!",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "Обмін може тривати до 60 хвилин. НЕ закривайте додаток!",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "Ви повинні вказати пароль для шифрування гаманця з міркувань безпеки.",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr} балансу недостатньо для оплати комісії за торгівлю",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "Мінімальна кількість, необхідна для цього замовлення",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "Недостатня кількість",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "Оновити",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "Підключення до Інтернету відновлено",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "Неможливо продовжити обмін",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "Подробиці",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} недоступен :(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "I understand",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "Японська",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "Корейська",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "Мова",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "Останні транзакції",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "Юридичний",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "Менше",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗Обережно! Ринок для {coinName} має менше 10 тисяч доларів США за 24 години!",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "Обмеження має бути до {value}",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "Завантаження...",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "Завантаження книги замовлень...",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "Екран заблоковано",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "Будь ласка, авторизуйтеся!",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "логін",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "Вийти",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "Вийти під час звороту",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "Налаштування виходу",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "Ви впевнені, що бажаєте вийти зараз?",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "хвилин",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "створити замовлення",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "Творець",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "Відмінити замовлення",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "Створено в",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "Отримати",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "ID замовлення",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "Жодні угоди не були розпочаті цим орденом",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "Ціна",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "Продати",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "Обміни розпочато цим ордером",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "Деталі замовлення виробника",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "Замовлення виробника",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "Ринок",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "Діаграма",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "Глибина",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "Запитів не знайдено",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "Заявок не знайдено",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "ОРДЕРБУК",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "Деталі замовлення",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "ЦІНА",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "Будь ласка, виберіть монети",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "Ринки",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "РИНКИ",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "Паролі мають збігатися",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "Зміна",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "Ваш загальний PIN-код і камуфляжний PIN-код однакові.\nРежим камуфляжу буде недоступний.\nБудь ласка, змініть PIN-код Camouflage.",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "Недійсний PIN-код",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "МАКС",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "Максимальная кількість замовлень:",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "Новини",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "ОГЛЯД",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "ПЕРЕГЛЯНУТИ СТРІЧКУ",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "за",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "У ВАС НЕМАЄ ЗБЕРЕЖЕНИХ СТАТТЕЙ",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "ЗБЕРЕЖЕНО",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "Пам'ятка",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "Зʼєднати",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "Об’єднане значення:",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "мс",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "ХВ",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "Попередження: згортання програми на iOS припинить процес активації.",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "Мінімальна кількість замовлень:",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "хв",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "Мінімальна сума для продажу становить {number} {coinName}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "Мінімальна сума для купівлі становить {number}{coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "Мінімальна сума замовлення становить {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "Мінімальна сума для продажу становить {number}{coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "Має бути більше ніж {minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "Має бути нижчою за суму продажу",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "Необхідний мінімальний обсяг",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "Використати довільний мінімальний обсяг",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "Зауважте, що зараз ви використовуєте мобільні дані та участь у мережі {appName} P2P споживає інтернет-трафік. Краще використовувати мережу WiFi, якщо ваш тарифний план стільникового зв’язку є дорогим.",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "Більше інформації",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "Більше",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "Спочатку активуйте {coin} і поповніть баланс",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "Сума",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "Монета",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "Стрічка новин",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "Скасувати",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "Підтвердити",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "Створіть замовлення ({number}):",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "Створити",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "Замовлення",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "Замовлення",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "внесок",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "Скасувати",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "Будь ласка, введіть фіатну суму, щоб отримати:",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "Автозаповнення",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "Перш ніж продовжити, виправте всі помилки",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "Недійсна сума",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "Недійсна сума продажу",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "Недостатньо {coin} для оплати комісії. MIN баланс становить {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "Баланс {coin} замалий",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "Максимальна сума продажу становить",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "Мінімальна сума отримання становить",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "Мінімальна сума продажу становить",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "Отримати:",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "Продати:",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "Мульти",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "Отримати суму",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "Ціна/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "Плата за мережу",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "Новий акаунт",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "Новий акаунт",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Стрічка новин",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "Нове значення:",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "далі",
-    "@next": {
-        "type": "text"
-    },
-    "no": "Hi",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "Немає новин - перевірте пізніше!",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "Монет не знайдено",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "Немає коштів",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "Немає коштів - внесіть депозит.",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "Немає підключення до Інтернету",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "Елементи не вибрано",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "Елементи не вибрано",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "Відповідних замовлень не знайдено",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "Жодного",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "Значення має бути числовим",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "Введіть суму {coinName}.",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "Натисніть, щоб створити замовлення",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "Немає транзакцій, розпочніть торгівлю",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "Немає винагород",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "Вимагати винагороду не можна. Повторіть спробу через 1 годину.",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "Немає такої монети",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "Немає транзакцій",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "Недостатньо {coin} для транзакції!",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "Недостатньо балансу для комісій - торгуйте на меншу суму",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "Примітка: зібране замовлення не можна скасувати знову",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "Додайте примітку",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "Примітка",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "Нічого не знайдено",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "Обмін {sell}/{buy} успішно завершено",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "Обмін завершено",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "Не вдалося обміняти {sell}/{buy}",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "Помилка обміну",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "Розпочато обмін {sell}/{buy}",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "Розпочато новий обмін",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "Статус обміну змінено",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "Час очікування обміну {sell}/{buy} минув",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "Час очікування обміну минув",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "Ви отримали {coin} трансакцію!",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "Вхідна транзакція",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "Немає транзацкій",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} активів",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "Офіційний прес-реліз",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "Ок",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "Видалити",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "Старі журнало",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "Використаний простір",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "Відкрийте повідомлення про помилку",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "Додатково",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "менше",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "більше",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "Усі замовлення {coin} буде скасовано.",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "Замовлення створено",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "Замовлення успішно створено",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "Адреса",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "Скасувати",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "Доцільно: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "Дорого: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "для",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "Ідентичний CEX",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "мін",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "Ціна",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "Отримати",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "Вибрати",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "Продає",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "Відкрийте «Деталі» одним дотиком і виберіть «Замовити довгим дотиком».",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "Витратити",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "Подробиці",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}% заповнено",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "Замовлення поєднане",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "Замовлення поєднується",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "Замовлення",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "Активні",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "Історія",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "Сума ({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "Ціна ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "Усього ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "Замовлення",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "Невідомий тип зумовлення",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "Перезаписати",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "Це ваше замовлення!",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "Сплачується з баланасу:",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "Сплатити з отриманої кількості",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "Сплачено з",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "Пароль має містити щонайменше 12 символів, з літерою нижнього та верхнього регістру та одного спеціального символу.",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "Оплатити",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "Ви приймаєте цю транзакцію?",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "Адресувати",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "сума:",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "Монета:",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "Скасувати",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "Запит на оплату",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} не активний. Будь ласка, активуйте і спробуйте ще раз.",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "Розмістіть своє замовлення",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "Грати на повній гучності",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "Будь ласка додайте монету",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "Перезапустіть додаток, щоб повторити спробу, або натисніть кнопку нижче.",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "Портфоліо",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "Powered by Komodo",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "ціна",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "Приватний ключ",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "Приватні ключі",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "Підтвердження",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "Використовуйте довільні налаштування захисту",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "ВИМКНЕНО",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "УВІМКНЕНО",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "Попередження, цей атомарний своп не захищений з dPoW.",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "Pubkey",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "Сканер QR-коду",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "Ви зберігаєте мої особисті ключі?",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "На яких пристроях я можу використовувати {appName}?",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "Чим торгівля в {appName} відрізняється від торгівлі в інших DEX?",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "Скільки часу займає кожна атомарна заміна?",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "Чи потрібно мені бути онлайн під час обміну?",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "Як розраховуються комісії за {appName}?",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "Чи забезпечуєте ви підтримку користувачів?",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "Чи є у вас обмеження по країні?",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "Хто стоїть за {appName}?",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "Чи можна розробити власну біржу white-label у {appName}?",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "Це нова ера! Ми офіційно змінили назву з \"AtomicDEX\" на \"Komodo Wallet\"",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "ОТРИМАТИ",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "Отримати",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "Ми рекомендуємо зберігати його офлайн.",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "Вимкнути",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "Запитана торгівля",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "ЗТЕРТИ",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "Скинути форму",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "ВІДНОВИТИ",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "Знову активувати усі монетию..",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "Знову активувати усі",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "Отримайте свої винагороди",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "Скасувати",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "Щось пішло не так. Будь-ласка спробуйте пізніше.",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "Трансакція триває",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "обробка",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "Сума UTXO менше 10 KMD",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10 KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "Ще не минула одна година",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1 години",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "В порядку",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "Статус нагород:",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "Докладніше про нагороди KMD для активних користувачів",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "Отримати",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "Успіх! Отримано {amount} KMD.",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "Фіат",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "Нагороди,\nKMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "Статус",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "Часу залиш.",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "Інформація про нагороди:",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO кіл,\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} дн.",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTitle": "Інформація про нагороди",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "Російська",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "Зберегти обʼєднання",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "Прокрутіть униз, щоб продовжити...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "Пошук монети",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "Виберіть усі токени Avax",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "Виберіть усі токени BEP",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "Виберіть всю мережу Cosmos",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "Виберіть усі токени ERC",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "Виберіть усі токени ETC",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "Виберіть усі токени Fantom",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "Виберіть усі токени HecoChain",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "Виберіть усі жетони Harmony",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "Виберіть всю мережу Iris",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "Виберіть усі токени Kucoin",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "Виберіть усі жетони Moonriver",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "Виберіть усі маркери Polygon",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "Виберіть усі токени QRC",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "Виберіть усі токени SmartBCH",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "Виберіть усі токени SLP",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "Виберіть усі SmartChains",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "Виберіть усі тестові активи",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "Виберіть усі монети Ubiq",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "Виберіть усі монети UTXO",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "Виберіть усі монети ZHTLC",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "Шукати по тікету",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "с",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "Безпека",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "Фраза насіння",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "Ваша нова насінна фраза",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "Натистіть щоб побачити {amount} угоди",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "Побачити історію транзакції",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "Виберіть монету",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "Виберіть монети, які ви хочете додати до свого портфоліо.",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "Активувати монети:",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "Виберіть монету, яку хочете КУПИТИ",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "Виберіть монету, яку хочете ПРОДАТИ",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "Виберіть угоду:",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "Виберіть файл",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "Виберіть мову",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "Виберіть спосіб оплати",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "Продати",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "Увага! Ви готові продати тестові монети БЕЗ реальної вартості!",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "НАДІСЛАТИ",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "Ви впевнені, що хочете видалити",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "гаманець?",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "Якщо так, переконайтеся, що ви",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "запишіть свою насінну фразу.",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "Щоб у майбутньому відновити свій гаманець.",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "Мови",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "Налаштування",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "ВСТАНОВИТИ ПАРОЛЬ",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "Поділитись",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "Моя адреса {coinName}:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "Показати адресу",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "Показати деталі",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "Показано {count} із {maxCount} замовлень.",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "Показати мої угоди",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "Увійдіть за допомогою пароля",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "Забули пароль? Відновити гаманець з насіння",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "Простий",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "Активувати",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "Будь ласка, введіть {coin} суму для купівлі",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "Купити",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "Закрити",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "Максимальна кількість активних монет становить {maxCoins}. Будь ласка, деактивуйте кілька монет.",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin} не активований!",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "Отримати",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "Будь ласка, введіть {coin} суму для продажу",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "Продати",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "Надіслати",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "Показати менше",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "Показати більше",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "Неможливо активувати {coin}",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "Пропустити",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "Відхилити",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "Звук",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "Будь ласка, виберіть файл mp3 або wav. Ми почнемо це, коли {description}.",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "Грає, коли {description}",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "Звуки",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "Зрозумів, більше не показуй",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "Звук",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "Налаштування звуку",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "Ви почуєте звукові сповіщення під час процесу обміну та коли у вас буде розміщено активне замовлення відправника.\nПротокол атомарних свопів вимагає від учасників бути онлайн для успішної торгівлі, а звукові сповіщення допомагають досягти цього.",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "Зверніть увагу, що ви можете встановити власні звуки в налаштуваннях програми.",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "Іспанська",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "Почати обмін",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "Крок",
-    "@step": {
-        "type": "text"
-    },
-    "success": "Успішно!",
-    "@success": {
-        "type": "text"
-    },
-    "support": "Підтримка",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "Якщо у вас виникли запитання або ви вважаєте, що виявили технічну проблему з додатком {appName}, ви можете повідомити про це та отримати підтримку від нашої команди.",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "своп",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "Поточний",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "ПІДТВЕРДИТИ ДЕТАЛІ ОБМІНУ",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "Оцінка",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "Помилка обміну",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "Спочатку активуйте {coin} і поповніть баланс",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "На балансі {coin} недостатньо для оплати комісії за трансакцію.",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "На балансі {coin} недостатньо для оплати комісії за трансакцію. Потрібно {coin} {amount}.",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "Обмін триває",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "Деталі прогресу",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "Розпочато",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "Обмін успішний",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "Всього",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "Swap UUID",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "Змінити тему",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "ЖТЛЦ",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "Отримувач",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "Замовлення покупця",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "Час вийшов",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "СТВОРИТИ ПАРОЛЬ",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "Обране замовлення",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "До",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "Адресувати:",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "Ти маєш",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "активовані активи. Максимальний ліміт активованих активів становить",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": ". Будь ласка, вимкніть деякі, перш ніж додавати нові.",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "Увімкнено забагато активів",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "Усього камісії:",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "TRADE",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "ОБМІН ЗАВЕРШЕНО!",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "ДЕТАЛІ ТОРГІВЛІ",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "Не вдалося розрахувати комісії за торгівлю",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "комісія за торгівлю:",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "Режим торгівлі",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "Адреса транзакції",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "Транзакція прихована",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "Ця трансакція була прихована через можливу спробу фішингу.",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "Якщо навіть після цього деякі монети все ще не активовані, спробуйте перезапустити програму.",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "Турецька",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "Блоків",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "Підтвердження",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "ПІДТВЕРДЖЕНО",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "Комісія",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "комісія за транзакцію:",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "ID транзакції",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "Транзакцій залишилось: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "Забагато запитів.\nПеревищено ліміт запитів історії транзакцій.\nБудь-ласка спробуйте пізніше.",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "НЕПІДТВЕРДЖЕНО",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "Український",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "розблокувати",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "Розблокувати",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "Успішно розблоковано {amnt} - TX: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "невитрачений",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "Доступна нова версія",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "Перевірка оновлень...",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "Ви використовуєте версію {version}",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "Доступна нова версія. Будь ласка, оновіть.",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "Доступна версія {version}. Будь ласка, оновіть.",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "Доступне оновлення",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "Пропустити поки що",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "Оновлення {appName}",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "Оновлення",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "Вже актуально",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "Недостатньо балансу для сканування",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "платіжний запит.",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "Недостатній баланс",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "Значення:",
-    "@value": {
-        "type": "text"
-    },
-    "version": "версія",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "Провідник",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "Насінний та приватні ключі",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "Обсяги",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "Імʼя гаманця вже використовується",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "Імʼя гаманця може мати максимум 40 символів",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "Тільки гаманець",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "УВАГА!",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "Ок",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "Увага! В особливих випадках дані журналу містять конфіденційну інформацію, яка може бути використана для витрачання монет із невдалих обмінів!",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "Не вдалося активувати {coinAbbr}",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "Не вдалося активувати {coinAbbr}. Будь-ласка спробуйте ще",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} mobile — це мультимонетний гаманець нового покоління з вбудованою функцією DEX третього покоління та більше.",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "ДАВАЙТЕ НАЛАШТОВУВАТИ!",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "ЛАСКАВО ПРОСИМО",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "гаманця",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "Після завершення ви будете перенаправлені на сторінку портфоліо.",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "Це займе деякий час, і програма має залишатися в активному режимі.\nЗакриття програми під час активації може призвести до проблем.",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "Відправити",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "Ви раніше забороняли {appName} доступ до камери. Будь ласка, вручну змініть дозвіл камери в налаштуваннях телефону, щоб продовжити сканування QR-коду",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "Доступ заборонено",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "Підтвердити зняття",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "Щось пішло не так. Спробуйте ще раз пізніше.",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "ВІДПРАВИТИ {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "Ви намагаєтеся відсканувати платіжний QR-код для",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "але ви знаходитесь на",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "знімати екран",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "Неправильна монета",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "Паролі не збігаються. Будь ласка спробуйте ще раз.",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "Так",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "Ви надсилаєте:",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "у вас є нове замовлення, яке намагається узгодити з існуючим",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "у вас триває активний своп",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "у вас є замовлення, з яким можуть відповідати нові замовлення",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "твій гаманець",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "Ви отримаєте {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "Ви отримаєте:",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "uk",
+  "accepteula": "Прийняти EULA",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "Прийміть ПОЛОЖЕННЯ та УМОВИ",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "Активуйте біометричний захист",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "Увімкніть захист PIN-кодом",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "Активувати монети {protocolName}?",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "Активація {coinName}",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "Активація {coinName}",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "Виконується активація {protocolName}",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "Активні",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "Активувати монету",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "{name} успішно активовано!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "Додати адресу",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "Адресна книга",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "Адресна книга порожня",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "Показано лише контакти з адресами {title}",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "Адресна книга",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "Ви не можете відправити кошти на адресу {abbr}, оскільки {abbr} не активований. Будь ласка, перейдіть у портфоліо.",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "Нічого не знайдено:(",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "Виберіть монету",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "Адреса отримувача",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "Розвинутий",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "Усі",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "Дозволити довільне насіння",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "У вашому гаманці відображатимуться всі минулі транзакції. Це займе багато пам’яті та часу, оскільки всі блоки будуть завантажені та відскановані.",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "вже існує",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "Сума",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "Сума для продажу",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "Ні! {appName} не зберігє. Ми ніколи не зберігаємо жодних конфіденційних даних, враховуючи ваші насінні ключі, початкові фрази або PIN-код. Ці дані зберігаються лише на пристрої користувача і ніколи не залишають його. Ви повністю контролюєте свої активи.",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} доступний для мобільних пристроїв на Android і iPhone, а також для комп’ютерів в <a href=\"https://komodoplatform.com/\">операційних системах Windows, Mac і Linux</a>.",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "Інші DEX, як правило, дозволяють лише торгувати активами, які базуються на одній мережі блокчейну, використовують проксі-токени та дозволяють розміщувати лише одне замовлення з тими самими коштами.\n\n{appName} дає вам змогу безпосередньо торгувати між двома різними блокчейн-мережами без проксі-токенів. Ви також можете розмістити кілька замовлень з однаковими коштами. Наприклад, ви можете продати 0,1 BTC за KMD, QTUM або VRSC — перше заповнене замовлення автоматично скасовує всі інші замовлення.",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "Кілька факторів визначають час обробки для кожного обміну. Час блокування торгових активів залежить від кожної мережі (біткойн зазвичай найповільніший). Крім того, користувач може налаштувати параметри безпеки. Наприклад, ви можете попросити {appName} вважати транзакцію KMD остаточною лише після 3 підтверджень, що скорочує час обміну порівняно з очікуванням <a href=\"https://komodoplatform.com/security-delayed-proof- of-work-dpow/\">нотаріальне засвідчення</a>.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "Так. Ви повинні залишатися підключеними до Інтернету та запустити програму, щоб успішно завершити кожну атомарну заміну (дуже короткі перерви в з’єднанні зазвичай не впливають). В іншому випадку існує ризик скасування угоди, якщо ви мейкер, і ризик втрати коштів, якщо ви тейкер. Протокол атомарного обміну вимагає, щоб обидва учасники залишалися онлайн і контролювали задіяні блокчейни, щоб процес залишався атомарним.",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "Під час торгівлі в {appName} слід враховувати дві категорії комісій.\n\n1. {appName} стягує приблизно 0,13% (1/777 об’єму торгів, але не менше 0,0001) як комісію за торгівлю замовленням-тейкерам, а замовлення-виконавці не мають комісії.\n\n2. Як виробники, так і приймачі повинні будуть сплачувати звичайні мережеві збори залученим блокчейнам під час здійснення транзакцій атомарного свопу.\n\nПлата мережі може значно відрізнятися залежно від вибраної торгової пари.",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "Так! {appName} пропонує підтримку через <a href=\"{link}\">{appCompanyShort} {name}</a>. Команда та спільнота завжди раді допомогти!",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "Ні! {appName} повністю децентралізовано. Неможливо обмежити доступ користувача сторонніми особами.",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} розроблено командою {appCompanyShort}. {appCompanyShort} — це один із найпопулярніших блокчейн-проектів, який працює над інноваційними рішеннями, такими як атомарні свопи, відкладене підтвердження роботи та взаємодіюча багатоланцюгова архітектура.",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "Абсолютно! Щоб дізнатися більше, прочитайте нашу <a href=\"https://developers.komodoplatform.com/\">документацію для розробників</a> або зв’яжіться з нами із запитами про партнерство. Є конкретне технічне запитання? Спільнота розробників {appName} завжди готова допомогти!",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "Оплески",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "ТИ ВПЕВНЕНИЙ?",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "обмін не вдається",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "обмін виконується до кінця",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "автентифікувати",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "Ви будете автоматично перенаправлені на сторінку портфоліо, коли завершиться процес повторної активації.",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "максимальний обсяг",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "назад",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "Резервне копіювання",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "на основі {coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "Заряд акумулятора має вирішальне значення ({batteryLevelCritical}%) для безпечної заміни. Будь ласка, зарядіть його та повторіть спробу.",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "Заряд акумулятора нижчий ніж {batteryLevelLow}%. Будь ласка, врахуйте зарядку телефону.",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "Ваш телефон у режимі економії заряду аккумулятора. Будь-ласка, вимкніть цей режим або НЕ переводьте програму у фоновий режим, інакше програма може бути закрита ОС і заміна не вдасться.",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "Курс обміну валют",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "Побудовано в Komodo",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "Побудовано в Komodo",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "Купити",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "Перетворити на Адресант (Maker), якщо не збігається",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "Обмін видається, зачекайте будь-ласка!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "Збіг із замовленням триває, зачекайте {seconde} секунд!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "Попередження, ви можете купити тестові монети БЕЗ реальної вартості!",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "Камуфляжний PIN-код і біозахист не можна ввімкнути одночасно.",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "Конфлікт камуфляжного PIN та Bio захисту.",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "Змінити PIN-код камуфляжу",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "Створіть камуфляжний PIN-код",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "Якщо ви розблокуєте додаток за допомогою камуфляжного PIN-коду, буде показано ПІДРОБЛЕННИЙ НИЗЬКИЙ баланс, а параметр налаштування камуфляжного PIN-коду НЕ буде видно у налаштуваннях",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "Недійсний камуфляжний PIN-код",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "Камуфляжий PIN-код",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "Камуфляжний PIN-код не знайдено",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "Вимкнено",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "Увімкнено",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "Камуфляжний PIN-код збережено",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "Камуфляжний PIN-код",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "Введіть новий камуфляжний PIN-код",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "Налаштування камуфляжного PIN-коду",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "Налаштування камуфляжного PIN-коду",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "Скасувати",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "Скасувати активацію",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "Ви впевнені, що бажаєте скасувати активацію?",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "Скасувати",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "Відмінити замовлення",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "Щось пішло не так. Спробуйте ще раз пізніше.",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "Ок",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": " є монетою за замовчуванням. Монети за замовчуванням не можна деактивувати.",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "Неможливо вимкнути",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "Не можу це програти",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEXобмінний курс",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "Дані CEX",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "Ринкові дані (ціни, діаграми, тощо), позначені цією піктограмою, походять із сторонніх джерел (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\" https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "Курс CEX",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "Змінити PIN-код",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "Перевірити наявність оновлень",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "Перевірити",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "Перевірте насінну фразу",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "ПРОДОВЖИТИ",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "ПОВЕРНІТИСЬ І ПЕРЕВІРИТИ ЗНОВУ",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "Введіть {index} слово",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "Ваша насінна фраза важлива, тому ми хочемо переконатися, що ви її запамʼятали. Ми задамо вам три різні запитання щодо насінної фрази, щоб переконатися, що ви зможете легко відновити свій гаманець, коли захочете.",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "Яке {index} слово у вашій насінній фразі?",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "ДАВАЙТЕ ПЕРЕВІРИМО ВАШУ НАСІННУ ФРАЗУ",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "Китайська",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "Зібрати",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "Зібрати свою винагороду KMD?",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "Натисніть, щоб побачити ",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "Скопійовано в буфер обміну",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "Копіювати в буфер обміну",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "Закрити",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "Закрити повідомлення про помилку",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "Закрити попередній перегляд",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "Код:",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "Ви впевнені, що бажаєте скасувати активацію?",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "Ви вибрали максимальну кількість ресурсів",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "Монети {protocolName} активовані",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "Монети {protocolName} успішно активовані",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "Монети {protocolName} не активовані",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "Стерти",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "Немає активних монет",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "Виберіть монету",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "Незабаром...",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "Деталі TX незабаром!",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "Подробиці незабаром!",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "комісійна сплата",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "порівняно із середнім Ціна 24 години CEX",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "порівняно з CEX",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "Налаштування вашого гаманця, зачекайте...",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "Підтвердити",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "Підтвердіть комуфляжний PIN-код",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "Ви впевнені, що бажаєте скасувати замовлення?",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "Натискаючи кнопку нижче, ви підтверджуєте, що прочитали «Ліцензійну угоду» та «Умови використання» та приймаєте їх",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "Підтвердьте пароль",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "Підтвердьте PIN-код",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "Підтвердьте насінну фразу",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "Підключення...",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "Скасувати",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "Видалити контакт",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "Видалити",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "Ви впевнені, що хочете видалити контакт {name}?",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "Відмінити",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "Редагувати",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "Вихід",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "Скасувати зміни?",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "Контакти не знайдено",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "Зберегти",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "Контактні дані",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "Ім'я",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "Договір",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "Конвертувати",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "Не вдалося запустити URL",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "Не вдалося імпортувати:",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "торгівля",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "СТВОРИТИ ГАМАНЕЦЬ",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "Створити контакт",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "Створити PIN-код",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "Валюта",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "Валюта",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "Поточна ціна",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "Довільна комісія ",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "Використовуйте довільні комісії, лише якщо знаєте, що робите!",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "Довільна насінна фраза може бути менш безпечною та її легше зламати, ніж згенерована початкова фраза або закритий ключ (WIF), сумісна з BIP39. Щоб підтвердити, що ви розумієте ризик і знаєте, що робите, введіть \"${iUnderstand}\" у полі нижче.",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "Дата",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "Розшифровка гаманця",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "Видалити",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "Підтвердити деактивацію",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "Ви хочете видалити ",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": " з вашого портфоліо? Усі незʼєднані замовлення будуть скасовані.",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " також буде деактивовано",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "Видалити гаманець",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "Видалення гаманця...",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "отримати комісію за транзакцію {coinName}",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "надіслати комісію за транзакцію {coinName}",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "відправити плату за торгівлю плату за транзакцію",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "комісія за торгівлю",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "деталі",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "Німецька",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "Розробник",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX недоступний для цієї монети",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "Вимкнути знімки екрана/попередній перегляд",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "Disclaimer & ToS",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "Готово",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "Не закривайте програму. Торкніться, щоб дізнатися більше...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "Більше не запитуйте",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "Я не хочу пароль",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Безпека Komodo dPoW",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "Тривалість",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "Редагувати контакт",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "Ведіть {abbr} адресу",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "Пароль шифрування не може бути порожнім",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "Пароль не може бути порожнім",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "Ім’я контакта не може бути пустим",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "Ім’я гаманця не може бути пустим",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "Ви все ще можете ввімкнути {remains}, Вибрано: {selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "Увімкніть сповіщення, щоб отримувати оновлення про хід активації.",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "Увімкнути тестові монети",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "Ти маєш",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "активів увімкнено та намагається ввімкнути",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "більше. Максимальний ліміт активованих активів становить",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": ". Будь-ласка, вимкніть деякі монети, перш ніж додавати нові.",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "Спроба ввімкнути занадто багато ресурсів",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "Шифрування гаманця",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "Англійська",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "Введіть новий PIN-код",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "Введіть свій старий PIN-код",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "Щоб продовжити, введіть свій пароль.",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "Введіть свій PIN-код",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "Введіть свою насінну фразу",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "Спочатку потрібно ввести суму продажу",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "Не вистачає балансу",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "Недійсна адреса",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "Адреси Segwit не підтримуються (поки що)",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "Недостатньо газу  - використовуйте принаймні {gas} Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "Помилка, спробуйте ще раз",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "Помилка, спробуйте пізніше",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "Значення занадто високе або низьке",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "Будь-ласка введіть дані",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "Розрахункова загальна вартість",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}.\nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application.\nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights.\nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information;\n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages.\nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You.\nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from:\n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses;\n(b) server failure or data loss;\n(c) corrupted or otherwise non-performing Wallets or Wallet files;\n(d) unauthorized access to applications;\n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}.\nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination.\nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination.\n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time.\n\n",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data).\nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.\n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application.\nYour access to this application does not itself create an adviser-client relationship between You and us.\nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us.\nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free.\nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies).\n\n",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:\n\n",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY\n\n",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS\n\n",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER\n\n",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY\n\n",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS\n\n",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION\n\n",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET\n\n",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE\n\n",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION\n\n",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS\n\n",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)\n\n",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS\n\n",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER\n\n",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE\n\n",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS\n\n",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE\n\n",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP\n\n",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS\n\n",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING\n\n",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "Приклад: build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "Доцільно",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "Дорого",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "Ідентичний CEX",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "Курс обміну:",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "ОБМІН",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "Експорт",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "Контакти",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "Виберіть елементи для експорту в зашифрований файл.",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "Експорт",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "Примітки",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "Елементи успішно експортовано:",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "Обмін",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "Експорт",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "Не вдалося",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "Підроблена сума балансу:",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "Часто задавані питання",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "Помилка",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "Надсилання запиту на FAUCET {coin}...",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "FAUCET",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "Успіх",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "Час запиту вичерпано",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "Поділитися файлом журналу",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "Новини",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "Тут нічого",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "Новини {appCompanyShort}",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "Детальніше...",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Новини",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Стрічка новин",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "Не вдалося продовжити оновлення новин",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "Не вдалося отримати оновлення новин",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Стрічку новин оновлено",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "Вже актуально",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "Комісії мають бути до {value}",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "Все",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "Фільтр",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "Очистити всі фільтри",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "Не вдалося",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "Від дати",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "Творець",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "Отримати монету",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "Продати монету",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "Статус",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "Успішний",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "Отримувач",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "До дати",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "Відправник/ Отримувач",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "Відбиток пальця",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "Закінчується, будь ласка, зачекайте",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "Знайдено QR-код",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "Французька",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "Від",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "Ми будемо синхронізувати майбутні транзакції, здійснені після активації, пов’язаної з вашим відкритим ключем. Це найшвидший варіант, який займає найменшу кількість пам’яті.",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "Комісія {coin}",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "Ліміт комісії",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "Будь ласка, активуйте {coin}.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "Ціна на комісію",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "Загальний захист PIN-кодом не активний.\nРежим камуфляжу буде недоступний.\nУвімкніть захист PIN-кодом.",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "Важливо: створіть резервну копію насінної фрази, перш ніж продовжити!",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "Отримання трансакції, зачекайте",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "Перейти до портфоліо",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei має бути до {value}",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "Допомога",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "Допомога та підтримка",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "Приховати баланси",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "Підтвердьте пароль",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "Створити пароль",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "Поточний пароль",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "Введіть ваш пароль",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "Введіть насінну фразу",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "Назвіть свій гаманець",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "Пароль",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "історія",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "г",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "Угорська",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "Імпорт",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "Неправельний пароль або пошкоджені дані",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "Елементи для імпорту:",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "Файл не знайдено",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "Недійсні дані обміну. Надайте дійсний файл JSON статусу обміну.",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "Імпорт",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "Виберіть зашифрований файл для імпорту.",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "Відкриття...",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "Будь ласка, виберіть простий текстовий файл обміну для імпорту.",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "Скасувати",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "ОК",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "Пароль",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "Імпортувати єдиний Своп",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "Імпорт Своп",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "Деякі елементи були пропущені",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "Елементи успішно імпортовано:",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "Не вдалося імпортувати обмін",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "Помилка декодування файлу json",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "Імпорт",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "Налаштування захисту вхідних {coinName} txs",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "Використовуйте надійний пароль і не зберігайте його ні на одному пристрої",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "Запит на обмін не можна скасувати і є остаточною подією!",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "Обмін може тривати до 60 хвилин. НЕ закривайте додаток!",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "Ви повинні вказати пароль для шифрування гаманця з міркувань безпеки.",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr} балансу недостатньо для оплати комісії за торгівлю",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "Мінімальна кількість, необхідна для цього замовлення",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "Недостатня кількість",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "Оновити",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "Підключення до Інтернету відновлено",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "Недійсна адреса {coin}",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "Неможливо продовжити обмін",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "Подробиці",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} недоступен :(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "I understand",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "Японська",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "Корейська",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "Мова",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "Останні транзакції",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "Юридичний",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "Менше",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗Обережно! Ринок для {coinName} має менше 10 тисяч доларів США за 24 години!",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "Обмеження має бути до {value}",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "Завантаження...",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "Завантаження книги замовлень...",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "Екран заблоковано",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "Будь ласка, авторизуйтеся!",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "логін",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "Вийти",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "Вийти під час звороту",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "Налаштування виходу",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "Ви впевнені, що бажаєте вийти зараз?",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "хвилин",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "створити замовлення",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "Творець",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "Відмінити замовлення",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "Створено в",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "Отримати",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "ID замовлення",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "Жодні угоди не були розпочаті цим орденом",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "Ціна",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "Продати",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "Обміни розпочато цим ордером",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "Деталі замовлення виробника",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "Замовлення виробника",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "Ринок",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "Діаграма",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "Глибина",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "Запитів не знайдено",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "Заявок не знайдено",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "ОРДЕРБУК",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "Деталі замовлення",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "ЦІНА",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "Будь ласка, виберіть монети",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "Ринки",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "РИНКИ",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "Паролі мають збігатися",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "Зміна",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "Ваш загальний PIN-код і камуфляжний PIN-код однакові.\nРежим камуфляжу буде недоступний.\nБудь ласка, змініть PIN-код Camouflage.",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "Недійсний PIN-код",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "МАКС",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "Максимальная кількість замовлень:",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "Новини",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "ОГЛЯД",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "ПЕРЕГЛЯНУТИ СТРІЧКУ",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "за",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "У ВАС НЕМАЄ ЗБЕРЕЖЕНИХ СТАТТЕЙ",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "ЗБЕРЕЖЕНО",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "Пам'ятка",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "Зʼєднати",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "Об’єднане значення:",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "мс",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "ХВ",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "Попередження: згортання програми на iOS припинить процес активації.",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "Мінімальна кількість замовлень:",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "хв",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "Мінімальна сума для продажу становить {number} {coinName}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "Мінімальна сума для купівлі становить {number}{coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "Мінімальна сума замовлення становить {buyAmount}{buyCoin}\n({sellAmount}{sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "Мінімальна сума для продажу становить {number}{coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "Має бути більше ніж {minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "Має бути нижчою за суму продажу",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "Необхідний мінімальний обсяг",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "Використати довільний мінімальний обсяг",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "Зауважте, що зараз ви використовуєте мобільні дані та участь у мережі {appName} P2P споживає інтернет-трафік. Краще використовувати мережу WiFi, якщо ваш тарифний план стільникового зв’язку є дорогим.",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "Більше інформації",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "Більше",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "Спочатку активуйте {coin} і поповніть баланс",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "Сума",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "Монета",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "Стрічка новин",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "Скасувати",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "Підтвердити",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "Створіть замовлення ({number}):",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "Створити",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "Замовлення",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "Замовлення",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "внесок",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "Скасувати",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "Будь ласка, введіть фіатну суму, щоб отримати:",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "Автозаповнення",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "Перш ніж продовжити, виправте всі помилки",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "Недійсна сума",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "Недійсна сума продажу",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "Недостатньо {coin} для оплати комісії. MIN баланс становить {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "Баланс {coin} замалий",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "Максимальна сума продажу становить",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "Мінімальна сума отримання становить",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "Мінімальна сума продажу становить",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "Отримати:",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "Продати:",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "Мульти",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "Отримати суму",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "Ціна/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "Плата за мережу",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "Новий акаунт",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "Новий акаунт",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Стрічка новин",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "Нове значення:",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "далі",
+  "@next": {
+    "type": "text"
+  },
+  "no": "Hi",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "Немає новин - перевірте пізніше!",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "Монет не знайдено",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "Немає коштів",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "Немає коштів - внесіть депозит.",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "Немає підключення до Інтернету",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "Елементи не вибрано",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "Елементи не вибрано",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "Відповідних замовлень не знайдено",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "Жодного",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "Значення має бути числовим",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "Введіть суму {coinName}.",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "Натисніть, щоб створити замовлення",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "Немає транзакцій, розпочніть торгівлю",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "Немає винагород",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "Вимагати винагороду не можна. Повторіть спробу через 1 годину.",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "Немає такої монети",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "Немає транзакцій",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "Недостатньо {coin} для транзакції!",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "Недостатньо балансу для комісій - торгуйте на меншу суму",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "Примітка: зібране замовлення не можна скасувати знову",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "Додайте примітку",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "Примітка",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "Нічого не знайдено",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "Обмін {sell}/{buy} успішно завершено",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "Обмін завершено",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "Не вдалося обміняти {sell}/{buy}",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "Помилка обміну",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "Розпочато обмін {sell}/{buy}",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "Розпочато новий обмін",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "Статус обміну змінено",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "Час очікування обміну {sell}/{buy} минув",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "Час очікування обміну минув",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "Ви отримали {coin} трансакцію!",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "Вхідна транзакція",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "Немає транзацкій",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} активів",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "Офіційний прес-реліз",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "Ок",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "Видалити",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "Старі журнало",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "Використаний простір",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "Відкрийте повідомлення про помилку",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "Додатково",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "менше",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "більше",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "Усі замовлення {coin} буде скасовано.",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "Замовлення створено",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "Замовлення успішно створено",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "Адреса",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "Скасувати",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "Доцільно: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "Дорого: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "для",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "Ідентичний CEX",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "мін",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "Ціна",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "Отримати",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "Вибрати",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "Продає",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "Відкрийте «Деталі» одним дотиком і виберіть «Замовити довгим дотиком».",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "Витратити",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "Подробиці",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}% заповнено",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "Замовлення поєднане",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "Замовлення поєднується",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "Замовлення",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "Активні",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "Історія",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "Сума ({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "Ціна ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "Усього ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "Замовлення",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "Невідомий тип зумовлення",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "Перезаписати",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "Це ваше замовлення!",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "Сплачується з баланасу:",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "Сплатити з отриманої кількості",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "Сплачено з",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "Пароль має містити щонайменше 12 символів, з літерою нижнього та верхнього регістру та одного спеціального символу.",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "Ваш гаманець відображатиме ваші минулі транзакції, здійснені після вказаної дати.",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "Оплатити",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "Ви приймаєте цю транзакцію?",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "Адресувати",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "сума:",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "Монета:",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "Скасувати",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "Запит на оплату",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} не активний. Будь ласка, активуйте і спробуйте ще раз.",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "Розмістіть своє замовлення",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "Грати на повній гучності",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "Будь ласка додайте монету",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "Перезапустіть додаток, щоб повторити спробу, або натисніть кнопку нижче.",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "Портфоліо",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "Powered by Komodo",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "ціна",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "Приватний ключ",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "Приватні ключі",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "Підтвердження",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "Використовуйте довільні налаштування захисту",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "ВИМКНЕНО",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "УВІМКНЕНО",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "Попередження, цей атомарний своп не захищений з dPoW.",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "Pubkey",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "Сканер QR-коду",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "Ви зберігаєте мої особисті ключі?",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "На яких пристроях я можу використовувати {appName}?",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "Чим торгівля в {appName} відрізняється від торгівлі в інших DEX?",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "Скільки часу займає кожна атомарна заміна?",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "Чи потрібно мені бути онлайн під час обміну?",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "Як розраховуються комісії за {appName}?",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "Чи забезпечуєте ви підтримку користувачів?",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "Чи є у вас обмеження по країні?",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "Хто стоїть за {appName}?",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "Чи можна розробити власну біржу white-label у {appName}?",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "Це нова ера! Ми офіційно змінили назву з \"AtomicDEX\" на \"Komodo Wallet\"",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "ОТРИМАТИ",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "Отримати",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "Ми рекомендуємо зберігати його офлайн.",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "Вимкнути",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "Запитана торгівля",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "ЗТЕРТИ",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "Скинути форму",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "ВІДНОВИТИ",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "Знову активувати усі монетию..",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "Знову активувати усі",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "Отримайте свої винагороди",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "Скасувати",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "Щось пішло не так. Будь-ласка спробуйте пізніше.",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "Трансакція триває",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "обробка",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "Сума UTXO менше 10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10 KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "Ще не минула одна година",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1 години",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "В порядку",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "Статус нагород:",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "Докладніше про нагороди KMD для активних користувачів",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "Отримати",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "Успіх! Отримано {amount} KMD.",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "Фіат",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "Нагороди,\nKMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "Статус",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "Часу залиш.",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "Інформація про нагороди:",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO кіл,\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} дн.",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{гч} год {хвилин} хв",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{мм} хв",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "Інформація про нагороди",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "Російська",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "Зберегти обʼєднання",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "Прокрутіть униз, щоб продовжити...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "Пошук монети",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "Виберіть усі токени Avax",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "Виберіть усі токени BEP",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "Виберіть всю мережу Cosmos",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "Виберіть усі токени ERC",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "Виберіть усі токени ETC",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "Виберіть усі токени Fantom",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "Виберіть усі токени HecoChain",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "Виберіть усі жетони Harmony",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "Виберіть всю мережу Iris",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "Виберіть усі токени Kucoin",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "Виберіть усі жетони Moonriver",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "Виберіть усі маркери Polygon",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "Виберіть усі токени QRC",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "Виберіть усі токени SmartBCH",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "Виберіть усі токени SLP",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "Виберіть усі SmartChains",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "Виберіть усі тестові активи",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "Виберіть усі монети Ubiq",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "Виберіть усі монети UTXO",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "Виберіть усі монети ZHTLC",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "Шукати по тікету",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "с",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "Безпека",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "Фраза насіння",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "Ваша нова насінна фраза",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "Натистіть щоб побачити {amount} угоди",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "Побачити історію транзакції",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "Виберіть монету",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "Виберіть монети, які ви хочете додати до свого портфоліо.",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "Активувати монети:",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "Виберіть монету, яку хочете КУПИТИ",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "Виберіть монету, яку хочете ПРОДАТИ",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "Виберіть дату",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "Виберіть угоду:",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "Виберіть файл",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "Виберіть мову",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "Виберіть спосіб оплати",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "Продати",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "Увага! Ви готові продати тестові монети БЕЗ реальної вартості!",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "НАДІСЛАТИ",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "Ви впевнені, що хочете видалити",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "гаманець?",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "Якщо так, переконайтеся, що ви",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "запишіть свою насінну фразу.",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "Щоб у майбутньому відновити свій гаманець.",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "Мови",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "Налаштування",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "ВСТАНОВИТИ ПАРОЛЬ",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "Поділитись",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "Моя адреса {coinName}:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "Сканувати минулі транзакції {coin}?",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "Показати адресу",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "Показати деталі",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "Показано {count} із {maxCount} замовлень.",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "Показати мої угоди",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "Увійдіть за допомогою пароля",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "Забули пароль? Відновити гаманець з насіння",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "Простий",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "Активувати",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "Будь ласка, введіть {coin} суму для купівлі",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "Купити",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "Закрити",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "Максимальна кількість активних монет становить {maxCoins}. Будь ласка, деактивуйте кілька монет.",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin} не активований!",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "Отримати",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "Будь ласка, введіть {coin} суму для продажу",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "Продати",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "Надіслати",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "Показати менше",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "Показати більше",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "Неможливо активувати {coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "Пропустити",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "Відхилити",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "Звук",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "Будь ласка, виберіть файл mp3 або wav. Ми почнемо це, коли {description}.",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "Грає, коли {description}",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "Звуки",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "Зрозумів, більше не показуй",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "Звук",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "Налаштування звуку",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "Ви почуєте звукові сповіщення під час процесу обміну та коли у вас буде розміщено активне замовлення відправника.\nПротокол атомарних свопів вимагає від учасників бути онлайн для успішної торгівлі, а звукові сповіщення допомагають досягти цього.",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "Зверніть увагу, що ви можете встановити власні звуки в налаштуваннях програми.",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "Іспанська",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "Дата початку",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "Почати обмін",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "Крок",
+  "@step": {
+    "type": "text"
+  },
+  "success": "Успішно!",
+  "@success": {
+    "type": "text"
+  },
+  "support": "Підтримка",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "Якщо у вас виникли запитання або ви вважаєте, що виявили технічну проблему з додатком {appName}, ви можете повідомити про це та отримати підтримку від нашої команди.",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "своп",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "Поточний",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "ПІДТВЕРДИТИ ДЕТАЛІ ОБМІНУ",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "Оцінка",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "Помилка обміну",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "Спочатку активуйте {coin} і поповніть баланс",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "На балансі {coin} недостатньо для оплати комісії за трансакцію.",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "На балансі {coin} недостатньо для оплати комісії за трансакцію. Потрібно {coin} {amount}.",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "Обмін триває",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "Деталі прогресу",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "Розпочато",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "Обмін успішний",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "Всього",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "Swap UUID",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "Змінити тему",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "Синхронізувати з указаної дати",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "Синхронізація з активації саджанця",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "Синхронізувати нові транзакції",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "Які транзакції {name} ви хочете синхронізувати?",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "Отримувач",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "Замовлення покупця",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "Час вийшов",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "СТВОРИТИ ПАРОЛЬ",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "Обране замовлення",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "До",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "Адресувати:",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "Ти маєш",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "активовані активи. Максимальний ліміт активованих активів становить",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": ". Будь ласка, вимкніть деякі, перш ніж додавати нові.",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "Увімкнено забагато активів",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "Усього камісії:",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "TRADE",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "ОБМІН ЗАВЕРШЕНО!",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "ДЕТАЛІ ТОРГІВЛІ",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "Не вдалося розрахувати комісії за торгівлю",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "комісія за торгівлю:",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "Режим торгівлі",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "Адреса транзакції",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "Транзакція прихована",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "Ця трансакція була прихована через можливу спробу фішингу.",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "Якщо навіть після цього деякі монети все ще не активовані, спробуйте перезапустити програму.",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "Турецька",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "Блоків",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "Підтвердження",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "ПІДТВЕРДЖЕНО",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "Комісія",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "комісія за транзакцію:",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "ID транзакції",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "Транзакцій залишилось: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "Забагато запитів.\nПеревищено ліміт запитів історії транзакцій.\nБудь-ласка спробуйте пізніше.",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "НЕПІДТВЕРДЖЕНО",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "Український",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "розблокувати",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "Розблокувати",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "Успішно розблоковано {amnt} - TX: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "невитрачений",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "Доступна нова версія",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "Перевірка оновлень...",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "Ви використовуєте версію {version}",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "Доступна нова версія. Будь ласка, оновіть.",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "Доступна версія {version}. Будь ласка, оновіть.",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "Доступне оновлення",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "Пропустити поки що",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "Оновлення {appName}",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "Оновлення",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "Вже актуально",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "Недостатньо балансу для сканування",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "платіжний запит.",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "Недостатній баланс",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "Значення:",
+  "@value": {
+    "type": "text"
+  },
+  "version": "версія",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "Провідник",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "Насінний та приватні ключі",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "Обсяги",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "Імʼя гаманця вже використовується",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "Імʼя гаманця може мати максимум 40 символів",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "Тільки гаманець",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "УВАГА!",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "Ок",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "Увага! В особливих випадках дані журналу містять конфіденційну інформацію, яка може бути використана для витрачання монет із невдалих обмінів!",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "Не вдалося активувати {coinAbbr}",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "Не вдалося активувати {coinAbbr}. Будь-ласка спробуйте ще",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} mobile — це мультимонетний гаманець нового покоління з вбудованою функцією DEX третього покоління та більше.",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "ДАВАЙТЕ НАЛАШТОВУВАТИ!",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "ЛАСКАВО ПРОСИМО",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "гаманця",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "Після завершення ви будете перенаправлені на сторінку портфоліо.",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "Це займе деякий час, і програма має залишатися в активному режимі.\nЗакриття програми під час активації може призвести до проблем.",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "Відправити",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "Ви раніше забороняли {appName} доступ до камери. Будь ласка, вручну змініть дозвіл камери в налаштуваннях телефону, щоб продовжити сканування QR-коду",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "Доступ заборонено",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "Підтвердити зняття",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "Щось пішло не так. Спробуйте ще раз пізніше.",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "ВІДПРАВИТИ {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "Ви намагаєтеся відсканувати платіжний QR-код для",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "але ви знаходитесь на",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "знімати екран",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "Неправильна монета",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "Паролі не збігаються. Будь ласка спробуйте ще раз.",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "Так",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "Ви надсилаєте:",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "у вас є нове замовлення, яке намагається узгодити з існуючим",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "у вас триває активний своп",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "у вас є замовлення, з яким можуть відповідати нові замовлення",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "твій гаманець",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "Ви отримаєте {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "Ви отримаєте:",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -3599,6 +3599,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "Не вдалося скасувати активацію {coinAbbr}",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} недоступен :(",
     "@isUnavailable": {
         "type": "text",
@@ -5438,6 +5448,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "Активацію монет скасовано",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "Успішно активовано {coin}",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "Активацію {coin} скасовано",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "Будь ласка, прийміть усі спеціальні запити на активацію монет або скасуйте вибір монет.",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "Скасувати активацію",
     "@cancelActivation": {

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,3660 +1,3726 @@
 {
-    "accepteula": "同意接受终端使用者授权协议 (EULA)",
-    "@accepteula": {
-        "type": "text"
-    },
-    "accepttac": "接受条款与条件",
-    "@accepttac": {
-        "type": "text"
-    },
-    "activateAccessBiometric": "启动生物识别功能",
-    "@activateAccessBiometric": {
-        "type": "text"
-    },
-    "activateAccessPin": "启动PIN码保护",
-    "@activateAccessPin": {
-        "type": "text"
-    },
-    "activateCoins": "激活 {protocolName} 币？",
-    "@activateCoins": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "activating": "激活{coinName}",
-    "@activating": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activation": "{coinName} 激活",
-    "@activation": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "activationInProgress": "{protocolName} 激活正在进行中",
-    "@activationInProgress": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "Active": "活跃",
-    "@Active": {
-        "type": "text"
-    },
-    "addCoin": "新增货币",
-    "@addCoin": {
-        "type": "text"
-    },
-    "addingCoinSuccess": "成功新增 {name}!",
-    "@addingCoinSuccess": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "addressAdd": "添加地址",
-    "@addressAdd": {
-        "type": "text"
-    },
-    "addressBook": "地址簿",
-    "@addressBook": {
-        "type": "text"
-    },
-    "addressBookEmpty": "地址簿为空",
-    "@addressBookEmpty": {
-        "type": "text"
-    },
-    "addressBookFilter": "仅显示具有{title}地址的联系人",
-    "@addressBookFilter": {
-        "type": "text",
-        "placeholders": {
-            "title": {}
-        }
-    },
-    "addressBookTitle": "地址簿",
-    "@addressBookTitle": {
-        "type": "text"
-    },
-    "addressCoinInactive": "您无法将基金发送到{abbr}地址，因为{abbr}未激活。请转到投资组合页面",
-    "@addressCoinInactive": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "addressNotFound": "未找到任何内容",
-    "@addressNotFound": {
-        "type": "text"
-    },
-    "addressSelectCoin": "选择货币",
-    "@addressSelectCoin": {
-        "type": "text"
-    },
-    "addressSend": "收款人钱包地址",
-    "@addressSend": {
-        "type": "text"
-    },
-    "advanced": "高级",
-    "@advanced": {
-        "type": "text"
-    },
-    "all": "全部",
-    "@all": {
-        "type": "text"
-    },
-    "allowCustomSeed": "允许自定义助记词",
-    "@allowCustomSeed": {
-        "type": "text"
-    },
-    "alreadyExists": "已存在",
-    "@alreadyExists": {
-        "type": "text"
-    },
-    "amount": "数量",
-    "@amount": {
-        "type": "text"
-    },
-    "amountToSell": "卖出量",
-    "@amountToSell": {
-        "type": "text"
-    },
-    "answer_1": "不{appName}是非托管应用。我们不会存储任何敏感数据，包括您的私钥、助记词或PIN。此数据仅存储在用户的设备上，不会转移。您的资产只由您掌控。",
-    "@answer_1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_10": "{appName} 适用于 Android 和 iPhone 上的移动设备，以及 <a href=\"https://komodoplatform.com/\">Windows、Mac 和 Linux 操作系统</a> 上的桌面设备。",
-    "@answer_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_2": "其他DEX（去中心化交易所）通常只允许您使用代理代币交易基于单个区块链网络的资产，并且只能用一个基金下一个订单。\n但用{appName}您可以在两个不同的区块链网络之间进行交易，且无需代理代币。您还可以用一个基金下多个订单。例如，您可以用KMD、QTUM或VRSC兑0.1 BTC，第一个订单成交后自动取消其他所有订单",
-    "@answer_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_3": "几个因素决定了每次交易的处理时间。交易资产的区块时间取决于各自的网络（比特币通常是最慢的）。此外，用户可以自定义安全偏好。例如，您可以要求{appName}在确认KMD交易为最终交易前确认3次，这使得交易时间短于等待公证的<a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">时间</a>.",
-    "@answer_3": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_4": "是的，必须保持互联网连接，并确保您的应用程序在运行，才能成功完成原子交换（网络短暂中断通常是可以的）。否则，如果是挂单，会有交易取消的风险，如果是吃单，会有资金损失的风险。原子交换协议要求双方参与者保持在线，并监控所涉及的区块链，确保该过程保持原子性。",
-    "@answer_4": {
-        "type": "text"
-    },
-    "answer_5": "在｛appName｝上进行交易时，需要考虑两种费用。\n1.｛appName｝收取约0.13%（交易量的1/777，但不低于0.0001）作为吃单交易的交易费用，挂单交易不收费。\n2.在进行原子交换交易时，无论挂单还是吃单，都需要向相关区块链支付常规的网络费用\n网络费用具体取决于你选择的交易对，不同交易对费用可能大大不同。",
-    "@answer_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_6": "是的 {appName} 通过 <a href=\"{link}\">{appCompanyShort} {name}</a>提供支持。团队和社区总是乐于提供帮助！",
-    "@answer_6": {
-        "type": "text",
-        "placeholders": {
-            "name": {},
-            "link": {},
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_7": "不是{appName} 是完全去中心化的。不会限制任何第三方用户访问。",
-    "@answer_7": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "answer_8": "{appName} 由{appCompanyShort}团队开发。{appCompanyShort}是最成熟的区块链项目之一，致力于开发创新解决方案，如原子交换、延迟工作量证明和可互操作的多链架构。",
-    "@answer_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyShort": {}
-        }
-    },
-    "answer_9": "绝对地！您可以阅读我们的<a href=\"https://developers.komodoplatform.com/\">开发者文档</a>了解更多详细信息，或者联系我们咨询您的合作伙伴关系。有具体的技术问题吗？ {appName} 开发者社区随时准备提供帮助！",
-    "@answer_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "Applause": "掌声",
-    "@Applause": {
-        "type": "text"
-    },
-    "areYouSure": "您确定吗？",
-    "@areYouSure": {
-        "type": "text"
-    },
-    "a swap fails": "交换失败",
-    "@a swap fails": {
-        "type": "text"
-    },
-    "a swap runs to completion": "交换完成",
-    "@a swap runs to completion": {
-        "type": "text"
-    },
-    "authenticate": "身份验证",
-    "@authenticate": {
-        "type": "text"
-    },
-    "automaticRedirected": "重新激活后，您将自动跳转至投资组合页面。",
-    "@automaticRedirected": {
-        "type": "text"
-    },
-    "availableVolume": "最大交易量",
-    "@availableVolume": {
-        "type": "text"
-    },
-    "back": "上一步",
-    "@back": {
-        "type": "text"
-    },
-    "backupTitle": "备份",
-    "@backupTitle": {
-        "type": "text"
-    },
-    "basedOnCoinRatio": "基于{coinName1}/{coinName2}",
-    "@basedOnCoinRatio": {
-        "type": "text",
-        "placeholders": {
-            "coinName1": {},
-            "coinName2": {}
-        }
-    },
-    "batteryCriticalError": "您的电池电量过低 ({batteryLevelCritical}%) ，无法安全地进行交换。请先充电，然后重试。",
-    "@batteryCriticalError": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelCritical": {}
-        }
-    },
-    "batteryLowWarning": "您的电池电量低于 {batteryLevelLow}%。请充电。",
-    "@batteryLowWarning": {
-        "type": "text",
-        "placeholders": {
-            "batteryLevelLow": {}
-        }
-    },
-    "batterySavingWarning": "您的手机处于省电模式。请停用此模式或不要将应用程序置于后台，否则，应用程序可能会被系统自动清除，导致交换失败。",
-    "@batterySavingWarning": {
-        "type": "text"
-    },
-    "bestAvailableRate": "兑换率",
-    "@bestAvailableRate": {
-        "type": "text"
-    },
-    "builtKomodo": "基于Komodo",
-    "@builtKomodo": {
-        "type": "text"
-    },
-    "builtOnKmd": "基于Komodo",
-    "@builtOnKmd": {
-        "type": "text"
-    },
-    "buy": "买入",
-    "@buy": {
-        "type": "text"
-    },
-    "buyOrderType": "如果不匹配，则转为挂单",
-    "@buyOrderType": {
-        "type": "text"
-    },
-    "buySuccessWaiting": "交换已发起，请等待!",
-    "@buySuccessWaiting": {
-        "type": "text"
-    },
-    "buySuccessWaitingError": "正在进行交易匹配，请等待 {seconde} 秒!",
-    "@buySuccessWaitingError": {
-        "type": "text",
-        "placeholders": {
-            "seconde": {}
-        }
-    },
-    "buyTestCoinWarning": "警告，你正在购买没有实际价值的测试币!",
-    "@buyTestCoinWarning": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflict": "不能同时启用伪装PIN和生物识别保护",
-    "@camoPinBioProtectionConflict": {
-        "type": "text"
-    },
-    "camoPinBioProtectionConflictTitle": "伪装PIN和生物识别保护冲突",
-    "@camoPinBioProtectionConflictTitle": {
-        "type": "text"
-    },
-    "camoPinChange": "更改伪装PIN",
-    "@camoPinChange": {
-        "type": "text"
-    },
-    "camoPinCreate": "创建伪装PIN",
-    "@camoPinCreate": {
-        "type": "text"
-    },
-    "camoPinDesc": "如果您用伪装PIN解锁应用程序，将显示一个虚假的低余额，并且设置中不会显示伪装PIN配置选项。",
-    "@camoPinDesc": {
-        "type": "text"
-    },
-    "camoPinInvalid": "无效的伪装PIN",
-    "@camoPinInvalid": {
-        "type": "text"
-    },
-    "camoPinLink": "伪装PIN",
-    "@camoPinLink": {
-        "type": "text"
-    },
-    "camoPinNotFound": "未找到伪装PIN",
-    "@camoPinNotFound": {
-        "type": "text"
-    },
-    "camoPinOff": "关闭",
-    "@camoPinOff": {
-        "type": "text"
-    },
-    "camoPinOn": "开启",
-    "@camoPinOn": {
-        "type": "text"
-    },
-    "camoPinSaved": "已保存的伪装PIN",
-    "@camoPinSaved": {
-        "type": "text"
-    },
-    "camoPinTitle": "伪装PIN",
-    "@camoPinTitle": {
-        "type": "text"
-    },
-    "camoSetupSubtitle": "输入新的伪装PIN",
-    "@camoSetupSubtitle": {
-        "type": "text"
-    },
-    "camoSetupTitle": "伪装PIN设置",
-    "@camoSetupTitle": {
-        "type": "text"
-    },
-    "camouflageSetup": "伪装PIN设置",
-    "@camouflageSetup": {
-        "type": "text"
-    },
-    "cancel": "取消",
-    "@cancel": {
-        "type": "text"
-    },
-    "cancelButton": "取消",
-    "@cancelButton": {
-        "type": "text"
-    },
-    "cancelOrder": "取消交易",
-    "@cancelOrder": {
-        "type": "text"
-    },
-    "candleChartError": "出现错误，稍后重试",
-    "@candleChartError": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinOk": "好的",
-    "@cantDeleteDefaultCoinOk": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinSpan": "是默认币。无法停用默认币。",
-    "@cantDeleteDefaultCoinSpan": {
-        "type": "text"
-    },
-    "cantDeleteDefaultCoinTitle": "无法停用",
-    "@cantDeleteDefaultCoinTitle": {
-        "type": "text"
-    },
-    "Can't play that": "不能播放",
-    "@Can't play that": {
-        "type": "text"
-    },
-    "cex": "CEX(中心化交易所)",
-    "@cex": {
-        "type": "text"
-    },
-    "cexChangeRate": "CEX兑换率",
-    "@cexChangeRate": {
-        "type": "text"
-    },
-    "cexData": "CEX 数据",
-    "@cexData": {
-        "type": "text"
-    },
-    "cexDataDesc": "带有此图标的市场数据（价格、图表等）来源于第三方(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-    "@cexDataDesc": {
-        "type": "text"
-    },
-    "cexRate": "CEX 汇率",
-    "@cexRate": {
-        "type": "text"
-    },
-    "changePin": "更改PIN",
-    "@changePin": {
-        "type": "text"
-    },
-    "checkForUpdates": "检查更新",
-    "@checkForUpdates": {
-        "type": "text"
-    },
-    "checkOut": "退出",
-    "@checkOut": {
-        "type": "text"
-    },
-    "checkSeedPhrase": "检查助记词",
-    "@checkSeedPhrase": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton1": "继续",
-    "@checkSeedPhraseButton1": {
-        "type": "text"
-    },
-    "checkSeedPhraseButton2": "返回並再次檢查",
-    "@checkSeedPhraseButton2": {
-        "type": "text"
-    },
-    "checkSeedPhraseHint": "请输入第 {index}个单词",
-    "@checkSeedPhraseHint": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseInfo": "您的助记词很重要——因此我们要确保它是正确的。我们将问您三个关于您的助记词的问题，以确保您可以随时轻松地恢复钱包。",
-    "@checkSeedPhraseInfo": {
-        "type": "text"
-    },
-    "checkSeedPhraseSubtile": "您的助記詞的第 {index}個单词是什麼？",
-    "@checkSeedPhraseSubtile": {
-        "type": "text",
-        "placeholders": {
-            "index": {}
-        }
-    },
-    "checkSeedPhraseTitle": "请再次确认助记词",
-    "@checkSeedPhraseTitle": {
-        "type": "text"
-    },
-    "chineseLanguage": "中文",
-    "@chineseLanguage": {
-        "type": "text"
-    },
-    "claim": "领取",
-    "@claim": {
-        "type": "text"
-    },
-    "claimTitle": "领取您的KMD奖励？",
-    "@claimTitle": {
-        "type": "text"
-    },
-    "clickToSee": "点击查看",
-    "@clickToSee": {
-        "type": "text"
-    },
-    "clipboard": "复制到剪贴板",
-    "@clipboard": {
-        "type": "text"
-    },
-    "clipboardCopy": "复制到剪贴板",
-    "@clipboardCopy": {
-        "type": "text"
-    },
-    "close": "关闭",
-    "@close": {
-        "type": "text"
-    },
-    "closeMessage": "关闭错误信息",
-    "@closeMessage": {
-        "type": "text"
-    },
-    "closePreview": "关闭预览",
-    "@closePreview": {
-        "type": "text"
-    },
-    "code": "代码",
-    "@code": {
-        "type": "text"
-    },
-    "coinsActivatedLimitReached": "您已选择最大资产数量",
-    "@coinsActivatedLimitReached": {
-        "type": "text"
-    },
-    "coinsAreActivated": "{protocolName} 币已激活",
-    "@coinsAreActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreActivatedSuccessfully": "{protocolName}币激活成功",
-    "@coinsAreActivatedSuccessfully": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinsAreNotActivated": "{protocolName} 代币未激活",
-    "@coinsAreNotActivated": {
-        "type": "text",
-        "placeholders": {
-            "protocolName": {}
-        }
-    },
-    "coinSelectClear": "清除",
-    "@coinSelectClear": {
-        "type": "text"
-    },
-    "coinSelectNotFound": "没有活跃币",
-    "@coinSelectNotFound": {
-        "type": "text"
-    },
-    "coinSelectTitle": "选择货币",
-    "@coinSelectTitle": {
-        "type": "text"
-    },
-    "comingSoon": "即将上线，敬请期待。。。",
-    "@comingSoon": {
-        "type": "text"
-    },
-    "commingsoon": "交易明细加载中！",
-    "@commingsoon": {
-        "type": "text"
-    },
-    "commingsoonGeneral": "详情载入中！",
-    "@commingsoonGeneral": {
-        "type": "text"
-    },
-    "commissionFee": "手续费",
-    "@commissionFee": {
-        "type": "text"
-    },
-    "comparedTo24hrCex": "与平均值相比24小时CEX价格",
-    "@comparedTo24hrCex": {
-        "type": "text"
-    },
-    "comparedToCex": "与CEX比较",
-    "@comparedToCex": {
-        "type": "text"
-    },
-    "configureWallet": "正在配置您的钱包，请稍候。。。",
-    "@configureWallet": {
-        "type": "text"
-    },
-    "confirm": "确认",
-    "@confirm": {
-        "type": "text"
-    },
-    "confirmCamouflageSetup": "确认伪装PIN",
-    "@confirmCamouflageSetup": {
-        "type": "text"
-    },
-    "confirmCancel": "您确定要取消交易吗",
-    "@confirmCancel": {
-        "type": "text"
-    },
-    "confirmeula": "我已了解点击以下的按钮即代表我已阅读并接受终端使用者授权协议(EULA) & 使用条款与条件",
-    "@confirmeula": {
-        "type": "text"
-    },
-    "confirmPassword": "确认密码",
-    "@confirmPassword": {
-        "type": "text"
-    },
-    "confirmPin": "确认PIN",
-    "@confirmPin": {
-        "type": "text"
-    },
-    "confirmSeed": "确认助记词",
-    "@confirmSeed": {
-        "type": "text"
-    },
-    "connecting": "连接中",
-    "@connecting": {
-        "type": "text"
-    },
-    "contactCancel": "取消",
-    "@contactCancel": {
-        "type": "text"
-    },
-    "contactDelete": "删除联系人",
-    "@contactDelete": {
-        "type": "text"
-    },
-    "contactDeleteBtn": "删除",
-    "@contactDeleteBtn": {
-        "type": "text"
-    },
-    "contactDeleteWarning": "确认删除该联系人{name}？",
-    "@contactDeleteWarning": {
-        "type": "text",
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "contactDiscardBtn": "放弃",
-    "@contactDiscardBtn": {
-        "type": "text"
-    },
-    "contactEdit": "编辑",
-    "@contactEdit": {
-        "type": "text"
-    },
-    "contactExit": "退出",
-    "@contactExit": {
-        "type": "text"
-    },
-    "contactExitWarning": "放弃更改？",
-    "@contactExitWarning": {
-        "type": "text"
-    },
-    "contactNotFound": "未找到联系人",
-    "@contactNotFound": {
-        "type": "text"
-    },
-    "contactSave": "保存",
-    "@contactSave": {
-        "type": "text"
-    },
-    "contactTitle": "联系人详细信息",
-    "@contactTitle": {
-        "type": "text"
-    },
-    "contactTitleName": "名称",
-    "@contactTitleName": {
-        "type": "text"
-    },
-    "contract": "合同",
-    "@contract": {
-        "type": "text"
-    },
-    "convert": "转换",
-    "@convert": {
-        "type": "text"
-    },
-    "couldNotLaunchUrl": "无法启动 URL",
-    "@couldNotLaunchUrl": {
-        "type": "text"
-    },
-    "couldntImportError": "无法导入：",
-    "@couldntImportError": {
-        "type": "text"
-    },
-    "create": "交易",
-    "@create": {
-        "type": "text"
-    },
-    "createAWallet": "创建钱包",
-    "@createAWallet": {
-        "type": "text"
-    },
-    "createContact": "创建联系人",
-    "@createContact": {
-        "type": "text"
-    },
-    "createPin": "创建PIN码",
-    "@createPin": {
-        "type": "text"
-    },
-    "currency": "货币",
-    "@currency": {
-        "type": "text"
-    },
-    "currencyDialogTitle": "货币",
-    "@currencyDialogTitle": {
-        "type": "text"
-    },
-    "currentValue": "当前值",
-    "@currentValue": {
-        "type": "text"
-    },
-    "customFee": "定制费用",
-    "@customFee": {
-        "type": "text"
-    },
-    "customFeeWarning": "选择定制费用前务必明确知晓自己的行为",
-    "@customFeeWarning": {
-        "type": "text"
-    },
-    "customSeedWarning": "自定义助记词的安全性可能比自动生成的符合BIP39规范的助记词或私钥（WIF）低，更容易被破解。如您已了解风险并知道您正在做什么，请在下面的框中输入\"{iUnderstand}\"。",
-    "@customSeedWarning": {
-        "type": "text",
-        "placeholders": {
-            "iUnderstand": {}
-        }
-    },
-    "date": "日期",
-    "@date": {
-        "type": "text"
-    },
-    "decryptingWallet": "钱包解密中",
-    "@decryptingWallet": {
-        "type": "text"
-    },
-    "delete": "删除",
-    "@delete": {
-        "type": "text"
-    },
-    "deleteConfirm": "确认停用",
-    "@deleteConfirm": {
-        "type": "text"
-    },
-    "deleteSpan1": "是否要",
-    "@deleteSpan1": {
-        "type": "text"
-    },
-    "deleteSpan2": "从投资组合中删除？所有不匹配的订单将被取消。",
-    "@deleteSpan2": {
-        "type": "text"
-    },
-    "deleteSpan3": " 也将被停用",
-    "@deleteSpan3": {
-        "type": "text"
-    },
-    "deleteWallet": "删除钱包",
-    "@deleteWallet": {
-        "type": "text"
-    },
-    "deletingWallet": "删除钱包中",
-    "@deletingWallet": {
-        "type": "text"
-    },
-    "detailedFeesReceiveCoinTransactionFee": "接收{coinName}交易费",
-    "@detailedFeesReceiveCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendCoinTransactionFee": "发送 {coinName} 交易费",
-    "@detailedFeesSendCoinTransactionFee": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "detailedFeesSendTradingFeeTransactionFee": "发送交易费 交易费",
-    "@detailedFeesSendTradingFeeTransactionFee": {
-        "type": "text"
-    },
-    "detailedFeesTradingFee": "交易费",
-    "@detailedFeesTradingFee": {
-        "type": "text"
-    },
-    "details": "详细信息",
-    "@details": {
-        "type": "text"
-    },
-    "deutscheLanguage": "德语",
-    "@deutscheLanguage": {
-        "type": "text"
-    },
-    "developerTitle": "开发者",
-    "@developerTitle": {
-        "type": "text"
-    },
-    "dex": "DEX",
-    "@dex": {
-        "type": "text"
-    },
-    "dexIsNotAvailable": "DEX不适合该货币",
-    "@dexIsNotAvailable": {
-        "type": "text"
-    },
-    "disableScreenshots": "禁用屏幕截图/预览",
-    "@disableScreenshots": {
-        "type": "text"
-    },
-    "disclaimerAndTos": "免责声明 & 使用条款",
-    "@disclaimerAndTos": {
-        "type": "text"
-    },
-    "done": "完成",
-    "@done": {
-        "type": "text"
-    },
-    "doNotCloseTheAppTapForMoreInfo": "不要关闭应用程序。点按了解更多信息...",
-    "@doNotCloseTheAppTapForMoreInfo": {
-        "type": "text"
-    },
-    "dontAskAgain": "不再询问",
-    "@dontAskAgain": {
-        "type": "text"
-    },
-    "dontWantPassword": "我不想要使用密碼",
-    "@dontWantPassword": {
-        "type": "text"
-    },
-    "dPow": "Komodo dPoW安全",
-    "@dPow": {
-        "type": "text"
-    },
-    "duration": "有效期",
-    "@duration": {
-        "type": "text"
-    },
-    "editContact": "编辑联系人",
-    "@editContact": {
-        "type": "text"
-    },
-    "emptyCoin": "输入{abbr}地址",
-    "@emptyCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "emptyExportPass": "加密密码不能为空",
-    "@emptyExportPass": {
-        "type": "text"
-    },
-    "emptyImportPass": "密码不能为空",
-    "@emptyImportPass": {
-        "type": "text"
-    },
-    "emptyName": "联系人名称不能为空",
-    "@emptyName": {
-        "type": "text"
-    },
-    "emptyWallet": "钱包名称不能为空",
-    "@emptyWallet": {
-        "type": "text"
-    },
-    "enable": "您仍然可以启用{remains}，已选择：{selected}",
-    "@enable": {
-        "type": "text",
-        "placeholders": {
-            "selected": {},
-            "remains": {}
-        }
-    },
-    "enableNotificationsForActivationProgress": "请启用通知以获取有关激活进度的更新。",
-    "@enableNotificationsForActivationProgress": {
-        "type": "text"
-    },
-    "enableTestCoins": "启用测试币",
-    "@enableTestCoins": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan1": "您已启用",
-    "@enablingTooManyAssetsSpan1": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan2": "资产并尝试启用",
-    "@enablingTooManyAssetsSpan2": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan3": "更多。最多启用",
-    "@enablingTooManyAssetsSpan3": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsSpan4": "请在添加新资产前停用一些资产。",
-    "@enablingTooManyAssetsSpan4": {
-        "type": "text"
-    },
-    "enablingTooManyAssetsTitle": "试图启用太多资产",
-    "@enablingTooManyAssetsTitle": {
-        "type": "text"
-    },
-    "encryptingWallet": "錢包加密中",
-    "@encryptingWallet": {
-        "type": "text"
-    },
-    "englishLanguage": "英文",
-    "@englishLanguage": {
-        "type": "text"
-    },
-    "enterNewPinCode": "输入您的新PIN",
-    "@enterNewPinCode": {
-        "type": "text"
-    },
-    "enterOldPinCode": "输入您的旧PIN",
-    "@enterOldPinCode": {
-        "type": "text"
-    },
-    "enterpassword": "继续前请输入密码",
-    "@enterpassword": {
-        "type": "text"
-    },
-    "enterPinCode": "输入您的PIN码",
-    "@enterPinCode": {
-        "type": "text"
-    },
-    "enterSeedPhrase": "输入您的助记词",
-    "@enterSeedPhrase": {
-        "type": "text"
-    },
-    "enterSellAmount": "您必须先输入卖出数量",
-    "@enterSellAmount": {
-        "type": "text"
-    },
-    "errorAmountBalance": "余额不足",
-    "@errorAmountBalance": {
-        "type": "text"
-    },
-    "errorNotAValidAddress": "钱包地址错误",
-    "@errorNotAValidAddress": {
-        "type": "text"
-    },
-    "errorNotAValidAddressSegWit": "尚不支持Segwit地址",
-    "@errorNotAValidAddressSegWit": {
-        "type": "text"
-    },
-    "errorNotEnoughGas": "燃料不足-至少使用｛gas｝Gwei",
-    "@errorNotEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "gas": {}
-        }
-    },
-    "errorTryAgain": "出现错误, 請重试",
-    "@errorTryAgain": {
-        "type": "text"
-    },
-    "errorTryLater": "出现错误，請稍後重试",
-    "@errorTryLater": {
-        "type": "text"
-    },
-    "errorValueEmpty": "价值太高或太低",
-    "@errorValueEmpty": {
-        "type": "text"
-    },
-    "errorValueNotEmpty": "请输入数据",
-    "@errorValueNotEmpty": {
-        "type": "text"
-    },
-    "estimateValue": "预估总价",
-    "@estimateValue": {
-        "type": "text"
-    },
-    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-    "@eulaParagraphe10": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-    "@eulaParagraphe11": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-    "@eulaParagraphe12": {
-        "type": "text"
-    },
-    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-    "@eulaParagraphe13": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-    "@eulaParagraphe14": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-    "@eulaParagraphe15": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-    "@eulaParagraphe16": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-    "@eulaParagraphe17": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-    "@eulaParagraphe18": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-    "@eulaParagraphe19": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-    "@eulaParagraphe2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-    "@eulaParagraphe3": {
-        "type": "text"
-    },
-    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-    "@eulaParagraphe4": {
-        "type": "text"
-    },
-    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-    "@eulaParagraphe5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-    "@eulaParagraphe6": {
-        "type": "text",
-        "placeholders": {
-            "appName": {},
-            "appCompanyLong": {}
-        }
-    },
-    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-    "@eulaParagraphe7": {
-        "type": "text"
-    },
-    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-    "@eulaParagraphe8": {
-        "type": "text"
-    },
-    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-    "@eulaParagraphe9": {
-        "type": "text"
-    },
-    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-    "@eulaTitle1": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "eulaTitle10": "ACCESS AND SECURITY",
-    "@eulaTitle10": {
-        "type": "text"
-    },
-    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-    "@eulaTitle11": {
-        "type": "text"
-    },
-    "eulaTitle12": "DISCLAIMER",
-    "@eulaTitle12": {
-        "type": "text"
-    },
-    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-    "@eulaTitle13": {
-        "type": "text"
-    },
-    "eulaTitle14": "GENERAL RISK FACTORS",
-    "@eulaTitle14": {
-        "type": "text"
-    },
-    "eulaTitle15": "INDEMNIFICATION",
-    "@eulaTitle15": {
-        "type": "text"
-    },
-    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-    "@eulaTitle16": {
-        "type": "text"
-    },
-    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-    "@eulaTitle17": {
-        "type": "text"
-    },
-    "eulaTitle18": "TERMINATION",
-    "@eulaTitle18": {
-        "type": "text"
-    },
-    "eulaTitle19": "THIRD PARTY RIGHTS",
-    "@eulaTitle19": {
-        "type": "text"
-    },
-    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-    "@eulaTitle2": {
-        "type": "text"
-    },
-    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-    "@eulaTitle20": {
-        "type": "text"
-    },
-    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-    "@eulaTitle3": {
-        "type": "text"
-    },
-    "eulaTitle4": "GENERAL USE",
-    "@eulaTitle4": {
-        "type": "text"
-    },
-    "eulaTitle5": "MODIFICATIONS",
-    "@eulaTitle5": {
-        "type": "text"
-    },
-    "eulaTitle6": "LIMITATIONS ON USE",
-    "@eulaTitle6": {
-        "type": "text"
-    },
-    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-    "@eulaTitle7": {
-        "type": "text"
-    },
-    "eulaTitle8": "BACKUPS",
-    "@eulaTitle8": {
-        "type": "text"
-    },
-    "eulaTitle9": "GENERAL WARNING",
-    "@eulaTitle9": {
-        "type": "text"
-    },
-    "exampleHintSeed": "例如：build case level ...",
-    "@exampleHintSeed": {
-        "type": "text"
-    },
-    "exchangeExpedient": "划算的",
-    "@exchangeExpedient": {
-        "type": "text"
-    },
-    "exchangeExpensive": "昂贵的",
-    "@exchangeExpensive": {
-        "type": "text"
-    },
-    "exchangeIdentical": "与CEX相同",
-    "@exchangeIdentical": {
-        "type": "text"
-    },
-    "exchangeRate": "兑换率",
-    "@exchangeRate": {
-        "type": "text"
-    },
-    "exchangeTitle": "兑换",
-    "@exchangeTitle": {
-        "type": "text"
-    },
-    "exportButton": "导出",
-    "@exportButton": {
-        "type": "text"
-    },
-    "exportContactsTitle": "联系人",
-    "@exportContactsTitle": {
-        "type": "text"
-    },
-    "exportDesc": "请选择要导出到加密文件中的项目。",
-    "@exportDesc": {
-        "type": "text"
-    },
-    "exportLink": "导出",
-    "@exportLink": {
-        "type": "text"
-    },
-    "exportNotesTitle": "备注",
-    "@exportNotesTitle": {
-        "type": "text"
-    },
-    "exportSuccessTitle": "项目成功导出",
-    "@exportSuccessTitle": {
-        "type": "text"
-    },
-    "exportSwapsTitle": "交换",
-    "@exportSwapsTitle": {
-        "type": "text"
-    },
-    "exportTitle": "导出",
-    "@exportTitle": {
-        "type": "text"
-    },
-    "Failed": "失败",
-    "@Failed": {
-        "type": "text"
-    },
-    "fakeBalanceAmt": "虚假余额",
-    "@fakeBalanceAmt": {
-        "type": "text"
-    },
-    "faqTitle": "常见问题",
-    "@faqTitle": {
-        "type": "text"
-    },
-    "faucetError": "错误",
-    "@faucetError": {
-        "type": "text"
-    },
-    "faucetInProgress": "正在向 {coin} 水龙头发送请求",
-    "@faucetInProgress": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "faucetName": "水龙头",
-    "@faucetName": {
-        "type": "text"
-    },
-    "faucetSuccess": "成功",
-    "@faucetSuccess": {
-        "type": "text"
-    },
-    "faucetTimedOut": "请求超时",
-    "@faucetTimedOut": {
-        "type": "text"
-    },
-    "feedback": "共享日志文件",
-    "@feedback": {
-        "type": "text"
-    },
-    "feedNewsTab": "新闻",
-    "@feedNewsTab": {
-        "type": "text"
-    },
-    "feedNotFound": "无内容",
-    "@feedNotFound": {
-        "type": "text"
-    },
-    "feedNotifTitle": "{appCompanyShort} 新闻",
-    "@feedNotifTitle": {
-        "type": "text",
-        "placeholders": {
-            "appCompanyShort": {}
-        }
-    },
-    "feedReadMore": "阅读更多",
-    "@feedReadMore": {
-        "type": "text"
-    },
-    "feedTab": "Feed",
-    "@feedTab": {
-        "type": "text"
-    },
-    "feedTitle": "Feed新闻",
-    "@feedTitle": {
-        "type": "text"
-    },
-    "feedUnableToProceed": "无法继续更新新闻",
-    "@feedUnableToProceed": {
-        "type": "text"
-    },
-    "feedUnableToUpdate": "无法获取新闻更新",
-    "@feedUnableToUpdate": {
-        "type": "text"
-    },
-    "feedUpdated": "Feed新闻已更新",
-    "@feedUpdated": {
-        "type": "text"
-    },
-    "feedUpToDate": "已更新",
-    "@feedUpToDate": {
-        "type": "text"
-    },
-    "feesError": "费用必须高达 {value}",
-    "@feesError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "filtersAll": "全部",
-    "@filtersAll": {
-        "type": "text"
-    },
-    "filtersButton": "过滤器",
-    "@filtersButton": {
-        "type": "text"
-    },
-    "filtersClearAll": "清除所有过滤器",
-    "@filtersClearAll": {
-        "type": "text"
-    },
-    "filtersFailed": "失败",
-    "@filtersFailed": {
-        "type": "text"
-    },
-    "filtersFrom": "起始日期",
-    "@filtersFrom": {
-        "type": "text"
-    },
-    "filtersMaker": "挂单",
-    "@filtersMaker": {
-        "type": "text"
-    },
-    "filtersReceive": "接收货币",
-    "@filtersReceive": {
-        "type": "text"
-    },
-    "filtersSell": "出售货币",
-    "@filtersSell": {
-        "type": "text"
-    },
-    "filtersStatus": "状态",
-    "@filtersStatus": {
-        "type": "text"
-    },
-    "filtersSuccessful": "成功",
-    "@filtersSuccessful": {
-        "type": "text"
-    },
-    "filtersTaker": "吃单",
-    "@filtersTaker": {
-        "type": "text"
-    },
-    "filtersTo": "截止日期",
-    "@filtersTo": {
-        "type": "text"
-    },
-    "filtersType": "吃单/挂单",
-    "@filtersType": {
-        "type": "text"
-    },
-    "fingerprint": "指纹",
-    "@fingerprint": {
-        "type": "text"
-    },
-    "finishingUp": "已完成，请稍候",
-    "@finishingUp": {
-        "type": "text"
-    },
-    "foundQrCode": "找到二维码",
-    "@foundQrCode": {
-        "type": "text"
-    },
-    "frenchLanguage": "法语",
-    "@frenchLanguage": {
-        "type": "text"
-    },
-    "from": "起始日期",
-    "@from": {
-        "type": "text"
-    },
-    "gasFee": "{coin} 费用",
-    "@gasFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasLimit": "燃料上限",
-    "@gasLimit": {
-        "type": "text"
-    },
-    "gasNotActive": "请激活{coin}.",
-    "@gasNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "gasPrice": "燃料价格",
-    "@gasPrice": {
-        "type": "text"
-    },
-    "generalPinNotActive": "常规PIN保护未激活。\n伪装模式将失效\n请激活PIN保护",
-    "@generalPinNotActive": {
-        "type": "text"
-    },
-    "getBackupPhrase": "重要提醒: 請在繼續之前備份助記詞 !",
-    "@getBackupPhrase": {
-        "type": "text"
-    },
-    "gettingTxWait": "正在获取交易，请稍候",
-    "@gettingTxWait": {
-        "type": "text"
-    },
-    "goToPorfolio": "前往投资组合",
-    "@goToPorfolio": {
-        "type": "text"
-    },
-    "gweiError": "Gwei 必须达到 {value}",
-    "@gweiError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "helpLink": "帮助",
-    "@helpLink": {
-        "type": "text"
-    },
-    "helpTitle": "帮助和支持",
-    "@helpTitle": {
-        "type": "text"
-    },
-    "hideBalance": "隐藏余额",
-    "@hideBalance": {
-        "type": "text"
-    },
-    "hintConfirmPassword": "确认密码",
-    "@hintConfirmPassword": {
-        "type": "text"
-    },
-    "hintCreatePassword": "创建密码",
-    "@hintCreatePassword": {
-        "type": "text"
-    },
-    "hintCurrentPassword": "当前密码",
-    "@hintCurrentPassword": {
-        "type": "text"
-    },
-    "hintEnterPassword": "请输入您的密码",
-    "@hintEnterPassword": {
-        "type": "text"
-    },
-    "hintEnterSeedPhrase": "请输入您的助记词",
-    "@hintEnterSeedPhrase": {
-        "type": "text"
-    },
-    "hintNameYourWallet": "命名您的钱包",
-    "@hintNameYourWallet": {
-        "type": "text"
-    },
-    "hintPassword": "密码",
-    "@hintPassword": {
-        "type": "text"
-    },
-    "history": "历史记录",
-    "@history": {
-        "type": "text"
-    },
-    "hours": "小时",
-    "@hours": {
-        "type": "text"
-    },
-    "hungarianLanguage": "匈牙利语",
-    "@hungarianLanguage": {
-        "type": "text"
-    },
-    "importButton": "导入",
-    "@importButton": {
-        "type": "text"
-    },
-    "importDecryptError": "密码无效或数据损坏",
-    "@importDecryptError": {
-        "type": "text"
-    },
-    "importDesc": "要导入的项目：",
-    "@importDesc": {
-        "type": "text"
-    },
-    "importFileNotFound": "找不到文件",
-    "@importFileNotFound": {
-        "type": "text"
-    },
-    "importInvalidSwapData": "交换数据无效。请提供有效的交换状态JSON文件。",
-    "@importInvalidSwapData": {
-        "type": "text"
-    },
-    "importLink": "导入",
-    "@importLink": {
-        "type": "text"
-    },
-    "importLoadDesc": "请选择要导入的加密文件。",
-    "@importLoadDesc": {
-        "type": "text"
-    },
-    "importLoading": "开始",
-    "@importLoading": {
-        "type": "text"
-    },
-    "importLoadSwapDesc": "请选择要导入的纯文本交换文件。",
-    "@importLoadSwapDesc": {
-        "type": "text"
-    },
-    "importPassCancel": "取消",
-    "@importPassCancel": {
-        "type": "text"
-    },
-    "importPassOk": "好的",
-    "@importPassOk": {
-        "type": "text"
-    },
-    "importPassword": "密码",
-    "@importPassword": {
-        "type": "text"
-    },
-    "importSingleSwapLink": "导入单个交换",
-    "@importSingleSwapLink": {
-        "type": "text"
-    },
-    "importSingleSwapTitle": "导入交换",
-    "@importSingleSwapTitle": {
-        "type": "text"
-    },
-    "importSomeItemsSkippedWarning": "已跳过某些项目",
-    "@importSomeItemsSkippedWarning": {
-        "type": "text"
-    },
-    "importSuccessTitle": "已成功导入项目：",
-    "@importSuccessTitle": {
-        "type": "text"
-    },
-    "importSwapFailed": "无法导入交换",
-    "@importSwapFailed": {
-        "type": "text"
-    },
-    "importSwapJsonDecodingError": "解码json文件时出错",
-    "@importSwapJsonDecodingError": {
-        "type": "text"
-    },
-    "importTitle": "导入",
-    "@importTitle": {
-        "type": "text"
-    },
-    "incomingTransactionsProtectionSettings": "传入 {coinName} 交易保护设置",
-    "@incomingTransactionsProtectionSettings": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "infoPasswordDialog": "使用安全密码，不要将其存储在同一设备上",
-    "@infoPasswordDialog": {
-        "type": "text"
-    },
-    "infoTrade1": "無法撤銷交换请求！",
-    "@infoTrade1": {
-        "type": "text"
-    },
-    "infoTrade2": "交换最长需要60分钟。不要关闭此应用程序！",
-    "@infoTrade2": {
-        "type": "text"
-    },
-    "infoWalletPassword": "安全起见，您必须为加密钱包设置密码。",
-    "@infoWalletPassword": {
-        "type": "text"
-    },
-    "insufficientBalanceToPay": "{abbr}余额不足以支付交易费",
-    "@insufficientBalanceToPay": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "insufficientText": "此订单最小交易量为",
-    "@insufficientText": {
-        "type": "text"
-    },
-    "insufficientTitle": "交易量不足",
-    "@insufficientTitle": {
-        "type": "text"
-    },
-    "internetRefreshButton": "刷新",
-    "@internetRefreshButton": {
-        "type": "text"
-    },
-    "internetRestored": "已重新连接互联网",
-    "@internetRestored": {
-        "type": "text"
-    },
-    "invalidSwap": "无法继续交换",
-    "@invalidSwap": {
-        "type": "text"
-    },
-    "invalidSwapDetailsLink": "详细信息",
-    "@invalidSwapDetailsLink": {
-        "type": "text"
-    },
-    "isUnavailable": "{coinAbbr} 不可用:(",
-    "@isUnavailable": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "iUnderstand": "我已了解",
-    "@iUnderstand": {
-        "type": "text"
-    },
-    "japaneseLanguage": "日文",
-    "@japaneseLanguage": {
-        "type": "text"
-    },
-    "koreanLanguage": "韩国人",
-    "@koreanLanguage": {
-        "type": "text"
-    },
-    "language": "语言",
-    "@language": {
-        "type": "text"
-    },
-    "latestTxs": "最新交易",
-    "@latestTxs": {
-        "type": "text"
-    },
-    "legalTitle": "合法的",
-    "@legalTitle": {
-        "type": "text"
-    },
-    "less": "较少",
-    "@less": {
-        "type": "text"
-    },
-    "lessThanCaution": "❗注意！ {coinName} 市场的 24 小时交易量不到 1 万美元！",
-    "@lessThanCaution": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "limitError": "限制必须达到 {value}",
-    "@limitError": {
-        "type": "text",
-        "placeholders": {
-            "value": {}
-        }
-    },
-    "loading": "載入中",
-    "@loading": {
-        "type": "text"
-    },
-    "loadingOrderbook": "正在加载订单记录",
-    "@loadingOrderbook": {
-        "type": "text"
-    },
-    "lockScreen": "屏幕已锁定",
-    "@lockScreen": {
-        "type": "text"
-    },
-    "lockScreenAuth": "请验证！",
-    "@lockScreenAuth": {
-        "type": "text"
-    },
-    "login": "登录",
-    "@login": {
-        "type": "text"
-    },
-    "logout": "注销",
-    "@logout": {
-        "type": "text"
-    },
-    "logoutOnExit": "退出时注销",
-    "@logoutOnExit": {
-        "type": "text"
-    },
-    "logoutsettings": "注销设置",
-    "@logoutsettings": {
-        "type": "text"
-    },
-    "logoutWarning": "您确定要立即注销吗？",
-    "@logoutWarning": {
-        "type": "text"
-    },
-    "longMinutes": "分钟",
-    "@longMinutes": {
-        "type": "text"
-    },
-    "makeAorder": "下订单",
-    "@makeAorder": {
-        "type": "text"
-    },
-    "Maker": "挂单",
-    "@Maker": {
-        "type": "text"
-    },
-    "makerDetailsCancel": "取消订单",
-    "@makerDetailsCancel": {
-        "type": "text"
-    },
-    "makerDetailsCreated": "创建",
-    "@makerDetailsCreated": {
-        "type": "text"
-    },
-    "makerDetailsFor": "接收",
-    "@makerDetailsFor": {
-        "type": "text"
-    },
-    "makerDetailsId": "订单ID",
-    "@makerDetailsId": {
-        "type": "text"
-    },
-    "makerDetailsNoSwaps": "此订单未启动交换",
-    "@makerDetailsNoSwaps": {
-        "type": "text"
-    },
-    "makerDetailsPrice": "价格",
-    "@makerDetailsPrice": {
-        "type": "text"
-    },
-    "makerDetailsSell": "卖出",
-    "@makerDetailsSell": {
-        "type": "text"
-    },
-    "makerDetailsSwaps": "此订单开始交换",
-    "@makerDetailsSwaps": {
-        "type": "text"
-    },
-    "makerDetailsTitle": "挂单交易详细信息",
-    "@makerDetailsTitle": {
-        "type": "text"
-    },
-    "makerOrder": "挂单交易",
-    "@makerOrder": {
-        "type": "text"
-    },
-    "marketplace": "市场",
-    "@marketplace": {
-        "type": "text"
-    },
-    "marketsChart": "图表",
-    "@marketsChart": {
-        "type": "text"
-    },
-    "marketsDepth": "交易深度",
-    "@marketsDepth": {
-        "type": "text"
-    },
-    "marketsNoAsks": "未找到问题",
-    "@marketsNoAsks": {
-        "type": "text"
-    },
-    "marketsNoBids": "未找到出价",
-    "@marketsNoBids": {
-        "type": "text"
-    },
-    "marketsOrderbook": "订单记录",
-    "@marketsOrderbook": {
-        "type": "text"
-    },
-    "marketsOrderDetails": "订单详细信息",
-    "@marketsOrderDetails": {
-        "type": "text"
-    },
-    "marketsPrice": "价格",
-    "@marketsPrice": {
-        "type": "text"
-    },
-    "marketsSelectCoins": "请选择货币",
-    "@marketsSelectCoins": {
-        "type": "text"
-    },
-    "marketsTab": "市场",
-    "@marketsTab": {
-        "type": "text"
-    },
-    "marketsTitle": "市场",
-    "@marketsTitle": {
-        "type": "text"
-    },
-    "matchExportPass": "密码必须匹配",
-    "@matchExportPass": {
-        "type": "text"
-    },
-    "matchingCamoChange": "改变",
-    "@matchingCamoChange": {
-        "type": "text"
-    },
-    "matchingCamoPinError": "您的通用PIN码和伪装PIN码相同。伪装模式将不可用。请更改伪装PIN",
-    "@matchingCamoPinError": {
-        "type": "text"
-    },
-    "matchingCamoTitle": "无效PIN",
-    "@matchingCamoTitle": {
-        "type": "text"
-    },
-    "max": "最大",
-    "@max": {
-        "type": "text"
-    },
-    "maxOrder": "最大交易量",
-    "@maxOrder": {
-        "type": "text"
-    },
-    "media": "消息",
-    "@media": {
-        "type": "text"
-    },
-    "mediaBrowse": "浏览",
-    "@mediaBrowse": {
-        "type": "text"
-    },
-    "mediaBrowseFeed": "浏览Feed",
-    "@mediaBrowseFeed": {
-        "type": "text"
-    },
-    "mediaBy": "通过",
-    "@mediaBy": {
-        "type": "text"
-    },
-    "mediaNotSavedDescription": "您没有收藏的文章",
-    "@mediaNotSavedDescription": {
-        "type": "text"
-    },
-    "mediaSaved": "已收藏",
-    "@mediaSaved": {
-        "type": "text"
-    },
-    "memo": "备忘录",
-    "@memo": {
-        "type": "text"
-    },
-    "merge": "合并",
-    "@merge": {
-        "type": "text"
-    },
-    "mergedValue": "合并值",
-    "@mergedValue": {
-        "type": "text"
-    },
-    "milliseconds": "毫秒",
-    "@milliseconds": {
-        "type": "text"
-    },
-    "min": "最小",
-    "@min": {
-        "type": "text"
-    },
-    "minimizingWillTerminate": "警告：最小化 iOS 上的应用程序将终止激活过程。",
-    "@minimizingWillTerminate": {
-        "type": "text"
-    },
-    "minOrder": "最小交易量",
-    "@minOrder": {
-        "type": "text"
-    },
-    "minutes": "分钟",
-    "@minutes": {
-        "type": "text"
-    },
-    "minValue": "最低售出量为{number} {coinName}",
-    "@minValue": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueBuy": "最低买入量为{number} {coinName}",
-    "@minValueBuy": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minValueOrder": "最小交易量为 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
-    "@minValueOrder": {
-        "type": "text",
-        "placeholders": {
-            "buyCoin": {},
-            "buyAmount": {},
-            "sellCoin": {},
-            "sellAmount": {}
-        }
-    },
-    "minValueSell": "最低售出量为 {number} {coinName}",
-    "@minValueSell": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "number": {}
-        }
-    },
-    "minVolumeInput": "必须大于{minValue} {coin}",
-    "@minVolumeInput": {
-        "type": "text",
-        "placeholders": {
-            "minValue": {},
-            "coin": {}
-        }
-    },
-    "minVolumeIsTDH": "必须低于售出量",
-    "@minVolumeIsTDH": {
-        "type": "text"
-    },
-    "minVolumeTitle": "所需最小量",
-    "@minVolumeTitle": {
-        "type": "text"
-    },
-    "minVolumeToggle": "使用自定义最小量",
-    "@minVolumeToggle": {
-        "type": "text"
-    },
-    "mobileDataWarning": "请注意，您现在正在使用流量，使用{appName} P2P网络会消耗互联网流量。如果您的手机流量很贵，最好连接WIFI。",
-    "@mobileDataWarning": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "moreInfo": "更多信息",
-    "@moreInfo": {
-        "type": "text"
-    },
-    "moreTab": "更多",
-    "@moreTab": {
-        "type": "text"
-    },
-    "multiActivateGas": "先激活{coin}并充值余额",
-    "@multiActivateGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiBaseAmtPlaceholder": "数量",
-    "@multiBaseAmtPlaceholder": {
-        "type": "text"
-    },
-    "multiBasePlaceholder": "货币",
-    "@multiBasePlaceholder": {
-        "type": "text"
-    },
-    "multiBaseSelectTitle": "卖出",
-    "@multiBaseSelectTitle": {
-        "type": "text"
-    },
-    "multiConfirmCancel": "取消",
-    "@multiConfirmCancel": {
-        "type": "text"
-    },
-    "multiConfirmConfirm": "确认",
-    "@multiConfirmConfirm": {
-        "type": "text"
-    },
-    "multiConfirmTitle": "创建{number}订单：",
-    "@multiConfirmTitle": {
-        "type": "text",
-        "placeholders": {
-            "number": {}
-        }
-    },
-    "multiCreate": "创建",
-    "@multiCreate": {
-        "type": "text"
-    },
-    "multiCreateOrder": "订单",
-    "@multiCreateOrder": {
-        "type": "text"
-    },
-    "multiCreateOrders": "订单",
-    "@multiCreateOrders": {
-        "type": "text"
-    },
-    "multiEthFee": "费用",
-    "@multiEthFee": {
-        "type": "text"
-    },
-    "multiFiatCancel": "取消",
-    "@multiFiatCancel": {
-        "type": "text"
-    },
-    "multiFiatDesc": "请输入要接收的法币数量",
-    "@multiFiatDesc": {
-        "type": "text"
-    },
-    "multiFiatFill": "自动填充",
-    "@multiFiatFill": {
-        "type": "text"
-    },
-    "multiFixErrors": "请在继续之前修复所有错误",
-    "@multiFixErrors": {
-        "type": "text"
-    },
-    "multiInvalidAmt": "数量无效",
-    "@multiInvalidAmt": {
-        "type": "text"
-    },
-    "multiInvalidSellAmt": "售出量无效",
-    "@multiInvalidSellAmt": {
-        "type": "text"
-    },
-    "multiLowerThanFee": "{coin}不足支付。最低余额为 {fee} {coin}",
-    "@multiLowerThanFee": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "fee": {}
-        }
-    },
-    "multiLowGas": "{coin}余额过低",
-    "@multiLowGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "multiMaxSellAmt": "最大售出量为",
-    "@multiMaxSellAmt": {
-        "type": "text"
-    },
-    "multiMinReceiveAmt": "最小接收量为",
-    "@multiMinReceiveAmt": {
-        "type": "text"
-    },
-    "multiMinSellAmt": "最小售出量为",
-    "@multiMinSellAmt": {
-        "type": "text"
-    },
-    "multiReceiveTitle": "接收：",
-    "@multiReceiveTitle": {
-        "type": "text"
-    },
-    "multiSellTitle": "卖出",
-    "@multiSellTitle": {
-        "type": "text"
-    },
-    "multiTab": "多个",
-    "@multiTab": {
-        "type": "text"
-    },
-    "multiTableAmt": "接收量",
-    "@multiTableAmt": {
-        "type": "text"
-    },
-    "multiTablePrice": "价格/CEX",
-    "@multiTablePrice": {
-        "type": "text"
-    },
-    "networkFee": "网络费用",
-    "@networkFee": {
-        "type": "text"
-    },
-    "newAccount": "新帳戶",
-    "@newAccount": {
-        "type": "text"
-    },
-    "newAccountUpper": "新帳戶",
-    "@newAccountUpper": {
-        "type": "text"
-    },
-    "newsFeed": "Feed新闻",
-    "@newsFeed": {
-        "type": "text"
-    },
-    "newValue": "新价值",
-    "@newValue": {
-        "type": "text"
-    },
-    "next": "继续",
-    "@next": {
-        "type": "text"
-    },
-    "no": "不",
-    "@no": {
-        "type": "text"
-    },
-    "noArticles": "没有新闻-请稍后再查看",
-    "@noArticles": {
-        "type": "text"
-    },
-    "noCoinFound": "未找到货币",
-    "@noCoinFound": {
-        "type": "text"
-    },
-    "noFunds": "无基金",
-    "@noFunds": {
-        "type": "text"
-    },
-    "noFundsDetected": "没有可用基金-请先存入",
-    "@noFundsDetected": {
-        "type": "text"
-    },
-    "noInternet": "无互联网连接",
-    "@noInternet": {
-        "type": "text"
-    },
-    "noItemsToExport": "未选择项目",
-    "@noItemsToExport": {
-        "type": "text"
-    },
-    "noItemsToImport": "未选择项目",
-    "@noItemsToImport": {
-        "type": "text"
-    },
-    "noMatchingOrders": "无匹配订单",
-    "@noMatchingOrders": {
-        "type": "text"
-    },
-    "none": "没有任何",
-    "@none": {
-        "type": "text"
-    },
-    "nonNumericInput": "该值必须是数字",
-    "@nonNumericInput": {
-        "type": "text"
-    },
-    "noOrder": "请输入 {coinName} 量",
-    "@noOrder": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {}
-        }
-    },
-    "noOrderAvailable": "点击创建订单",
-    "@noOrderAvailable": {
-        "type": "text"
-    },
-    "noOrders": "没有订单，请先交易",
-    "@noOrders": {
-        "type": "text"
-    },
-    "noRewards": "没有奖励可领取",
-    "@noRewards": {
-        "type": "text"
-    },
-    "noRewardYet": "没有奖励可领取-请一小时后重试",
-    "@noRewardYet": {
-        "type": "text"
-    },
-    "noSuchCoin": "没有该货币",
-    "@noSuchCoin": {
-        "type": "text"
-    },
-    "noSwaps": "没有历史记录",
-    "@noSwaps": {
-        "type": "text"
-    },
-    "notEnoughGas": "没有足够的{coin} 用于交易！",
-    "@notEnoughGas": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notEnoughtBalanceForFee": "手续费余额不足-减少交易量",
-    "@notEnoughtBalanceForFee": {
-        "type": "text"
-    },
-    "noteOnOrder": "备注：不能取消已匹配的订单",
-    "@noteOnOrder": {
-        "type": "text"
-    },
-    "notePlaceholder": "添加备注",
-    "@notePlaceholder": {
-        "type": "text"
-    },
-    "noteTitle": "备注",
-    "@noteTitle": {
-        "type": "text"
-    },
-    "nothingFound": "无内容",
-    "@nothingFound": {
-        "type": "text"
-    },
-    "notifSwapCompletedText": "{sell}/{buy} 已成功完成交换",
-    "@notifSwapCompletedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapCompletedTitle": "交换已完成",
-    "@notifSwapCompletedTitle": {
-        "type": "text"
-    },
-    "notifSwapFailedText": "{sell}/{buy}交换失败",
-    "@notifSwapFailedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapFailedTitle": "交换失败",
-    "@notifSwapFailedTitle": {
-        "type": "text"
-    },
-    "notifSwapStartedText": "{sell}/{buy}交换开始",
-    "@notifSwapStartedText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapStartedTitle": "已开始新交换",
-    "@notifSwapStartedTitle": {
-        "type": "text"
-    },
-    "notifSwapStatusTitle": "交换状态已更改",
-    "@notifSwapStatusTitle": {
-        "type": "text"
-    },
-    "notifSwapTimeoutText": "{sell}/{buy}交换超时",
-    "@notifSwapTimeoutText": {
-        "type": "text",
-        "placeholders": {
-            "sell": {},
-            "buy": {}
-        }
-    },
-    "notifSwapTimeoutTitle": "交换超时",
-    "@notifSwapTimeoutTitle": {
-        "type": "text"
-    },
-    "notifTxText": "您已收到｛coin｝交易！",
-    "@notifTxText": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "notifTxTitle": "应记交易",
-    "@notifTxTitle": {
-        "type": "text"
-    },
-    "noTxs": "没有交易",
-    "@noTxs": {
-        "type": "text"
-    },
-    "numberAssets": "{assets} 资产",
-    "@numberAssets": {
-        "type": "text",
-        "placeholders": {
-            "assets": {}
-        }
-    },
-    "officialPressRelease": "官方新闻稿",
-    "@officialPressRelease": {
-        "type": "text"
-    },
-    "okButton": "好的",
-    "@okButton": {
-        "type": "text"
-    },
-    "oldLogsDelete": "删除",
-    "@oldLogsDelete": {
-        "type": "text"
-    },
-    "oldLogsTitle": "历史记录",
-    "@oldLogsTitle": {
-        "type": "text"
-    },
-    "oldLogsUsed": "占用的空间",
-    "@oldLogsUsed": {
-        "type": "text"
-    },
-    "openMessage": "打开错误消息",
-    "@openMessage": {
-        "type": "text"
-    },
-    "Optional": "选修的",
-    "@Optional": {
-        "type": "text"
-    },
-    "orderBookLess": "较少的",
-    "@orderBookLess": {
-        "type": "text"
-    },
-    "orderBookMore": "更多的",
-    "@orderBookMore": {
-        "type": "text"
-    },
-    "orderCancel": "所有{coin}订单将被取消。",
-    "@orderCancel": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderCreated": "订单已创建",
-    "@orderCreated": {
-        "type": "text"
-    },
-    "orderCreatedInfo": "订单已成功创建",
-    "@orderCreatedInfo": {
-        "type": "text"
-    },
-    "orderDetailsAddress": "地址",
-    "@orderDetailsAddress": {
-        "type": "text"
-    },
-    "orderDetailsCancel": "取消",
-    "@orderDetailsCancel": {
-        "type": "text"
-    },
-    "orderDetailsExpedient": "划算的: CEX +{delta}%",
-    "@orderDetailsExpedient": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsExpensive": "昂贵的: CEX {delta}%",
-    "@orderDetailsExpensive": {
-        "type": "text",
-        "placeholders": {
-            "delta": {}
-        }
-    },
-    "orderDetailsFor": "与",
-    "@orderDetailsFor": {
-        "type": "text"
-    },
-    "orderDetailsIdentical": "CEX相同",
-    "@orderDetailsIdentical": {
-        "type": "text"
-    },
-    "orderDetailsMin": "最小量",
-    "@orderDetailsMin": {
-        "type": "text"
-    },
-    "orderDetailsPrice": "价格",
-    "@orderDetailsPrice": {
-        "type": "text"
-    },
-    "orderDetailsReceive": "接收",
-    "@orderDetailsReceive": {
-        "type": "text"
-    },
-    "orderDetailsSelect": "选择",
-    "@orderDetailsSelect": {
-        "type": "text"
-    },
-    "orderDetailsSells": "卖出",
-    "@orderDetailsSells": {
-        "type": "text"
-    },
-    "orderDetailsSettings": "单击打开详细信息，然后长按选择订购",
-    "@orderDetailsSettings": {
-        "type": "text"
-    },
-    "orderDetailsSpend": "花费",
-    "@orderDetailsSpend": {
-        "type": "text"
-    },
-    "orderDetailsTitle": "详细信息",
-    "@orderDetailsTitle": {
-        "type": "text"
-    },
-    "orderFilled": "{fill}%已填充",
-    "@orderFilled": {
-        "type": "text",
-        "placeholders": {
-            "fill": {}
-        }
-    },
-    "orderMatched": "已匹配订单",
-    "@orderMatched": {
-        "type": "text"
-    },
-    "orderMatching": "订单匹配中",
-    "@orderMatching": {
-        "type": "text"
-    },
-    "orders": "订单",
-    "@orders": {
-        "type": "text"
-    },
-    "ordersActive": "活跃",
-    "@ordersActive": {
-        "type": "text"
-    },
-    "ordersHistory": "历史记录",
-    "@ordersHistory": {
-        "type": "text"
-    },
-    "ordersTableAmount": "数量({coin})",
-    "@ordersTableAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTablePrice": "价格 ({coin})",
-    "@ordersTablePrice": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "ordersTableTotal": "总计 ({coin})",
-    "@ordersTableTotal": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "orderTypePartial": "订单",
-    "@orderTypePartial": {
-        "type": "text"
-    },
-    "orderTypeUnknown": "未知类型订单",
-    "@orderTypeUnknown": {
-        "type": "text"
-    },
-    "overwrite": "覆盖",
-    "@overwrite": {
-        "type": "text"
-    },
-    "ownOrder": "这是您个人的订单",
-    "@ownOrder": {
-        "type": "text"
-    },
-    "paidFromBalance": "用余额支付：",
-    "@paidFromBalance": {
-        "type": "text"
-    },
-    "paidFromVolume": "用已接收的交易量支付",
-    "@paidFromVolume": {
-        "type": "text"
-    },
-    "paidWith": "支付方式：",
-    "@paidWith": {
-        "type": "text"
-    },
-    "passwordRequirement": "密码必须至少包含12个字符，包括一个小写、一个大写和一个特殊符号",
-    "@passwordRequirement": {
-        "type": "text"
-    },
-    "paymentUriDetailsAccept": "支付",
-    "@paymentUriDetailsAccept": {
-        "type": "text"
-    },
-    "paymentUriDetailsAcceptQuestion": "您接受这笔交易吗？",
-    "@paymentUriDetailsAcceptQuestion": {
-        "type": "text"
-    },
-    "paymentUriDetailsAddressSpan": "接收方地址",
-    "@paymentUriDetailsAddressSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsAmountSpan": "数量：",
-    "@paymentUriDetailsAmountSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsCoinSpan": "货币：",
-    "@paymentUriDetailsCoinSpan": {
-        "type": "text"
-    },
-    "paymentUriDetailsDeny": "取消",
-    "@paymentUriDetailsDeny": {
-        "type": "text"
-    },
-    "paymentUriDetailsTitle": "已请求的付款",
-    "@paymentUriDetailsTitle": {
-        "type": "text"
-    },
-    "paymentUriInactiveCoin": "{abbr} 未激活。请激活后重试。",
-    "@paymentUriInactiveCoin": {
-        "type": "text",
-        "placeholders": {
-            "abbr": {}
-        }
-    },
-    "placeOrder": "下单",
-    "@placeOrder": {
-        "type": "text"
-    },
-    "Play at full volume": "音量开到最大",
-    "@Play at full volume": {
-        "type": "text"
-    },
-    "pleaseAddCoin": "请添加货币",
-    "@pleaseAddCoin": {
-        "type": "text"
-    },
-    "pleaseRestart": "请重启应用程序后重试，或按下面的按钮。",
-    "@pleaseRestart": {
-        "type": "text"
-    },
-    "portfolio": "投资组合",
-    "@portfolio": {
-        "type": "text"
-    },
-    "poweredOnKmd": "由Komodo支持",
-    "@poweredOnKmd": {
-        "type": "text"
-    },
-    "price": "价格",
-    "@price": {
-        "type": "text"
-    },
-    "privateKey": "私钥",
-    "@privateKey": {
-        "type": "text"
-    },
-    "privateKeys": "私钥",
-    "@privateKeys": {
-        "type": "text"
-    },
-    "protectionCtrlConfirmations": "确认",
-    "@protectionCtrlConfirmations": {
-        "type": "text"
-    },
-    "protectionCtrlCustom": "使用自定义保护设置",
-    "@protectionCtrlCustom": {
-        "type": "text"
-    },
-    "protectionCtrlOff": "关闭",
-    "@protectionCtrlOff": {
-        "type": "text"
-    },
-    "protectionCtrlOn": "开启",
-    "@protectionCtrlOn": {
-        "type": "text"
-    },
-    "protectionCtrlWarning": "警告，此原子交换不受dPoW保护。",
-    "@protectionCtrlWarning": {
-        "type": "text"
-    },
-    "pubkey": "公钥",
-    "@pubkey": {
-        "type": "text"
-    },
-    "qrCodeScanner": "二维码扫描仪",
-    "@qrCodeScanner": {
-        "type": "text"
-    },
-    "question_1": "你们会保存我的私钥吗？",
-    "@question_1": {
-        "type": "text"
-    },
-    "question_10": "我可以在哪些设备上使用{appName} ？",
-    "@question_10": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_2": "在{appName} 上交易与在其他DEX上交易有何不同？",
-    "@question_2": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_3": "每次原子交换需要多长时间？",
-    "@question_3": {
-        "type": "text"
-    },
-    "question_4": "在交换期间我要保持在线吗",
-    "@question_4": {
-        "type": "text"
-    },
-    "question_5": "{appName} 的费用如何计算？",
-    "@question_5": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_6": "你们会提供用户支持吗？",
-    "@question_6": {
-        "type": "text"
-    },
-    "question_7": "你们有地区限制吗？",
-    "@question_7": {
-        "type": "text"
-    },
-    "question_8": "{appName} 的背后是谁？",
-    "@question_8": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "question_9": "是否可以在{appName} 上开发我个人的白标交换？",
-    "@question_9": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "rebrandingAnnouncement": "这是一个新时代！我们已正式将名称从“AtomicDEX”更改为“Komodo Wallet”",
-    "@rebrandingAnnouncement": {
-        "type": "text"
-    },
-    "receive": "接收",
-    "@receive": {
-        "type": "text"
-    },
-    "receiveLower": "接收",
-    "@receiveLower": {
-        "type": "text"
-    },
-    "recommendSeedMessage": "我们建议在线下存档。",
-    "@recommendSeedMessage": {
-        "type": "text"
-    },
-    "remove": "停用",
-    "@remove": {
-        "type": "text"
-    },
-    "requestedTrade": "已请求的交易",
-    "@requestedTrade": {
-        "type": "text"
-    },
-    "reset": "清除",
-    "@reset": {
-        "type": "text"
-    },
-    "resetTitle": "重置表格",
-    "@resetTitle": {
-        "type": "text"
-    },
-    "restoreWallet": "恢复",
-    "@restoreWallet": {
-        "type": "text"
-    },
-    "retryActivating": "正在重试激活所有货币",
-    "@retryActivating": {
-        "type": "text"
-    },
-    "retryAll": "重试激活所有",
-    "@retryAll": {
-        "type": "text"
-    },
-    "rewardsButton": "领取奖励",
-    "@rewardsButton": {
-        "type": "text"
-    },
-    "rewardsCancel": "取消",
-    "@rewardsCancel": {
-        "type": "text"
-    },
-    "rewardsError": "出现错误。请稍后再试。",
-    "@rewardsError": {
-        "type": "text"
-    },
-    "rewardsInProgressLong": "交易正在进行",
-    "@rewardsInProgressLong": {
-        "type": "text"
-    },
-    "rewardsInProgressShort": "处理",
-    "@rewardsInProgressShort": {
-        "type": "text"
-    },
-    "rewardsLowAmountLong": "UTXO金额小于10 KMD",
-    "@rewardsLowAmountLong": {
-        "type": "text"
-    },
-    "rewardsLowAmountShort": "<10KMD",
-    "@rewardsLowAmountShort": {
-        "type": "text"
-    },
-    "rewardsOneHourLong": "还未过去一小时",
-    "@rewardsOneHourLong": {
-        "type": "text"
-    },
-    "rewardsOneHourShort": "<1小时",
-    "@rewardsOneHourShort": {
-        "type": "text"
-    },
-    "rewardsPopupOk": "好的",
-    "@rewardsPopupOk": {
-        "type": "text"
-    },
-    "rewardsPopupTitle": "奖励状态：",
-    "@rewardsPopupTitle": {
-        "type": "text"
-    },
-    "rewardsReadMore": "阅读有关KMD活跃用户奖励的更多信息",
-    "@rewardsReadMore": {
-        "type": "text"
-    },
-    "rewardsReceive": "接收",
-    "@rewardsReceive": {
-        "type": "text"
-    },
-    "rewardsSuccess": "成功！收到 {amount}KMD",
-    "@rewardsSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "rewardsTableFiat": "法币",
-    "@rewardsTableFiat": {
-        "type": "text"
-    },
-    "rewardsTableRewards": "奖励，KMD",
-    "@rewardsTableRewards": {
-        "type": "text"
-    },
-    "rewardsTableStatus": "状态",
-    "@rewardsTableStatus": {
-        "type": "text"
-    },
-    "rewardsTableTime": "剩余时间",
-    "@rewardsTableTime": {
-        "type": "text"
-    },
-    "rewardsTableTitle": "奖励信息",
-    "@rewardsTableTitle": {
-        "type": "text"
-    },
-    "rewardsTableUXTO": "UTXO 数量\nKMD",
-    "@rewardsTableUXTO": {
-        "type": "text"
-    },
-    "rewardsTimeDays": "{dd} 天",
-    "@rewardsTimeDays": {
-        "type": "text",
-        "placeholders": {
-            "dd": {}
-        }
-    },
-    "rewardsTimeHours": "{hh}小时 {minutes}分钟",
-    "@rewardsTimeHours": {
-        "type": "text",
-        "placeholders": {
-            "hh": {},
-            "minutes": {}
-        }
-    },
-    "rewardsTimeMin": "{mm}分钟",
-    "@rewardsTimeMin": {
-        "type": "text",
-        "placeholders": {
-            "mm": {}
-        }
-    },
-    "rewardsTitle": "奖励信息",
-    "@rewardsTitle": {
-        "type": "text"
-    },
-    "russianLanguage": "俄语",
-    "@russianLanguage": {
-        "type": "text"
-    },
-    "saveMerged": "保存合并",
-    "@saveMerged": {
-        "type": "text"
-    },
-    "scrollToContinue": "滚动到底部继续...",
-    "@scrollToContinue": {
-        "type": "text"
-    },
-    "searchFilterCoin": "搜索货币",
-    "@searchFilterCoin": {
-        "type": "text"
-    },
-    "searchFilterSubtitleAVX": "选择所有Avax代币",
-    "@searchFilterSubtitleAVX": {
-        "type": "text"
-    },
-    "searchFilterSubtitleBEP": "选择所有BEP代币",
-    "@searchFilterSubtitleBEP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleCosmos": "选择所有 Cosmos 网络",
-    "@searchFilterSubtitleCosmos": {
-        "type": "text"
-    },
-    "searchFilterSubtitleERC": "选择所有ERC代币",
-    "@searchFilterSubtitleERC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleETC": "选择所有ETC代币",
-    "@searchFilterSubtitleETC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleFTM": "选择所有Fantom代币",
-    "@searchFilterSubtitleFTM": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHCO": "选择所有HecoChain代币",
-    "@searchFilterSubtitleHCO": {
-        "type": "text"
-    },
-    "searchFilterSubtitleHRC": "选择所有Harmony代币",
-    "@searchFilterSubtitleHRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleIris": "选择所有虹膜网络",
-    "@searchFilterSubtitleIris": {
-        "type": "text"
-    },
-    "searchFilterSubtitleKRC": "选择所有Kucoin代币",
-    "@searchFilterSubtitleKRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleMVR": "选择所有Moonriver代币",
-    "@searchFilterSubtitleMVR": {
-        "type": "text"
-    },
-    "searchFilterSubtitlePLG": "选择所有Polygon代币",
-    "@searchFilterSubtitlePLG": {
-        "type": "text"
-    },
-    "searchFilterSubtitleQRC": "选择所有QRC代币",
-    "@searchFilterSubtitleQRC": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSBCH": "选择所有SmartBCH代币",
-    "@searchFilterSubtitleSBCH": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSLP": "选择所有 SLP 代币",
-    "@searchFilterSubtitleSLP": {
-        "type": "text"
-    },
-    "searchFilterSubtitleSmartChain": "选择所有智能链",
-    "@searchFilterSubtitleSmartChain": {
-        "type": "text"
-    },
-    "searchFilterSubtitleTestCoins": "选择所有测试资产",
-    "@searchFilterSubtitleTestCoins": {
-        "type": "text"
-    },
-    "searchFilterSubtitleUBQ": "选择所有Ubiq货币",
-    "@searchFilterSubtitleUBQ": {
-        "type": "text"
-    },
-    "searchFilterSubtitleutxo": "选择所有UTXO货币",
-    "@searchFilterSubtitleutxo": {
-        "type": "text"
-    },
-    "searchFilterSubtitleZHTLC": "选择所有ZHTLC币",
-    "@searchFilterSubtitleZHTLC": {
-        "type": "text"
-    },
-    "searchForTicker": "搜索货币代码",
-    "@searchForTicker": {
-        "type": "text"
-    },
-    "seconds": "秒",
-    "@seconds": {
-        "type": "text"
-    },
-    "security": "证券",
-    "@security": {
-        "type": "text"
-    },
-    "seedPhrase": "助记词",
-    "@seedPhrase": {
-        "type": "text"
-    },
-    "seedPhraseTitle": "您的新助記詞",
-    "@seedPhraseTitle": {
-        "type": "text"
-    },
-    "seeOrders": "点击查看{amount} 交易",
-    "@seeOrders": {
-        "type": "text",
-        "placeholders": {
-            "amount": {}
-        }
-    },
-    "seeTxHistory": "查看交易记录",
-    "@seeTxHistory": {
-        "type": "text"
-    },
-    "selectCoin": "选择货币",
-    "@selectCoin": {
-        "type": "text"
-    },
-    "selectCoinInfo": "选择您想要添加到投资组合的货币",
-    "@selectCoinInfo": {
-        "type": "text"
-    },
-    "selectCoinTitle": "激活货币：",
-    "@selectCoinTitle": {
-        "type": "text"
-    },
-    "selectCoinToBuy": "选择您想买入的货币",
-    "@selectCoinToBuy": {
-        "type": "text"
-    },
-    "selectCoinToSell": "选择您想卖出的货币",
-    "@selectCoinToSell": {
-        "type": "text"
-    },
-    "selectedOrder": "选择订单",
-    "@selectedOrder": {
-        "type": "text"
-    },
-    "selectFileImport": "选择文件",
-    "@selectFileImport": {
-        "type": "text"
-    },
-    "selectLanguage": "选择语言",
-    "@selectLanguage": {
-        "type": "text"
-    },
-    "selectPaymentMethod": "选择您的支付方式",
-    "@selectPaymentMethod": {
-        "type": "text"
-    },
-    "sell": "卖出",
-    "@sell": {
-        "type": "text"
-    },
-    "sellTestCoinWarning": "警告，您正在卖出没有实际价值的测试币!",
-    "@sellTestCoinWarning": {
-        "type": "text"
-    },
-    "send": "发送",
-    "@send": {
-        "type": "text"
-    },
-    "settingDialogSpan1": "您确定要删除",
-    "@settingDialogSpan1": {
-        "type": "text"
-    },
-    "settingDialogSpan2": "钱包吗",
-    "@settingDialogSpan2": {
-        "type": "text"
-    },
-    "settingDialogSpan3": "如果是，请确认您已",
-    "@settingDialogSpan3": {
-        "type": "text"
-    },
-    "settingDialogSpan4": "记下助记词",
-    "@settingDialogSpan4": {
-        "type": "text"
-    },
-    "settingDialogSpan5": "以便在将来恢复您的钱包",
-    "@settingDialogSpan5": {
-        "type": "text"
-    },
-    "settingLanguageTitle": "语言",
-    "@settingLanguageTitle": {
-        "type": "text"
-    },
-    "settings": "设置",
-    "@settings": {
-        "type": "text"
-    },
-    "setUpPassword": "创建密码",
-    "@setUpPassword": {
-        "type": "text"
-    },
-    "share": "分享",
-    "@share": {
-        "type": "text"
-    },
-    "shareAddress": "我的{coinName} 地址:\n{address}",
-    "@shareAddress": {
-        "type": "text",
-        "placeholders": {
-            "coinName": {},
-            "address": {}
-        }
-    },
-    "showAddress": "显示地址",
-    "@showAddress": {
-        "type": "text"
-    },
-    "showDetails": "显示详细信息",
-    "@showDetails": {
-        "type": "text"
-    },
-    "showingOrders": "显示 {count} 个订单（共 {maxCount} 个）。",
-    "@showingOrders": {
-        "type": "text",
-        "placeholders": {
-            "count": {},
-            "maxCount": {}
-        }
-    },
-    "showMyOrders": "显示我的订单",
-    "@showMyOrders": {
-        "type": "text"
-    },
-    "signInWithPassword": "使用密码登录",
-    "@signInWithPassword": {
-        "type": "text"
-    },
-    "signInWithSeedPhrase": "忘记密码？用助记词恢复钱包",
-    "@signInWithSeedPhrase": {
-        "type": "text"
-    },
-    "simple": "简单",
-    "@simple": {
-        "type": "text"
-    },
-    "simpleTradeActivate": "激活",
-    "@simpleTradeActivate": {
-        "type": "text"
-    },
-    "simpleTradeBuyHint": "请输入要买入的 {coin} 数量",
-    "@simpleTradeBuyHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeBuyTitle": "买入",
-    "@simpleTradeBuyTitle": {
-        "type": "text"
-    },
-    "simpleTradeClose": "关闭",
-    "@simpleTradeClose": {
-        "type": "text"
-    },
-    "simpleTradeMaxActiveCoins": "货币最大活跃量为{maxCoins}。请停用一些。",
-    "@simpleTradeMaxActiveCoins": {
-        "type": "text",
-        "placeholders": {
-            "maxCoins": {}
-        }
-    },
-    "simpleTradeNotActive": "{coin}未激活！",
-    "@simpleTradeNotActive": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeRecieve": "接收",
-    "@simpleTradeRecieve": {
-        "type": "text"
-    },
-    "simpleTradeSellHint": "请输入要卖出的{coin}数量",
-    "@simpleTradeSellHint": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "simpleTradeSellTitle": "卖出",
-    "@simpleTradeSellTitle": {
-        "type": "text"
-    },
-    "simpleTradeSend": "发送",
-    "@simpleTradeSend": {
-        "type": "text"
-    },
-    "simpleTradeShowLess": "收起",
-    "@simpleTradeShowLess": {
-        "type": "text"
-    },
-    "simpleTradeShowMore": "显示更多",
-    "@simpleTradeShowMore": {
-        "type": "text"
-    },
-    "simpleTradeUnableActivate": "无法激活{coin}",
-    "@simpleTradeUnableActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "skip": "跳过",
-    "@skip": {
-        "type": "text"
-    },
-    "snackbarDismiss": "不予考虑",
-    "@snackbarDismiss": {
-        "type": "text"
-    },
-    "Sound": "声音",
-    "@Sound": {
-        "type": "text"
-    },
-    "soundCantPlayThatMsg": "请选择mp3或wav文件。我们将在{description}时播放它。",
-    "@soundCantPlayThatMsg": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundPlayedWhen": "当{description}播放",
-    "@soundPlayedWhen": {
-        "type": "text",
-        "placeholders": {
-            "description": {
-                "example": "a swap runs to completion"
-            }
-        }
-    },
-    "soundsDialogTitle": "声音",
-    "@soundsDialogTitle": {
-        "type": "text"
-    },
-    "soundsDoNotShowAgain": "已知晓，不再显示",
-    "@soundsDoNotShowAgain": {
-        "type": "text"
-    },
-    "soundSettingsLink": "声音",
-    "@soundSettingsLink": {
-        "type": "text"
-    },
-    "soundSettingsTitle": "声音设置",
-    "@soundSettingsTitle": {
-        "type": "text"
-    },
-    "soundsExplanation": "交换时，如果您有一个活跃的挂单交易，会收到声音提醒。\n原子交换协议要求参与者在线才能成功交易，声音通知可以帮助实现这一点。",
-    "@soundsExplanation": {
-        "type": "text"
-    },
-    "soundsNote": "请注意，您可以在应用程序设置中设置自定义声音。",
-    "@soundsNote": {
-        "type": "text"
-    },
-    "spanishLanguage": "西班牙语",
-    "@spanishLanguage": {
-        "type": "text"
-    },
-    "startSwap": "开始交换",
-    "@startSwap": {
-        "type": "text"
-    },
-    "step": "步骤",
-    "@step": {
-        "type": "text"
-    },
-    "success": "成功",
-    "@success": {
-        "type": "text"
-    },
-    "support": "支持",
-    "@support": {
-        "type": "text"
-    },
-    "supportLinksDesc": "如果您有任何问题，或者认为您发现{appName} 应用程序存在技术问题，请联系我们获取我们团队的支持。",
-    "@supportLinksDesc": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "swap": "交换",
-    "@swap": {
-        "type": "text"
-    },
-    "swapCurrent": "现状",
-    "@swapCurrent": {
-        "type": "text"
-    },
-    "swapDetailTitle": "确认兑换细节",
-    "@swapDetailTitle": {
-        "type": "text"
-    },
-    "swapEstimated": "预估",
-    "@swapEstimated": {
-        "type": "text"
-    },
-    "swapFailed": "交换失败",
-    "@swapFailed": {
-        "type": "text"
-    },
-    "swapGasActivate": "请先激活 {coin} 并充值余额",
-    "@swapGasActivate": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmount": "{coin} 余额不足以支付交易费用。",
-    "@swapGasAmount": {
-        "type": "text",
-        "placeholders": {
-            "coin": {}
-        }
-    },
-    "swapGasAmountRequired": "{coin} 余额不足以支付交易费用。需要 {coin} {amount}",
-    "@swapGasAmountRequired": {
-        "type": "text",
-        "placeholders": {
-            "coin": {},
-            "amount": {}
-        }
-    },
-    "swapOngoing": "正在交换",
-    "@swapOngoing": {
-        "type": "text"
-    },
-    "swapProgress": "进度详情",
-    "@swapProgress": {
-        "type": "text"
-    },
-    "swapStarted": "已开始",
-    "@swapStarted": {
-        "type": "text"
-    },
-    "swapSucceful": "交换成功",
-    "@swapSucceful": {
-        "type": "text"
-    },
-    "swapTotal": "总共",
-    "@swapTotal": {
-        "type": "text"
-    },
-    "swapUUID": "UUID交换",
-    "@swapUUID": {
-        "type": "text"
-    },
-    "switchTheme": "切换主题",
-    "@switchTheme": {
-        "type": "text"
-    },
-    "tagAVX20": "AVX20",
-    "@tagAVX20": {
-        "type": "text"
-    },
-    "tagBEP20": "BEP20",
-    "@tagBEP20": {
-        "type": "text"
-    },
-    "tagERC20": "ERC20",
-    "@tagERC20": {
-        "type": "text"
-    },
-    "tagETC": "ETC",
-    "@tagETC": {
-        "type": "text"
-    },
-    "tagFTM20": "FTM20",
-    "@tagFTM20": {
-        "type": "text"
-    },
-    "tagHCO20": "HCO20",
-    "@tagHCO20": {
-        "type": "text"
-    },
-    "tagHRC20": "HRC20",
-    "@tagHRC20": {
-        "type": "text"
-    },
-    "tagKMD": "KMD",
-    "@tagKMD": {
-        "type": "text"
-    },
-    "tagKRC20": "KRC20",
-    "@tagKRC20": {
-        "type": "text"
-    },
-    "tagMVR20": "MVR20",
-    "@tagMVR20": {
-        "type": "text"
-    },
-    "tagPLG20": "PLG20",
-    "@tagPLG20": {
-        "type": "text"
-    },
-    "tagQRC20": "QRC20",
-    "@tagQRC20": {
-        "type": "text"
-    },
-    "tagSBCH": "SBCH",
-    "@tagSBCH": {
-        "type": "text"
-    },
-    "tagUBQ": "UBQ",
-    "@tagUBQ": {
-        "type": "text"
-    },
-    "tagZHTLC": "中山HTLC",
-    "@tagZHTLC": {
-        "type": "text"
-    },
-    "Taker": "吃单",
-    "@Taker": {
-        "type": "text"
-    },
-    "takerOrder": "吃单交易",
-    "@takerOrder": {
-        "type": "text"
-    },
-    "timeOut": "超时",
-    "@timeOut": {
-        "type": "text"
-    },
-    "titleCreatePassword": "创建密码",
-    "@titleCreatePassword": {
-        "type": "text"
-    },
-    "titleCurrentAsk": "选择订单",
-    "@titleCurrentAsk": {
-        "type": "text"
-    },
-    "to": "至",
-    "@to": {
-        "type": "text"
-    },
-    "toAddress": "接收地址",
-    "@toAddress": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan1": "您已",
-    "@tooManyAssetsEnabledSpan1": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan2": "启用资产。启用资产上限为",
-    "@tooManyAssetsEnabledSpan2": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledSpan3": "请在启用新资产前停用一些资产",
-    "@tooManyAssetsEnabledSpan3": {
-        "type": "text"
-    },
-    "tooManyAssetsEnabledTitle": "已启用的资产太多",
-    "@tooManyAssetsEnabledTitle": {
-        "type": "text"
-    },
-    "totalFees": "总费用",
-    "@totalFees": {
-        "type": "text"
-    },
-    "trade": "交易",
-    "@trade": {
-        "type": "text"
-    },
-    "tradeCompleted": "交换完成！",
-    "@tradeCompleted": {
-        "type": "text"
-    },
-    "tradeDetail": "交易详情",
-    "@tradeDetail": {
-        "type": "text"
-    },
-    "tradePreimageError": "无法计算交易费用",
-    "@tradePreimageError": {
-        "type": "text"
-    },
-    "tradingFee": "交易费用：",
-    "@tradingFee": {
-        "type": "text"
-    },
-    "tradingMode": "交易模式：",
-    "@tradingMode": {
-        "type": "text"
-    },
-    "transactionAddress": "交易地址",
-    "@transactionAddress": {
-        "type": "text"
-    },
-    "transactionHidden": "交易隐藏",
-    "@transactionHidden": {
-        "type": "text"
-    },
-    "transactionHiddenPhishing": "由于可能存在网络钓鱼尝试，该交易被隐藏。",
-    "@transactionHiddenPhishing": {
-        "type": "text"
-    },
-    "tryRestarting": "如果还是有一些货币未被激活，请尝试重启应用程序。",
-    "@tryRestarting": {
-        "type": "text"
-    },
-    "turkishLanguage": "土耳其语",
-    "@turkishLanguage": {
-        "type": "text"
-    },
-    "txBlock": "区块",
-    "@txBlock": {
-        "type": "text"
-    },
-    "txConfirmations": "确认",
-    "@txConfirmations": {
-        "type": "text"
-    },
-    "txConfirmed": "已确认",
-    "@txConfirmed": {
-        "type": "text"
-    },
-    "txFee": "费用",
-    "@txFee": {
-        "type": "text"
-    },
-    "txFeeTitle": "交易费用",
-    "@txFeeTitle": {
-        "type": "text"
-    },
-    "txHash": "交易ID",
-    "@txHash": {
-        "type": "text"
-    },
-    "txleft": "剩余交易: {left}",
-    "@txleft": {
-        "type": "text",
-        "placeholders": {
-            "left": {}
-        }
-    },
-    "txLimitExceeded": "请求过多。超出交易历史请求限制。请稍后重试",
-    "@txLimitExceeded": {
-        "type": "text"
-    },
-    "txNotConfirmed": "未确认",
-    "@txNotConfirmed": {
-        "type": "text"
-    },
-    "ukrainianLanguage": "乌克兰",
-    "@ukrainianLanguage": {
-        "type": "text"
-    },
-    "unlock": "解锁",
-    "@unlock": {
-        "type": "text"
-    },
-    "unlockFunds": "解锁基金",
-    "@unlockFunds": {
-        "type": "text"
-    },
-    "unlockSuccess": "成功解锁 {amnt} 基金 - 交易: {hash}",
-    "@unlockSuccess": {
-        "type": "text",
-        "placeholders": {
-            "amnt": {},
-            "hash": {}
-        }
-    },
-    "unspendable": "不可交易",
-    "@unspendable": {
-        "type": "text"
-    },
-    "updatesAvailable": "已有新版本",
-    "@updatesAvailable": {
-        "type": "text"
-    },
-    "updatesChecking": "正在检查更新",
-    "@updatesChecking": {
-        "type": "text"
-    },
-    "updatesCurrentVersion": "您正在使用版本{version}",
-    "@updatesCurrentVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifAvailable": "已有新版本。请更新。",
-    "@updatesNotifAvailable": {
-        "type": "text"
-    },
-    "updatesNotifAvailableVersion": "版本{version}可用。请更新。",
-    "@updatesNotifAvailableVersion": {
-        "type": "text",
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "updatesNotifTitle": "可更新",
-    "@updatesNotifTitle": {
-        "type": "text"
-    },
-    "updatesSkip": "暂时跳过",
-    "@updatesSkip": {
-        "type": "text"
-    },
-    "updatesTitle": "更新{appName}",
-    "@updatesTitle": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "updatesUpdate": "已更新",
-    "@updatesUpdate": {
-        "type": "text"
-    },
-    "updatesUpToDate": "准备更新",
-    "@updatesUpToDate": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan1": "余额不足，无法扫描",
-    "@uriInsufficientBalanceSpan1": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceSpan2": "付款请求。",
-    "@uriInsufficientBalanceSpan2": {
-        "type": "text"
-    },
-    "uriInsufficientBalanceTitle": "余额不足",
-    "@uriInsufficientBalanceTitle": {
-        "type": "text"
-    },
-    "value": "价值",
-    "@value": {
-        "type": "text"
-    },
-    "version": "版本",
-    "@version": {
-        "type": "text"
-    },
-    "viewInExplorerButton": "资源管理器",
-    "@viewInExplorerButton": {
-        "type": "text"
-    },
-    "viewSeedAndKeys": "助记词和私钥",
-    "@viewSeedAndKeys": {
-        "type": "text"
-    },
-    "volumes": "交易量",
-    "@volumes": {
-        "type": "text"
-    },
-    "walletInUse": "钱包名称已被使用",
-    "@walletInUse": {
-        "type": "text"
-    },
-    "walletMaxChar": "钱包名称最多40个字符",
-    "@walletMaxChar": {
-        "type": "text"
-    },
-    "walletOnly": "仅钱包",
-    "@walletOnly": {
-        "type": "text"
-    },
-    "warning": "警告",
-    "@warning": {
-        "type": "text"
-    },
-    "warningOkBtn": "好的",
-    "@warningOkBtn": {
-        "type": "text"
-    },
-    "warningShareLogs": "警告-在特殊情况下，此登录数据包含敏感信息，可用于消费交换失败的货币！",
-    "@warningShareLogs": {
-        "type": "text"
-    },
-    "weFailedTo": "我们无法激活 {coinAbbr}",
-    "@weFailedTo": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "weFailedToActivate": "我们无法激活{coinAbbr}.\n请重启应用程序后重试",
-    "@weFailedToActivate": {
-        "type": "text",
-        "placeholders": {
-            "coinAbbr": {}
-        }
-    },
-    "welcomeInfo": "{appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。",
-    "@welcomeInfo": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "welcomeLetSetUp": "让我们开始吧",
-    "@welcomeLetSetUp": {
-        "type": "text"
-    },
-    "welcomeTitle": "欢迎",
-    "@welcomeTitle": {
-        "type": "text"
-    },
-    "welcomeWallet": "钱包",
-    "@welcomeWallet": {
-        "type": "text"
-    },
-    "willBeRedirected": "完成后，您将跳转至投资组合页面",
-    "@willBeRedirected": {
-        "type": "text"
-    },
-    "willTakeTime": "这将需要一段时间，并且应用程序必须保持在前台。\n在激活过程中终止应用程序可能会导致问题。",
-    "@willTakeTime": {
-        "type": "text"
-    },
-    "withdraw": "提取",
-    "@withdraw": {
-        "type": "text"
-    },
-    "withdrawCameraAccessText": "您之前禁止{appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描",
-    "@withdrawCameraAccessText": {
-        "type": "text",
-        "placeholders": {
-            "appName": {}
-        }
-    },
-    "withdrawCameraAccessTitle": "被拒绝使用",
-    "@withdrawCameraAccessTitle": {
-        "type": "text"
-    },
-    "withdrawConfirm": "确认提取",
-    "@withdrawConfirm": {
-        "type": "text"
-    },
-    "withdrawConfirmError": "出现错误。请稍后重试。",
-    "@withdrawConfirmError": {
-        "type": "text"
-    },
-    "withdrawValue": "提取 {amount} {coinName}",
-    "@withdrawValue": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coinName": {}
-        }
-    },
-    "wrongCoinSpan1": "您正在尝试扫描付款二维码",
-    "@wrongCoinSpan1": {
-        "type": "text"
-    },
-    "wrongCoinSpan2": "但您在",
-    "@wrongCoinSpan2": {
-        "type": "text"
-    },
-    "wrongCoinSpan3": "提取页面",
-    "@wrongCoinSpan3": {
-        "type": "text"
-    },
-    "wrongCoinTitle": "错误货币",
-    "@wrongCoinTitle": {
-        "type": "text"
-    },
-    "wrongPassword": "密码不匹配。请重试",
-    "@wrongPassword": {
-        "type": "text"
-    },
-    "yes": "对",
-    "@yes": {
-        "type": "text"
-    },
-    "youAreSending": "您正在发送：",
-    "@youAreSending": {
-        "type": "text"
-    },
-    "you have a fresh order that is trying to match with an existing order": "您有一个新订单正在尝试与现有订单匹配",
-    "@you have a fresh order that is trying to match with an existing order": {
-        "type": "text"
-    },
-    "you have an active swap in progress": "您有一个正在进行的活跃交换",
-    "@you have an active swap in progress": {
-        "type": "text"
-    },
-    "you have an order that new orders can match with": "你有一个新订单可以匹配的订单",
-    "@you have an order that new orders can match with": {
-        "type": "text"
-    },
-    "yourWallet": "您的钱包",
-    "@yourWallet": {
-        "type": "text"
-    },
-    "youWillReceiveClaim": "您将获得 {amount} {coin}",
-    "@youWillReceiveClaim": {
-        "type": "text",
-        "placeholders": {
-            "amount": {},
-            "coin": {}
-        }
-    },
-    "youWillReceived": "您将收到：",
-    "@youWillReceived": {
-        "type": "text"
+  "@@locale": "zh",
+  "accepteula": "同意接受终端使用者授权协议 (EULA)",
+  "@accepteula": {
+    "type": "text"
+  },
+  "accepttac": "接受条款与条件",
+  "@accepttac": {
+    "type": "text"
+  },
+  "activateAccessBiometric": "启动生物识别功能",
+  "@activateAccessBiometric": {
+    "type": "text"
+  },
+  "activateAccessPin": "启动PIN码保护",
+  "@activateAccessPin": {
+    "type": "text"
+  },
+  "activateCoins": "激活 {protocolName} 币？",
+  "@activateCoins": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
     }
+  },
+  "activating": "激活{coinName}",
+  "@activating": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activation": "{coinName} 激活",
+  "@activation": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "activationInProgress": "{protocolName} 激活正在进行中",
+  "@activationInProgress": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "Active": "活跃",
+  "@Active": {
+    "type": "text"
+  },
+  "addCoin": "新增货币",
+  "@addCoin": {
+    "type": "text"
+  },
+  "addingCoinSuccess": "成功新增 {name}!",
+  "@addingCoinSuccess": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "addressAdd": "添加地址",
+  "@addressAdd": {
+    "type": "text"
+  },
+  "addressBook": "地址簿",
+  "@addressBook": {
+    "type": "text"
+  },
+  "addressBookEmpty": "地址簿为空",
+  "@addressBookEmpty": {
+    "type": "text"
+  },
+  "addressBookFilter": "仅显示具有{title}地址的联系人",
+  "@addressBookFilter": {
+    "type": "text",
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "addressBookTitle": "地址簿",
+  "@addressBookTitle": {
+    "type": "text"
+  },
+  "addressCoinInactive": "您无法将基金发送到{abbr}地址，因为{abbr}未激活。请转到投资组合页面",
+  "@addressCoinInactive": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "addressNotFound": "未找到任何内容",
+  "@addressNotFound": {
+    "type": "text"
+  },
+  "addressSelectCoin": "选择货币",
+  "@addressSelectCoin": {
+    "type": "text"
+  },
+  "addressSend": "收款人钱包地址",
+  "@addressSend": {
+    "type": "text"
+  },
+  "advanced": "高级",
+  "@advanced": {
+    "type": "text"
+  },
+  "all": "全部",
+  "@all": {
+    "type": "text"
+  },
+  "allowCustomSeed": "允许自定义助记词",
+  "@allowCustomSeed": {
+    "type": "text"
+  },
+  "allPastTransactions": "您的钱包将显示任何过去的交易。这将占用大量存储空间和时间，因为所有块都将被下载和扫描。",
+  "@allPastTransactions": {
+    "type": "text"
+  },
+  "alreadyExists": "已存在",
+  "@alreadyExists": {
+    "type": "text"
+  },
+  "amount": "数量",
+  "@amount": {
+    "type": "text"
+  },
+  "amountToSell": "卖出量",
+  "@amountToSell": {
+    "type": "text"
+  },
+  "answer_1": "不{appName}是非托管应用。我们不会存储任何敏感数据，包括您的私钥、助记词或PIN。此数据仅存储在用户的设备上，不会转移。您的资产只由您掌控。",
+  "@answer_1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_10": "{appName} 适用于 Android 和 iPhone 上的移动设备，以及 <a href=\"https://komodoplatform.com/\">Windows、Mac 和 Linux 操作系统</a> 上的桌面设备。",
+  "@answer_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_2": "其他DEX（去中心化交易所）通常只允许您使用代理代币交易基于单个区块链网络的资产，并且只能用一个基金下一个订单。\n但用{appName}您可以在两个不同的区块链网络之间进行交易，且无需代理代币。您还可以用一个基金下多个订单。例如，您可以用KMD、QTUM或VRSC兑0.1 BTC，第一个订单成交后自动取消其他所有订单",
+  "@answer_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_3": "几个因素决定了每次交易的处理时间。交易资产的区块时间取决于各自的网络（比特币通常是最慢的）。此外，用户可以自定义安全偏好。例如，您可以要求{appName}在确认KMD交易为最终交易前确认3次，这使得交易时间短于等待公证的<a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">时间</a>.",
+  "@answer_3": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_4": "是的，必须保持互联网连接，并确保您的应用程序在运行，才能成功完成原子交换（网络短暂中断通常是可以的）。否则，如果是挂单，会有交易取消的风险，如果是吃单，会有资金损失的风险。原子交换协议要求双方参与者保持在线，并监控所涉及的区块链，确保该过程保持原子性。",
+  "@answer_4": {
+    "type": "text"
+  },
+  "answer_5": "在｛appName｝上进行交易时，需要考虑两种费用。\n1.｛appName｝收取约0.13%（交易量的1/777，但不低于0.0001）作为吃单交易的交易费用，挂单交易不收费。\n2.在进行原子交换交易时，无论挂单还是吃单，都需要向相关区块链支付常规的网络费用\n网络费用具体取决于你选择的交易对，不同交易对费用可能大大不同。",
+  "@answer_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_6": "是的 {appName} 通过 <a href=\"{link}\">{appCompanyShort} {name}</a>提供支持。团队和社区总是乐于提供帮助！",
+  "@answer_6": {
+    "type": "text",
+    "placeholders": {
+      "name": {},
+      "link": {},
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_7": "不是{appName} 是完全去中心化的。不会限制任何第三方用户访问。",
+  "@answer_7": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "answer_8": "{appName} 由{appCompanyShort}团队开发。{appCompanyShort}是最成熟的区块链项目之一，致力于开发创新解决方案，如原子交换、延迟工作量证明和可互操作的多链架构。",
+  "@answer_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyShort": {}
+    }
+  },
+  "answer_9": "绝对地！您可以阅读我们的<a href=\"https://developers.komodoplatform.com/\">开发者文档</a>了解更多详细信息，或者联系我们咨询您的合作伙伴关系。有具体的技术问题吗？ {appName} 开发者社区随时准备提供帮助！",
+  "@answer_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "Applause": "掌声",
+  "@Applause": {
+    "type": "text"
+  },
+  "areYouSure": "您确定吗？",
+  "@areYouSure": {
+    "type": "text"
+  },
+  "a swap fails": "交换失败",
+  "@a swap fails": {
+    "type": "text"
+  },
+  "a swap runs to completion": "交换完成",
+  "@a swap runs to completion": {
+    "type": "text"
+  },
+  "authenticate": "身份验证",
+  "@authenticate": {
+    "type": "text"
+  },
+  "automaticRedirected": "重新激活后，您将自动跳转至投资组合页面。",
+  "@automaticRedirected": {
+    "type": "text"
+  },
+  "availableVolume": "最大交易量",
+  "@availableVolume": {
+    "type": "text"
+  },
+  "back": "上一步",
+  "@back": {
+    "type": "text"
+  },
+  "backupTitle": "备份",
+  "@backupTitle": {
+    "type": "text"
+  },
+  "basedOnCoinRatio": "基于{coinName1}/{coinName2}",
+  "@basedOnCoinRatio": {
+    "type": "text",
+    "placeholders": {
+      "coinName1": {},
+      "coinName2": {}
+    }
+  },
+  "batteryCriticalError": "您的电池电量过低 ({batteryLevelCritical}%) ，无法安全地进行交换。请先充电，然后重试。",
+  "@batteryCriticalError": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelCritical": {}
+    }
+  },
+  "batteryLowWarning": "您的电池电量低于 {batteryLevelLow}%。请充电。",
+  "@batteryLowWarning": {
+    "type": "text",
+    "placeholders": {
+      "batteryLevelLow": {}
+    }
+  },
+  "batterySavingWarning": "您的手机处于省电模式。请停用此模式或不要将应用程序置于后台，否则，应用程序可能会被系统自动清除，导致交换失败。",
+  "@batterySavingWarning": {
+    "type": "text"
+  },
+  "bestAvailableRate": "兑换率",
+  "@bestAvailableRate": {
+    "type": "text"
+  },
+  "builtKomodo": "基于Komodo",
+  "@builtKomodo": {
+    "type": "text"
+  },
+  "builtOnKmd": "基于Komodo",
+  "@builtOnKmd": {
+    "type": "text"
+  },
+  "buy": "买入",
+  "@buy": {
+    "type": "text"
+  },
+  "buyOrderType": "如果不匹配，则转为挂单",
+  "@buyOrderType": {
+    "type": "text"
+  },
+  "buySuccessWaiting": "交换已发起，请等待!",
+  "@buySuccessWaiting": {
+    "type": "text"
+  },
+  "buySuccessWaitingError": "正在进行交易匹配，请等待 {seconde} 秒!",
+  "@buySuccessWaitingError": {
+    "type": "text",
+    "placeholders": {
+      "seconde": {}
+    }
+  },
+  "buyTestCoinWarning": "警告，你正在购买没有实际价值的测试币!",
+  "@buyTestCoinWarning": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflict": "不能同时启用伪装PIN和生物识别保护",
+  "@camoPinBioProtectionConflict": {
+    "type": "text"
+  },
+  "camoPinBioProtectionConflictTitle": "伪装PIN和生物识别保护冲突",
+  "@camoPinBioProtectionConflictTitle": {
+    "type": "text"
+  },
+  "camoPinChange": "更改伪装PIN",
+  "@camoPinChange": {
+    "type": "text"
+  },
+  "camoPinCreate": "创建伪装PIN",
+  "@camoPinCreate": {
+    "type": "text"
+  },
+  "camoPinDesc": "如果您用伪装PIN解锁应用程序，将显示一个虚假的低余额，并且设置中不会显示伪装PIN配置选项。",
+  "@camoPinDesc": {
+    "type": "text"
+  },
+  "camoPinInvalid": "无效的伪装PIN",
+  "@camoPinInvalid": {
+    "type": "text"
+  },
+  "camoPinLink": "伪装PIN",
+  "@camoPinLink": {
+    "type": "text"
+  },
+  "camoPinNotFound": "未找到伪装PIN",
+  "@camoPinNotFound": {
+    "type": "text"
+  },
+  "camoPinOff": "关闭",
+  "@camoPinOff": {
+    "type": "text"
+  },
+  "camoPinOn": "开启",
+  "@camoPinOn": {
+    "type": "text"
+  },
+  "camoPinSaved": "已保存的伪装PIN",
+  "@camoPinSaved": {
+    "type": "text"
+  },
+  "camoPinTitle": "伪装PIN",
+  "@camoPinTitle": {
+    "type": "text"
+  },
+  "camoSetupSubtitle": "输入新的伪装PIN",
+  "@camoSetupSubtitle": {
+    "type": "text"
+  },
+  "camoSetupTitle": "伪装PIN设置",
+  "@camoSetupTitle": {
+    "type": "text"
+  },
+  "camouflageSetup": "伪装PIN设置",
+  "@camouflageSetup": {
+    "type": "text"
+  },
+  "cancel": "取消",
+  "@cancel": {
+    "type": "text"
+  },
+  "cancelActivation": "取消激活",
+  "@cancelActivation": {
+    "type": "text"
+  },
+  "cancelActivationQuestion": "您确定要取消激活吗？",
+  "@cancelActivationQuestion": {
+    "type": "text"
+  },
+  "cancelButton": "取消",
+  "@cancelButton": {
+    "type": "text"
+  },
+  "cancelOrder": "取消交易",
+  "@cancelOrder": {
+    "type": "text"
+  },
+  "candleChartError": "出现错误，稍后重试",
+  "@candleChartError": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinOk": "好的",
+  "@cantDeleteDefaultCoinOk": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinSpan": "是默认币。无法停用默认币。",
+  "@cantDeleteDefaultCoinSpan": {
+    "type": "text"
+  },
+  "cantDeleteDefaultCoinTitle": "无法停用",
+  "@cantDeleteDefaultCoinTitle": {
+    "type": "text"
+  },
+  "Can't play that": "不能播放",
+  "@Can't play that": {
+    "type": "text"
+  },
+  "cex": "CEX(中心化交易所)",
+  "@cex": {
+    "type": "text"
+  },
+  "cexChangeRate": "CEX兑换率",
+  "@cexChangeRate": {
+    "type": "text"
+  },
+  "cexData": "CEX 数据",
+  "@cexData": {
+    "type": "text"
+  },
+  "cexDataDesc": "带有此图标的市场数据（价格、图表等）来源于第三方(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+  "@cexDataDesc": {
+    "type": "text"
+  },
+  "cexRate": "CEX 汇率",
+  "@cexRate": {
+    "type": "text"
+  },
+  "changePin": "更改PIN",
+  "@changePin": {
+    "type": "text"
+  },
+  "checkForUpdates": "检查更新",
+  "@checkForUpdates": {
+    "type": "text"
+  },
+  "checkOut": "退出",
+  "@checkOut": {
+    "type": "text"
+  },
+  "checkSeedPhrase": "检查助记词",
+  "@checkSeedPhrase": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton1": "继续",
+  "@checkSeedPhraseButton1": {
+    "type": "text"
+  },
+  "checkSeedPhraseButton2": "返回並再次檢查",
+  "@checkSeedPhraseButton2": {
+    "type": "text"
+  },
+  "checkSeedPhraseHint": "请输入第 {index}个单词",
+  "@checkSeedPhraseHint": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseInfo": "您的助记词很重要——因此我们要确保它是正确的。我们将问您三个关于您的助记词的问题，以确保您可以随时轻松地恢复钱包。",
+  "@checkSeedPhraseInfo": {
+    "type": "text"
+  },
+  "checkSeedPhraseSubtile": "您的助記詞的第 {index}個单词是什麼？",
+  "@checkSeedPhraseSubtile": {
+    "type": "text",
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "checkSeedPhraseTitle": "请再次确认助记词",
+  "@checkSeedPhraseTitle": {
+    "type": "text"
+  },
+  "chineseLanguage": "中文",
+  "@chineseLanguage": {
+    "type": "text"
+  },
+  "claim": "领取",
+  "@claim": {
+    "type": "text"
+  },
+  "claimTitle": "领取您的KMD奖励？",
+  "@claimTitle": {
+    "type": "text"
+  },
+  "clickToSee": "点击查看",
+  "@clickToSee": {
+    "type": "text"
+  },
+  "clipboard": "复制到剪贴板",
+  "@clipboard": {
+    "type": "text"
+  },
+  "clipboardCopy": "复制到剪贴板",
+  "@clipboardCopy": {
+    "type": "text"
+  },
+  "close": "关闭",
+  "@close": {
+    "type": "text"
+  },
+  "closeMessage": "关闭错误信息",
+  "@closeMessage": {
+    "type": "text"
+  },
+  "closePreview": "关闭预览",
+  "@closePreview": {
+    "type": "text"
+  },
+  "code": "代码",
+  "@code": {
+    "type": "text"
+  },
+  "cofirmCancelActivation": "您确定要取消激活吗？",
+  "@cofirmCancelActivation": {
+    "type": "text"
+  },
+  "coinsActivatedLimitReached": "您已选择最大资产数量",
+  "@coinsActivatedLimitReached": {
+    "type": "text"
+  },
+  "coinsAreActivated": "{protocolName} 币已激活",
+  "@coinsAreActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreActivatedSuccessfully": "{protocolName}币激活成功",
+  "@coinsAreActivatedSuccessfully": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinsAreNotActivated": "{protocolName} 代币未激活",
+  "@coinsAreNotActivated": {
+    "type": "text",
+    "placeholders": {
+      "protocolName": {}
+    }
+  },
+  "coinSelectClear": "清除",
+  "@coinSelectClear": {
+    "type": "text"
+  },
+  "coinSelectNotFound": "没有活跃币",
+  "@coinSelectNotFound": {
+    "type": "text"
+  },
+  "coinSelectTitle": "选择货币",
+  "@coinSelectTitle": {
+    "type": "text"
+  },
+  "comingSoon": "即将上线，敬请期待。。。",
+  "@comingSoon": {
+    "type": "text"
+  },
+  "commingsoon": "交易明细加载中！",
+  "@commingsoon": {
+    "type": "text"
+  },
+  "commingsoonGeneral": "详情载入中！",
+  "@commingsoonGeneral": {
+    "type": "text"
+  },
+  "commissionFee": "手续费",
+  "@commissionFee": {
+    "type": "text"
+  },
+  "comparedTo24hrCex": "与平均值相比24小时CEX价格",
+  "@comparedTo24hrCex": {
+    "type": "text"
+  },
+  "comparedToCex": "与CEX比较",
+  "@comparedToCex": {
+    "type": "text"
+  },
+  "configureWallet": "正在配置您的钱包，请稍候。。。",
+  "@configureWallet": {
+    "type": "text"
+  },
+  "confirm": "确认",
+  "@confirm": {
+    "type": "text"
+  },
+  "confirmCamouflageSetup": "确认伪装PIN",
+  "@confirmCamouflageSetup": {
+    "type": "text"
+  },
+  "confirmCancel": "您确定要取消交易吗",
+  "@confirmCancel": {
+    "type": "text"
+  },
+  "confirmeula": "我已了解点击以下的按钮即代表我已阅读并接受终端使用者授权协议(EULA) & 使用条款与条件",
+  "@confirmeula": {
+    "type": "text"
+  },
+  "confirmPassword": "确认密码",
+  "@confirmPassword": {
+    "type": "text"
+  },
+  "confirmPin": "确认PIN",
+  "@confirmPin": {
+    "type": "text"
+  },
+  "confirmSeed": "确认助记词",
+  "@confirmSeed": {
+    "type": "text"
+  },
+  "connecting": "连接中",
+  "@connecting": {
+    "type": "text"
+  },
+  "contactCancel": "取消",
+  "@contactCancel": {
+    "type": "text"
+  },
+  "contactDelete": "删除联系人",
+  "@contactDelete": {
+    "type": "text"
+  },
+  "contactDeleteBtn": "删除",
+  "@contactDeleteBtn": {
+    "type": "text"
+  },
+  "contactDeleteWarning": "确认删除该联系人{name}？",
+  "@contactDeleteWarning": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "contactDiscardBtn": "放弃",
+  "@contactDiscardBtn": {
+    "type": "text"
+  },
+  "contactEdit": "编辑",
+  "@contactEdit": {
+    "type": "text"
+  },
+  "contactExit": "退出",
+  "@contactExit": {
+    "type": "text"
+  },
+  "contactExitWarning": "放弃更改？",
+  "@contactExitWarning": {
+    "type": "text"
+  },
+  "contactNotFound": "未找到联系人",
+  "@contactNotFound": {
+    "type": "text"
+  },
+  "contactSave": "保存",
+  "@contactSave": {
+    "type": "text"
+  },
+  "contactTitle": "联系人详细信息",
+  "@contactTitle": {
+    "type": "text"
+  },
+  "contactTitleName": "名称",
+  "@contactTitleName": {
+    "type": "text"
+  },
+  "contract": "合同",
+  "@contract": {
+    "type": "text"
+  },
+  "convert": "转换",
+  "@convert": {
+    "type": "text"
+  },
+  "couldNotLaunchUrl": "无法启动 URL",
+  "@couldNotLaunchUrl": {
+    "type": "text"
+  },
+  "couldntImportError": "无法导入：",
+  "@couldntImportError": {
+    "type": "text"
+  },
+  "create": "交易",
+  "@create": {
+    "type": "text"
+  },
+  "createAWallet": "创建钱包",
+  "@createAWallet": {
+    "type": "text"
+  },
+  "createContact": "创建联系人",
+  "@createContact": {
+    "type": "text"
+  },
+  "createPin": "创建PIN码",
+  "@createPin": {
+    "type": "text"
+  },
+  "currency": "货币",
+  "@currency": {
+    "type": "text"
+  },
+  "currencyDialogTitle": "货币",
+  "@currencyDialogTitle": {
+    "type": "text"
+  },
+  "currentValue": "当前值",
+  "@currentValue": {
+    "type": "text"
+  },
+  "customFee": "定制费用",
+  "@customFee": {
+    "type": "text"
+  },
+  "customFeeWarning": "选择定制费用前务必明确知晓自己的行为",
+  "@customFeeWarning": {
+    "type": "text"
+  },
+  "customSeedWarning": "自定义助记词的安全性可能比自动生成的符合BIP39规范的助记词或私钥（WIF）低，更容易被破解。如您已了解风险并知道您正在做什么，请在下面的框中输入\"{iUnderstand}\"。",
+  "@customSeedWarning": {
+    "type": "text",
+    "placeholders": {
+      "iUnderstand": {}
+    }
+  },
+  "date": "日期",
+  "@date": {
+    "type": "text"
+  },
+  "decryptingWallet": "钱包解密中",
+  "@decryptingWallet": {
+    "type": "text"
+  },
+  "delete": "删除",
+  "@delete": {
+    "type": "text"
+  },
+  "deleteConfirm": "确认停用",
+  "@deleteConfirm": {
+    "type": "text"
+  },
+  "deleteSpan1": "是否要",
+  "@deleteSpan1": {
+    "type": "text"
+  },
+  "deleteSpan2": "从投资组合中删除？所有不匹配的订单将被取消。",
+  "@deleteSpan2": {
+    "type": "text"
+  },
+  "deleteSpan3": " 也将被停用",
+  "@deleteSpan3": {
+    "type": "text"
+  },
+  "deleteWallet": "删除钱包",
+  "@deleteWallet": {
+    "type": "text"
+  },
+  "deletingWallet": "删除钱包中",
+  "@deletingWallet": {
+    "type": "text"
+  },
+  "detailedFeesReceiveCoinTransactionFee": "接收{coinName}交易费",
+  "@detailedFeesReceiveCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendCoinTransactionFee": "发送 {coinName} 交易费",
+  "@detailedFeesSendCoinTransactionFee": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "detailedFeesSendTradingFeeTransactionFee": "发送交易费 交易费",
+  "@detailedFeesSendTradingFeeTransactionFee": {
+    "type": "text"
+  },
+  "detailedFeesTradingFee": "交易费",
+  "@detailedFeesTradingFee": {
+    "type": "text"
+  },
+  "details": "详细信息",
+  "@details": {
+    "type": "text"
+  },
+  "deutscheLanguage": "德语",
+  "@deutscheLanguage": {
+    "type": "text"
+  },
+  "developerTitle": "开发者",
+  "@developerTitle": {
+    "type": "text"
+  },
+  "dex": "DEX",
+  "@dex": {
+    "type": "text"
+  },
+  "dexIsNotAvailable": "DEX不适合该货币",
+  "@dexIsNotAvailable": {
+    "type": "text"
+  },
+  "disableScreenshots": "禁用屏幕截图/预览",
+  "@disableScreenshots": {
+    "type": "text"
+  },
+  "disclaimerAndTos": "免责声明 & 使用条款",
+  "@disclaimerAndTos": {
+    "type": "text"
+  },
+  "done": "完成",
+  "@done": {
+    "type": "text"
+  },
+  "doNotCloseTheAppTapForMoreInfo": "不要关闭应用程序。点按了解更多信息...",
+  "@doNotCloseTheAppTapForMoreInfo": {
+    "type": "text"
+  },
+  "dontAskAgain": "不再询问",
+  "@dontAskAgain": {
+    "type": "text"
+  },
+  "dontWantPassword": "我不想要使用密碼",
+  "@dontWantPassword": {
+    "type": "text"
+  },
+  "dPow": "Komodo dPoW安全",
+  "@dPow": {
+    "type": "text"
+  },
+  "duration": "有效期",
+  "@duration": {
+    "type": "text"
+  },
+  "editContact": "编辑联系人",
+  "@editContact": {
+    "type": "text"
+  },
+  "emptyCoin": "输入{abbr}地址",
+  "@emptyCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "emptyExportPass": "加密密码不能为空",
+  "@emptyExportPass": {
+    "type": "text"
+  },
+  "emptyImportPass": "密码不能为空",
+  "@emptyImportPass": {
+    "type": "text"
+  },
+  "emptyName": "联系人名称不能为空",
+  "@emptyName": {
+    "type": "text"
+  },
+  "emptyWallet": "钱包名称不能为空",
+  "@emptyWallet": {
+    "type": "text"
+  },
+  "enable": "您仍然可以启用{remains}，已选择：{selected}",
+  "@enable": {
+    "type": "text",
+    "placeholders": {
+      "selected": {},
+      "remains": {}
+    }
+  },
+  "enableNotificationsForActivationProgress": "请启用通知以获取有关激活进度的更新。",
+  "@enableNotificationsForActivationProgress": {
+    "type": "text"
+  },
+  "enableTestCoins": "启用测试币",
+  "@enableTestCoins": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan1": "您已启用",
+  "@enablingTooManyAssetsSpan1": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan2": "资产并尝试启用",
+  "@enablingTooManyAssetsSpan2": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan3": "更多。最多启用",
+  "@enablingTooManyAssetsSpan3": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsSpan4": "请在添加新资产前停用一些资产。",
+  "@enablingTooManyAssetsSpan4": {
+    "type": "text"
+  },
+  "enablingTooManyAssetsTitle": "试图启用太多资产",
+  "@enablingTooManyAssetsTitle": {
+    "type": "text"
+  },
+  "encryptingWallet": "錢包加密中",
+  "@encryptingWallet": {
+    "type": "text"
+  },
+  "englishLanguage": "英文",
+  "@englishLanguage": {
+    "type": "text"
+  },
+  "enterNewPinCode": "输入您的新PIN",
+  "@enterNewPinCode": {
+    "type": "text"
+  },
+  "enterOldPinCode": "输入您的旧PIN",
+  "@enterOldPinCode": {
+    "type": "text"
+  },
+  "enterpassword": "继续前请输入密码",
+  "@enterpassword": {
+    "type": "text"
+  },
+  "enterPinCode": "输入您的PIN码",
+  "@enterPinCode": {
+    "type": "text"
+  },
+  "enterSeedPhrase": "输入您的助记词",
+  "@enterSeedPhrase": {
+    "type": "text"
+  },
+  "enterSellAmount": "您必须先输入卖出数量",
+  "@enterSellAmount": {
+    "type": "text"
+  },
+  "errorAmountBalance": "余额不足",
+  "@errorAmountBalance": {
+    "type": "text"
+  },
+  "errorNotAValidAddress": "钱包地址错误",
+  "@errorNotAValidAddress": {
+    "type": "text"
+  },
+  "errorNotAValidAddressSegWit": "尚不支持Segwit地址",
+  "@errorNotAValidAddressSegWit": {
+    "type": "text"
+  },
+  "errorNotEnoughGas": "燃料不足-至少使用｛gas｝Gwei",
+  "@errorNotEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "gas": {}
+    }
+  },
+  "errorTryAgain": "出现错误, 請重试",
+  "@errorTryAgain": {
+    "type": "text"
+  },
+  "errorTryLater": "出现错误，請稍後重试",
+  "@errorTryLater": {
+    "type": "text"
+  },
+  "errorValueEmpty": "价值太高或太低",
+  "@errorValueEmpty": {
+    "type": "text"
+  },
+  "errorValueNotEmpty": "请输入数据",
+  "@errorValueNotEmpty": {
+    "type": "text"
+  },
+  "estimateValue": "预估总价",
+  "@estimateValue": {
+    "type": "text"
+  },
+  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+  "@eulaParagraphe10": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+  "@eulaParagraphe11": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+  "@eulaParagraphe12": {
+    "type": "text"
+  },
+  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+  "@eulaParagraphe13": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+  "@eulaParagraphe14": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+  "@eulaParagraphe15": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+  "@eulaParagraphe16": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+  "@eulaParagraphe17": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+  "@eulaParagraphe18": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+  "@eulaParagraphe19": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+  "@eulaParagraphe2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+  "@eulaParagraphe3": {
+    "type": "text"
+  },
+  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+  "@eulaParagraphe4": {
+    "type": "text"
+  },
+  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+  "@eulaParagraphe5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+  "@eulaParagraphe6": {
+    "type": "text",
+    "placeholders": {
+      "appName": {},
+      "appCompanyLong": {}
+    }
+  },
+  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+  "@eulaParagraphe7": {
+    "type": "text"
+  },
+  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+  "@eulaParagraphe8": {
+    "type": "text"
+  },
+  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+  "@eulaParagraphe9": {
+    "type": "text"
+  },
+  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+  "@eulaTitle1": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "eulaTitle10": "ACCESS AND SECURITY",
+  "@eulaTitle10": {
+    "type": "text"
+  },
+  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+  "@eulaTitle11": {
+    "type": "text"
+  },
+  "eulaTitle12": "DISCLAIMER",
+  "@eulaTitle12": {
+    "type": "text"
+  },
+  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+  "@eulaTitle13": {
+    "type": "text"
+  },
+  "eulaTitle14": "GENERAL RISK FACTORS",
+  "@eulaTitle14": {
+    "type": "text"
+  },
+  "eulaTitle15": "INDEMNIFICATION",
+  "@eulaTitle15": {
+    "type": "text"
+  },
+  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+  "@eulaTitle16": {
+    "type": "text"
+  },
+  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+  "@eulaTitle17": {
+    "type": "text"
+  },
+  "eulaTitle18": "TERMINATION",
+  "@eulaTitle18": {
+    "type": "text"
+  },
+  "eulaTitle19": "THIRD PARTY RIGHTS",
+  "@eulaTitle19": {
+    "type": "text"
+  },
+  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+  "@eulaTitle2": {
+    "type": "text"
+  },
+  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+  "@eulaTitle20": {
+    "type": "text"
+  },
+  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+  "@eulaTitle3": {
+    "type": "text"
+  },
+  "eulaTitle4": "GENERAL USE",
+  "@eulaTitle4": {
+    "type": "text"
+  },
+  "eulaTitle5": "MODIFICATIONS",
+  "@eulaTitle5": {
+    "type": "text"
+  },
+  "eulaTitle6": "LIMITATIONS ON USE",
+  "@eulaTitle6": {
+    "type": "text"
+  },
+  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+  "@eulaTitle7": {
+    "type": "text"
+  },
+  "eulaTitle8": "BACKUPS",
+  "@eulaTitle8": {
+    "type": "text"
+  },
+  "eulaTitle9": "GENERAL WARNING",
+  "@eulaTitle9": {
+    "type": "text"
+  },
+  "exampleHintSeed": "例如：build case level ...",
+  "@exampleHintSeed": {
+    "type": "text"
+  },
+  "exchangeExpedient": "划算的",
+  "@exchangeExpedient": {
+    "type": "text"
+  },
+  "exchangeExpensive": "昂贵的",
+  "@exchangeExpensive": {
+    "type": "text"
+  },
+  "exchangeIdentical": "与CEX相同",
+  "@exchangeIdentical": {
+    "type": "text"
+  },
+  "exchangeRate": "兑换率",
+  "@exchangeRate": {
+    "type": "text"
+  },
+  "exchangeTitle": "兑换",
+  "@exchangeTitle": {
+    "type": "text"
+  },
+  "exportButton": "导出",
+  "@exportButton": {
+    "type": "text"
+  },
+  "exportContactsTitle": "联系人",
+  "@exportContactsTitle": {
+    "type": "text"
+  },
+  "exportDesc": "请选择要导出到加密文件中的项目。",
+  "@exportDesc": {
+    "type": "text"
+  },
+  "exportLink": "导出",
+  "@exportLink": {
+    "type": "text"
+  },
+  "exportNotesTitle": "备注",
+  "@exportNotesTitle": {
+    "type": "text"
+  },
+  "exportSuccessTitle": "项目成功导出",
+  "@exportSuccessTitle": {
+    "type": "text"
+  },
+  "exportSwapsTitle": "交换",
+  "@exportSwapsTitle": {
+    "type": "text"
+  },
+  "exportTitle": "导出",
+  "@exportTitle": {
+    "type": "text"
+  },
+  "Failed": "失败",
+  "@Failed": {
+    "type": "text"
+  },
+  "fakeBalanceAmt": "虚假余额",
+  "@fakeBalanceAmt": {
+    "type": "text"
+  },
+  "faqTitle": "常见问题",
+  "@faqTitle": {
+    "type": "text"
+  },
+  "faucetError": "错误",
+  "@faucetError": {
+    "type": "text"
+  },
+  "faucetInProgress": "正在向 {coin} 水龙头发送请求",
+  "@faucetInProgress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "faucetName": "水龙头",
+  "@faucetName": {
+    "type": "text"
+  },
+  "faucetSuccess": "成功",
+  "@faucetSuccess": {
+    "type": "text"
+  },
+  "faucetTimedOut": "请求超时",
+  "@faucetTimedOut": {
+    "type": "text"
+  },
+  "feedback": "共享日志文件",
+  "@feedback": {
+    "type": "text"
+  },
+  "feedNewsTab": "新闻",
+  "@feedNewsTab": {
+    "type": "text"
+  },
+  "feedNotFound": "无内容",
+  "@feedNotFound": {
+    "type": "text"
+  },
+  "feedNotifTitle": "{appCompanyShort} 新闻",
+  "@feedNotifTitle": {
+    "type": "text",
+    "placeholders": {
+      "appCompanyShort": {}
+    }
+  },
+  "feedReadMore": "阅读更多",
+  "@feedReadMore": {
+    "type": "text"
+  },
+  "feedTab": "Feed",
+  "@feedTab": {
+    "type": "text"
+  },
+  "feedTitle": "Feed新闻",
+  "@feedTitle": {
+    "type": "text"
+  },
+  "feedUnableToProceed": "无法继续更新新闻",
+  "@feedUnableToProceed": {
+    "type": "text"
+  },
+  "feedUnableToUpdate": "无法获取新闻更新",
+  "@feedUnableToUpdate": {
+    "type": "text"
+  },
+  "feedUpdated": "Feed新闻已更新",
+  "@feedUpdated": {
+    "type": "text"
+  },
+  "feedUpToDate": "已更新",
+  "@feedUpToDate": {
+    "type": "text"
+  },
+  "feesError": "费用必须高达 {value}",
+  "@feesError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "filtersAll": "全部",
+  "@filtersAll": {
+    "type": "text"
+  },
+  "filtersButton": "过滤器",
+  "@filtersButton": {
+    "type": "text"
+  },
+  "filtersClearAll": "清除所有过滤器",
+  "@filtersClearAll": {
+    "type": "text"
+  },
+  "filtersFailed": "失败",
+  "@filtersFailed": {
+    "type": "text"
+  },
+  "filtersFrom": "起始日期",
+  "@filtersFrom": {
+    "type": "text"
+  },
+  "filtersMaker": "挂单",
+  "@filtersMaker": {
+    "type": "text"
+  },
+  "filtersReceive": "接收货币",
+  "@filtersReceive": {
+    "type": "text"
+  },
+  "filtersSell": "出售货币",
+  "@filtersSell": {
+    "type": "text"
+  },
+  "filtersStatus": "状态",
+  "@filtersStatus": {
+    "type": "text"
+  },
+  "filtersSuccessful": "成功",
+  "@filtersSuccessful": {
+    "type": "text"
+  },
+  "filtersTaker": "吃单",
+  "@filtersTaker": {
+    "type": "text"
+  },
+  "filtersTo": "截止日期",
+  "@filtersTo": {
+    "type": "text"
+  },
+  "filtersType": "吃单/挂单",
+  "@filtersType": {
+    "type": "text"
+  },
+  "fingerprint": "指纹",
+  "@fingerprint": {
+    "type": "text"
+  },
+  "finishingUp": "已完成，请稍候",
+  "@finishingUp": {
+    "type": "text"
+  },
+  "foundQrCode": "找到二维码",
+  "@foundQrCode": {
+    "type": "text"
+  },
+  "frenchLanguage": "法语",
+  "@frenchLanguage": {
+    "type": "text"
+  },
+  "from": "起始日期",
+  "@from": {
+    "type": "text"
+  },
+  "futureTransactions": "我们将同步与您的公钥关联的激活后进行的未来交易。这是最快的选项，占用的存储空间最少。",
+  "@futureTransactions": {
+    "type": "text"
+  },
+  "gasFee": "{coin} 费用",
+  "@gasFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasLimit": "燃料上限",
+  "@gasLimit": {
+    "type": "text"
+  },
+  "gasNotActive": "请激活{coin}.",
+  "@gasNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "gasPrice": "燃料价格",
+  "@gasPrice": {
+    "type": "text"
+  },
+  "generalPinNotActive": "常规PIN保护未激活。\n伪装模式将失效\n请激活PIN保护",
+  "@generalPinNotActive": {
+    "type": "text"
+  },
+  "getBackupPhrase": "重要提醒: 請在繼續之前備份助記詞 !",
+  "@getBackupPhrase": {
+    "type": "text"
+  },
+  "gettingTxWait": "正在获取交易，请稍候",
+  "@gettingTxWait": {
+    "type": "text"
+  },
+  "goToPorfolio": "前往投资组合",
+  "@goToPorfolio": {
+    "type": "text"
+  },
+  "gweiError": "Gwei 必须达到 {value}",
+  "@gweiError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "helpLink": "帮助",
+  "@helpLink": {
+    "type": "text"
+  },
+  "helpTitle": "帮助和支持",
+  "@helpTitle": {
+    "type": "text"
+  },
+  "hideBalance": "隐藏余额",
+  "@hideBalance": {
+    "type": "text"
+  },
+  "hintConfirmPassword": "确认密码",
+  "@hintConfirmPassword": {
+    "type": "text"
+  },
+  "hintCreatePassword": "创建密码",
+  "@hintCreatePassword": {
+    "type": "text"
+  },
+  "hintCurrentPassword": "当前密码",
+  "@hintCurrentPassword": {
+    "type": "text"
+  },
+  "hintEnterPassword": "请输入您的密码",
+  "@hintEnterPassword": {
+    "type": "text"
+  },
+  "hintEnterSeedPhrase": "请输入您的助记词",
+  "@hintEnterSeedPhrase": {
+    "type": "text"
+  },
+  "hintNameYourWallet": "命名您的钱包",
+  "@hintNameYourWallet": {
+    "type": "text"
+  },
+  "hintPassword": "密码",
+  "@hintPassword": {
+    "type": "text"
+  },
+  "history": "历史记录",
+  "@history": {
+    "type": "text"
+  },
+  "hours": "小时",
+  "@hours": {
+    "type": "text"
+  },
+  "hungarianLanguage": "匈牙利语",
+  "@hungarianLanguage": {
+    "type": "text"
+  },
+  "importButton": "导入",
+  "@importButton": {
+    "type": "text"
+  },
+  "importDecryptError": "密码无效或数据损坏",
+  "@importDecryptError": {
+    "type": "text"
+  },
+  "importDesc": "要导入的项目：",
+  "@importDesc": {
+    "type": "text"
+  },
+  "importFileNotFound": "找不到文件",
+  "@importFileNotFound": {
+    "type": "text"
+  },
+  "importInvalidSwapData": "交换数据无效。请提供有效的交换状态JSON文件。",
+  "@importInvalidSwapData": {
+    "type": "text"
+  },
+  "importLink": "导入",
+  "@importLink": {
+    "type": "text"
+  },
+  "importLoadDesc": "请选择要导入的加密文件。",
+  "@importLoadDesc": {
+    "type": "text"
+  },
+  "importLoading": "开始",
+  "@importLoading": {
+    "type": "text"
+  },
+  "importLoadSwapDesc": "请选择要导入的纯文本交换文件。",
+  "@importLoadSwapDesc": {
+    "type": "text"
+  },
+  "importPassCancel": "取消",
+  "@importPassCancel": {
+    "type": "text"
+  },
+  "importPassOk": "好的",
+  "@importPassOk": {
+    "type": "text"
+  },
+  "importPassword": "密码",
+  "@importPassword": {
+    "type": "text"
+  },
+  "importSingleSwapLink": "导入单个交换",
+  "@importSingleSwapLink": {
+    "type": "text"
+  },
+  "importSingleSwapTitle": "导入交换",
+  "@importSingleSwapTitle": {
+    "type": "text"
+  },
+  "importSomeItemsSkippedWarning": "已跳过某些项目",
+  "@importSomeItemsSkippedWarning": {
+    "type": "text"
+  },
+  "importSuccessTitle": "已成功导入项目：",
+  "@importSuccessTitle": {
+    "type": "text"
+  },
+  "importSwapFailed": "无法导入交换",
+  "@importSwapFailed": {
+    "type": "text"
+  },
+  "importSwapJsonDecodingError": "解码json文件时出错",
+  "@importSwapJsonDecodingError": {
+    "type": "text"
+  },
+  "importTitle": "导入",
+  "@importTitle": {
+    "type": "text"
+  },
+  "incomingTransactionsProtectionSettings": "传入 {coinName} 交易保护设置",
+  "@incomingTransactionsProtectionSettings": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "infoPasswordDialog": "使用安全密码，不要将其存储在同一设备上",
+  "@infoPasswordDialog": {
+    "type": "text"
+  },
+  "infoTrade1": "無法撤銷交换请求！",
+  "@infoTrade1": {
+    "type": "text"
+  },
+  "infoTrade2": "交换最长需要60分钟。不要关闭此应用程序！",
+  "@infoTrade2": {
+    "type": "text"
+  },
+  "infoWalletPassword": "安全起见，您必须为加密钱包设置密码。",
+  "@infoWalletPassword": {
+    "type": "text"
+  },
+  "insufficientBalanceToPay": "{abbr}余额不足以支付交易费",
+  "@insufficientBalanceToPay": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "insufficientText": "此订单最小交易量为",
+  "@insufficientText": {
+    "type": "text"
+  },
+  "insufficientTitle": "交易量不足",
+  "@insufficientTitle": {
+    "type": "text"
+  },
+  "internetRefreshButton": "刷新",
+  "@internetRefreshButton": {
+    "type": "text"
+  },
+  "internetRestored": "已重新连接互联网",
+  "@internetRestored": {
+    "type": "text"
+  },
+  "invalidCoinAddress": "{coin} 地址无效",
+  "@invalidCoinAddress": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "invalidSwap": "无法继续交换",
+  "@invalidSwap": {
+    "type": "text"
+  },
+  "invalidSwapDetailsLink": "详细信息",
+  "@invalidSwapDetailsLink": {
+    "type": "text"
+  },
+  "isUnavailable": "{coinAbbr} 不可用:(",
+  "@isUnavailable": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "iUnderstand": "我已了解",
+  "@iUnderstand": {
+    "type": "text"
+  },
+  "japaneseLanguage": "日文",
+  "@japaneseLanguage": {
+    "type": "text"
+  },
+  "koreanLanguage": "韩国人",
+  "@koreanLanguage": {
+    "type": "text"
+  },
+  "language": "语言",
+  "@language": {
+    "type": "text"
+  },
+  "latestTxs": "最新交易",
+  "@latestTxs": {
+    "type": "text"
+  },
+  "legalTitle": "合法的",
+  "@legalTitle": {
+    "type": "text"
+  },
+  "less": "较少",
+  "@less": {
+    "type": "text"
+  },
+  "lessThanCaution": "❗注意！ {coinName} 市场的 24 小时交易量不到 1 万美元！",
+  "@lessThanCaution": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "limitError": "限制必须达到 {value}",
+  "@limitError": {
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "loading": "載入中",
+  "@loading": {
+    "type": "text"
+  },
+  "loadingOrderbook": "正在加载订单记录",
+  "@loadingOrderbook": {
+    "type": "text"
+  },
+  "lockScreen": "屏幕已锁定",
+  "@lockScreen": {
+    "type": "text"
+  },
+  "lockScreenAuth": "请验证！",
+  "@lockScreenAuth": {
+    "type": "text"
+  },
+  "login": "登录",
+  "@login": {
+    "type": "text"
+  },
+  "logout": "注销",
+  "@logout": {
+    "type": "text"
+  },
+  "logoutOnExit": "退出时注销",
+  "@logoutOnExit": {
+    "type": "text"
+  },
+  "logoutsettings": "注销设置",
+  "@logoutsettings": {
+    "type": "text"
+  },
+  "logoutWarning": "您确定要立即注销吗？",
+  "@logoutWarning": {
+    "type": "text"
+  },
+  "longMinutes": "分钟",
+  "@longMinutes": {
+    "type": "text"
+  },
+  "makeAorder": "下订单",
+  "@makeAorder": {
+    "type": "text"
+  },
+  "Maker": "挂单",
+  "@Maker": {
+    "type": "text"
+  },
+  "makerDetailsCancel": "取消订单",
+  "@makerDetailsCancel": {
+    "type": "text"
+  },
+  "makerDetailsCreated": "创建",
+  "@makerDetailsCreated": {
+    "type": "text"
+  },
+  "makerDetailsFor": "接收",
+  "@makerDetailsFor": {
+    "type": "text"
+  },
+  "makerDetailsId": "订单ID",
+  "@makerDetailsId": {
+    "type": "text"
+  },
+  "makerDetailsNoSwaps": "此订单未启动交换",
+  "@makerDetailsNoSwaps": {
+    "type": "text"
+  },
+  "makerDetailsPrice": "价格",
+  "@makerDetailsPrice": {
+    "type": "text"
+  },
+  "makerDetailsSell": "卖出",
+  "@makerDetailsSell": {
+    "type": "text"
+  },
+  "makerDetailsSwaps": "此订单开始交换",
+  "@makerDetailsSwaps": {
+    "type": "text"
+  },
+  "makerDetailsTitle": "挂单交易详细信息",
+  "@makerDetailsTitle": {
+    "type": "text"
+  },
+  "makerOrder": "挂单交易",
+  "@makerOrder": {
+    "type": "text"
+  },
+  "marketplace": "市场",
+  "@marketplace": {
+    "type": "text"
+  },
+  "marketsChart": "图表",
+  "@marketsChart": {
+    "type": "text"
+  },
+  "marketsDepth": "交易深度",
+  "@marketsDepth": {
+    "type": "text"
+  },
+  "marketsNoAsks": "未找到问题",
+  "@marketsNoAsks": {
+    "type": "text"
+  },
+  "marketsNoBids": "未找到出价",
+  "@marketsNoBids": {
+    "type": "text"
+  },
+  "marketsOrderbook": "订单记录",
+  "@marketsOrderbook": {
+    "type": "text"
+  },
+  "marketsOrderDetails": "订单详细信息",
+  "@marketsOrderDetails": {
+    "type": "text"
+  },
+  "marketsPrice": "价格",
+  "@marketsPrice": {
+    "type": "text"
+  },
+  "marketsSelectCoins": "请选择货币",
+  "@marketsSelectCoins": {
+    "type": "text"
+  },
+  "marketsTab": "市场",
+  "@marketsTab": {
+    "type": "text"
+  },
+  "marketsTitle": "市场",
+  "@marketsTitle": {
+    "type": "text"
+  },
+  "matchExportPass": "密码必须匹配",
+  "@matchExportPass": {
+    "type": "text"
+  },
+  "matchingCamoChange": "改变",
+  "@matchingCamoChange": {
+    "type": "text"
+  },
+  "matchingCamoPinError": "您的通用PIN码和伪装PIN码相同。伪装模式将不可用。请更改伪装PIN",
+  "@matchingCamoPinError": {
+    "type": "text"
+  },
+  "matchingCamoTitle": "无效PIN",
+  "@matchingCamoTitle": {
+    "type": "text"
+  },
+  "max": "最大",
+  "@max": {
+    "type": "text"
+  },
+  "maxOrder": "最大交易量",
+  "@maxOrder": {
+    "type": "text"
+  },
+  "media": "消息",
+  "@media": {
+    "type": "text"
+  },
+  "mediaBrowse": "浏览",
+  "@mediaBrowse": {
+    "type": "text"
+  },
+  "mediaBrowseFeed": "浏览Feed",
+  "@mediaBrowseFeed": {
+    "type": "text"
+  },
+  "mediaBy": "通过",
+  "@mediaBy": {
+    "type": "text"
+  },
+  "mediaNotSavedDescription": "您没有收藏的文章",
+  "@mediaNotSavedDescription": {
+    "type": "text"
+  },
+  "mediaSaved": "已收藏",
+  "@mediaSaved": {
+    "type": "text"
+  },
+  "memo": "备忘录",
+  "@memo": {
+    "type": "text"
+  },
+  "merge": "合并",
+  "@merge": {
+    "type": "text"
+  },
+  "mergedValue": "合并值",
+  "@mergedValue": {
+    "type": "text"
+  },
+  "milliseconds": "毫秒",
+  "@milliseconds": {
+    "type": "text"
+  },
+  "min": "最小",
+  "@min": {
+    "type": "text"
+  },
+  "minimizingWillTerminate": "警告：最小化 iOS 上的应用程序将终止激活过程。",
+  "@minimizingWillTerminate": {
+    "type": "text"
+  },
+  "minOrder": "最小交易量",
+  "@minOrder": {
+    "type": "text"
+  },
+  "minutes": "分钟",
+  "@minutes": {
+    "type": "text"
+  },
+  "minValue": "最低售出量为{number} {coinName}",
+  "@minValue": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueBuy": "最低买入量为{number} {coinName}",
+  "@minValueBuy": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minValueOrder": "最小交易量为 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
+  "@minValueOrder": {
+    "type": "text",
+    "placeholders": {
+      "buyCoin": {},
+      "buyAmount": {},
+      "sellCoin": {},
+      "sellAmount": {}
+    }
+  },
+  "minValueSell": "最低售出量为 {number} {coinName}",
+  "@minValueSell": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "number": {}
+    }
+  },
+  "minVolumeInput": "必须大于{minValue} {coin}",
+  "@minVolumeInput": {
+    "type": "text",
+    "placeholders": {
+      "minValue": {},
+      "coin": {}
+    }
+  },
+  "minVolumeIsTDH": "必须低于售出量",
+  "@minVolumeIsTDH": {
+    "type": "text"
+  },
+  "minVolumeTitle": "所需最小量",
+  "@minVolumeTitle": {
+    "type": "text"
+  },
+  "minVolumeToggle": "使用自定义最小量",
+  "@minVolumeToggle": {
+    "type": "text"
+  },
+  "mobileDataWarning": "请注意，您现在正在使用流量，使用{appName} P2P网络会消耗互联网流量。如果您的手机流量很贵，最好连接WIFI。",
+  "@mobileDataWarning": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "moreInfo": "更多信息",
+  "@moreInfo": {
+    "type": "text"
+  },
+  "moreTab": "更多",
+  "@moreTab": {
+    "type": "text"
+  },
+  "multiActivateGas": "先激活{coin}并充值余额",
+  "@multiActivateGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiBaseAmtPlaceholder": "数量",
+  "@multiBaseAmtPlaceholder": {
+    "type": "text"
+  },
+  "multiBasePlaceholder": "货币",
+  "@multiBasePlaceholder": {
+    "type": "text"
+  },
+  "multiBaseSelectTitle": "卖出",
+  "@multiBaseSelectTitle": {
+    "type": "text"
+  },
+  "multiConfirmCancel": "取消",
+  "@multiConfirmCancel": {
+    "type": "text"
+  },
+  "multiConfirmConfirm": "确认",
+  "@multiConfirmConfirm": {
+    "type": "text"
+  },
+  "multiConfirmTitle": "创建{number}订单：",
+  "@multiConfirmTitle": {
+    "type": "text",
+    "placeholders": {
+      "number": {}
+    }
+  },
+  "multiCreate": "创建",
+  "@multiCreate": {
+    "type": "text"
+  },
+  "multiCreateOrder": "订单",
+  "@multiCreateOrder": {
+    "type": "text"
+  },
+  "multiCreateOrders": "订单",
+  "@multiCreateOrders": {
+    "type": "text"
+  },
+  "multiEthFee": "费用",
+  "@multiEthFee": {
+    "type": "text"
+  },
+  "multiFiatCancel": "取消",
+  "@multiFiatCancel": {
+    "type": "text"
+  },
+  "multiFiatDesc": "请输入要接收的法币数量",
+  "@multiFiatDesc": {
+    "type": "text"
+  },
+  "multiFiatFill": "自动填充",
+  "@multiFiatFill": {
+    "type": "text"
+  },
+  "multiFixErrors": "请在继续之前修复所有错误",
+  "@multiFixErrors": {
+    "type": "text"
+  },
+  "multiInvalidAmt": "数量无效",
+  "@multiInvalidAmt": {
+    "type": "text"
+  },
+  "multiInvalidSellAmt": "售出量无效",
+  "@multiInvalidSellAmt": {
+    "type": "text"
+  },
+  "multiLowerThanFee": "{coin}不足支付。最低余额为 {fee} {coin}",
+  "@multiLowerThanFee": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "fee": {}
+    }
+  },
+  "multiLowGas": "{coin}余额过低",
+  "@multiLowGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "multiMaxSellAmt": "最大售出量为",
+  "@multiMaxSellAmt": {
+    "type": "text"
+  },
+  "multiMinReceiveAmt": "最小接收量为",
+  "@multiMinReceiveAmt": {
+    "type": "text"
+  },
+  "multiMinSellAmt": "最小售出量为",
+  "@multiMinSellAmt": {
+    "type": "text"
+  },
+  "multiReceiveTitle": "接收：",
+  "@multiReceiveTitle": {
+    "type": "text"
+  },
+  "multiSellTitle": "卖出",
+  "@multiSellTitle": {
+    "type": "text"
+  },
+  "multiTab": "多个",
+  "@multiTab": {
+    "type": "text"
+  },
+  "multiTableAmt": "接收量",
+  "@multiTableAmt": {
+    "type": "text"
+  },
+  "multiTablePrice": "价格/CEX",
+  "@multiTablePrice": {
+    "type": "text"
+  },
+  "networkFee": "网络费用",
+  "@networkFee": {
+    "type": "text"
+  },
+  "newAccount": "新帳戶",
+  "@newAccount": {
+    "type": "text"
+  },
+  "newAccountUpper": "新帳戶",
+  "@newAccountUpper": {
+    "type": "text"
+  },
+  "newsFeed": "Feed新闻",
+  "@newsFeed": {
+    "type": "text"
+  },
+  "newValue": "新价值",
+  "@newValue": {
+    "type": "text"
+  },
+  "next": "继续",
+  "@next": {
+    "type": "text"
+  },
+  "no": "不",
+  "@no": {
+    "type": "text"
+  },
+  "noArticles": "没有新闻-请稍后再查看",
+  "@noArticles": {
+    "type": "text"
+  },
+  "noCoinFound": "未找到货币",
+  "@noCoinFound": {
+    "type": "text"
+  },
+  "noFunds": "无基金",
+  "@noFunds": {
+    "type": "text"
+  },
+  "noFundsDetected": "没有可用基金-请先存入",
+  "@noFundsDetected": {
+    "type": "text"
+  },
+  "noInternet": "无互联网连接",
+  "@noInternet": {
+    "type": "text"
+  },
+  "noItemsToExport": "未选择项目",
+  "@noItemsToExport": {
+    "type": "text"
+  },
+  "noItemsToImport": "未选择项目",
+  "@noItemsToImport": {
+    "type": "text"
+  },
+  "noMatchingOrders": "无匹配订单",
+  "@noMatchingOrders": {
+    "type": "text"
+  },
+  "none": "没有任何",
+  "@none": {
+    "type": "text"
+  },
+  "nonNumericInput": "该值必须是数字",
+  "@nonNumericInput": {
+    "type": "text"
+  },
+  "noOrder": "请输入 {coinName} 量",
+  "@noOrder": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {}
+    }
+  },
+  "noOrderAvailable": "点击创建订单",
+  "@noOrderAvailable": {
+    "type": "text"
+  },
+  "noOrders": "没有订单，请先交易",
+  "@noOrders": {
+    "type": "text"
+  },
+  "noRewards": "没有奖励可领取",
+  "@noRewards": {
+    "type": "text"
+  },
+  "noRewardYet": "没有奖励可领取-请一小时后重试",
+  "@noRewardYet": {
+    "type": "text"
+  },
+  "noSuchCoin": "没有该货币",
+  "@noSuchCoin": {
+    "type": "text"
+  },
+  "noSwaps": "没有历史记录",
+  "@noSwaps": {
+    "type": "text"
+  },
+  "notEnoughGas": "没有足够的{coin} 用于交易！",
+  "@notEnoughGas": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notEnoughtBalanceForFee": "手续费余额不足-减少交易量",
+  "@notEnoughtBalanceForFee": {
+    "type": "text"
+  },
+  "noteOnOrder": "备注：不能取消已匹配的订单",
+  "@noteOnOrder": {
+    "type": "text"
+  },
+  "notePlaceholder": "添加备注",
+  "@notePlaceholder": {
+    "type": "text"
+  },
+  "noteTitle": "备注",
+  "@noteTitle": {
+    "type": "text"
+  },
+  "nothingFound": "无内容",
+  "@nothingFound": {
+    "type": "text"
+  },
+  "notifSwapCompletedText": "{sell}/{buy} 已成功完成交换",
+  "@notifSwapCompletedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapCompletedTitle": "交换已完成",
+  "@notifSwapCompletedTitle": {
+    "type": "text"
+  },
+  "notifSwapFailedText": "{sell}/{buy}交换失败",
+  "@notifSwapFailedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapFailedTitle": "交换失败",
+  "@notifSwapFailedTitle": {
+    "type": "text"
+  },
+  "notifSwapStartedText": "{sell}/{buy}交换开始",
+  "@notifSwapStartedText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapStartedTitle": "已开始新交换",
+  "@notifSwapStartedTitle": {
+    "type": "text"
+  },
+  "notifSwapStatusTitle": "交换状态已更改",
+  "@notifSwapStatusTitle": {
+    "type": "text"
+  },
+  "notifSwapTimeoutText": "{sell}/{buy}交换超时",
+  "@notifSwapTimeoutText": {
+    "type": "text",
+    "placeholders": {
+      "sell": {},
+      "buy": {}
+    }
+  },
+  "notifSwapTimeoutTitle": "交换超时",
+  "@notifSwapTimeoutTitle": {
+    "type": "text"
+  },
+  "notifTxText": "您已收到｛coin｝交易！",
+  "@notifTxText": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "notifTxTitle": "应记交易",
+  "@notifTxTitle": {
+    "type": "text"
+  },
+  "noTxs": "没有交易",
+  "@noTxs": {
+    "type": "text"
+  },
+  "numberAssets": "{assets} 资产",
+  "@numberAssets": {
+    "type": "text",
+    "placeholders": {
+      "assets": {}
+    }
+  },
+  "officialPressRelease": "官方新闻稿",
+  "@officialPressRelease": {
+    "type": "text"
+  },
+  "okButton": "好的",
+  "@okButton": {
+    "type": "text"
+  },
+  "oldLogsDelete": "删除",
+  "@oldLogsDelete": {
+    "type": "text"
+  },
+  "oldLogsTitle": "历史记录",
+  "@oldLogsTitle": {
+    "type": "text"
+  },
+  "oldLogsUsed": "占用的空间",
+  "@oldLogsUsed": {
+    "type": "text"
+  },
+  "openMessage": "打开错误消息",
+  "@openMessage": {
+    "type": "text"
+  },
+  "Optional": "选修的",
+  "@Optional": {
+    "type": "text"
+  },
+  "orderBookLess": "较少的",
+  "@orderBookLess": {
+    "type": "text"
+  },
+  "orderBookMore": "更多的",
+  "@orderBookMore": {
+    "type": "text"
+  },
+  "orderCancel": "所有{coin}订单将被取消。",
+  "@orderCancel": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderCreated": "订单已创建",
+  "@orderCreated": {
+    "type": "text"
+  },
+  "orderCreatedInfo": "订单已成功创建",
+  "@orderCreatedInfo": {
+    "type": "text"
+  },
+  "orderDetailsAddress": "地址",
+  "@orderDetailsAddress": {
+    "type": "text"
+  },
+  "orderDetailsCancel": "取消",
+  "@orderDetailsCancel": {
+    "type": "text"
+  },
+  "orderDetailsExpedient": "划算的: CEX +{delta}%",
+  "@orderDetailsExpedient": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsExpensive": "昂贵的: CEX {delta}%",
+  "@orderDetailsExpensive": {
+    "type": "text",
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "orderDetailsFor": "与",
+  "@orderDetailsFor": {
+    "type": "text"
+  },
+  "orderDetailsIdentical": "CEX相同",
+  "@orderDetailsIdentical": {
+    "type": "text"
+  },
+  "orderDetailsMin": "最小量",
+  "@orderDetailsMin": {
+    "type": "text"
+  },
+  "orderDetailsPrice": "价格",
+  "@orderDetailsPrice": {
+    "type": "text"
+  },
+  "orderDetailsReceive": "接收",
+  "@orderDetailsReceive": {
+    "type": "text"
+  },
+  "orderDetailsSelect": "选择",
+  "@orderDetailsSelect": {
+    "type": "text"
+  },
+  "orderDetailsSells": "卖出",
+  "@orderDetailsSells": {
+    "type": "text"
+  },
+  "orderDetailsSettings": "单击打开详细信息，然后长按选择订购",
+  "@orderDetailsSettings": {
+    "type": "text"
+  },
+  "orderDetailsSpend": "花费",
+  "@orderDetailsSpend": {
+    "type": "text"
+  },
+  "orderDetailsTitle": "详细信息",
+  "@orderDetailsTitle": {
+    "type": "text"
+  },
+  "orderFilled": "{fill}%已填充",
+  "@orderFilled": {
+    "type": "text",
+    "placeholders": {
+      "fill": {}
+    }
+  },
+  "orderMatched": "已匹配订单",
+  "@orderMatched": {
+    "type": "text"
+  },
+  "orderMatching": "订单匹配中",
+  "@orderMatching": {
+    "type": "text"
+  },
+  "orders": "订单",
+  "@orders": {
+    "type": "text"
+  },
+  "ordersActive": "活跃",
+  "@ordersActive": {
+    "type": "text"
+  },
+  "ordersHistory": "历史记录",
+  "@ordersHistory": {
+    "type": "text"
+  },
+  "ordersTableAmount": "数量({coin})",
+  "@ordersTableAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTablePrice": "价格 ({coin})",
+  "@ordersTablePrice": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "ordersTableTotal": "总计 ({coin})",
+  "@ordersTableTotal": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "orderTypePartial": "订单",
+  "@orderTypePartial": {
+    "type": "text"
+  },
+  "orderTypeUnknown": "未知类型订单",
+  "@orderTypeUnknown": {
+    "type": "text"
+  },
+  "overwrite": "覆盖",
+  "@overwrite": {
+    "type": "text"
+  },
+  "ownOrder": "这是您个人的订单",
+  "@ownOrder": {
+    "type": "text"
+  },
+  "paidFromBalance": "用余额支付：",
+  "@paidFromBalance": {
+    "type": "text"
+  },
+  "paidFromVolume": "用已接收的交易量支付",
+  "@paidFromVolume": {
+    "type": "text"
+  },
+  "paidWith": "支付方式：",
+  "@paidWith": {
+    "type": "text"
+  },
+  "passwordRequirement": "密码必须至少包含12个字符，包括一个小写、一个大写和一个特殊符号",
+  "@passwordRequirement": {
+    "type": "text"
+  },
+  "pastTransactionsFromDate": "您的钱包将显示您过去在指定日期之后进行的交易。",
+  "@pastTransactionsFromDate": {
+    "type": "text"
+  },
+  "paymentUriDetailsAccept": "支付",
+  "@paymentUriDetailsAccept": {
+    "type": "text"
+  },
+  "paymentUriDetailsAcceptQuestion": "您接受这笔交易吗？",
+  "@paymentUriDetailsAcceptQuestion": {
+    "type": "text"
+  },
+  "paymentUriDetailsAddressSpan": "接收方地址",
+  "@paymentUriDetailsAddressSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsAmountSpan": "数量：",
+  "@paymentUriDetailsAmountSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsCoinSpan": "货币：",
+  "@paymentUriDetailsCoinSpan": {
+    "type": "text"
+  },
+  "paymentUriDetailsDeny": "取消",
+  "@paymentUriDetailsDeny": {
+    "type": "text"
+  },
+  "paymentUriDetailsTitle": "已请求的付款",
+  "@paymentUriDetailsTitle": {
+    "type": "text"
+  },
+  "paymentUriInactiveCoin": "{abbr} 未激活。请激活后重试。",
+  "@paymentUriInactiveCoin": {
+    "type": "text",
+    "placeholders": {
+      "abbr": {}
+    }
+  },
+  "placeOrder": "下单",
+  "@placeOrder": {
+    "type": "text"
+  },
+  "Play at full volume": "音量开到最大",
+  "@Play at full volume": {
+    "type": "text"
+  },
+  "pleaseAddCoin": "请添加货币",
+  "@pleaseAddCoin": {
+    "type": "text"
+  },
+  "pleaseRestart": "请重启应用程序后重试，或按下面的按钮。",
+  "@pleaseRestart": {
+    "type": "text"
+  },
+  "portfolio": "投资组合",
+  "@portfolio": {
+    "type": "text"
+  },
+  "poweredOnKmd": "由Komodo支持",
+  "@poweredOnKmd": {
+    "type": "text"
+  },
+  "price": "价格",
+  "@price": {
+    "type": "text"
+  },
+  "privateKey": "私钥",
+  "@privateKey": {
+    "type": "text"
+  },
+  "privateKeys": "私钥",
+  "@privateKeys": {
+    "type": "text"
+  },
+  "protectionCtrlConfirmations": "确认",
+  "@protectionCtrlConfirmations": {
+    "type": "text"
+  },
+  "protectionCtrlCustom": "使用自定义保护设置",
+  "@protectionCtrlCustom": {
+    "type": "text"
+  },
+  "protectionCtrlOff": "关闭",
+  "@protectionCtrlOff": {
+    "type": "text"
+  },
+  "protectionCtrlOn": "开启",
+  "@protectionCtrlOn": {
+    "type": "text"
+  },
+  "protectionCtrlWarning": "警告，此原子交换不受dPoW保护。",
+  "@protectionCtrlWarning": {
+    "type": "text"
+  },
+  "pubkey": "公钥",
+  "@pubkey": {
+    "type": "text"
+  },
+  "qrCodeScanner": "二维码扫描仪",
+  "@qrCodeScanner": {
+    "type": "text"
+  },
+  "question_1": "你们会保存我的私钥吗？",
+  "@question_1": {
+    "type": "text"
+  },
+  "question_10": "我可以在哪些设备上使用{appName} ？",
+  "@question_10": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_2": "在{appName} 上交易与在其他DEX上交易有何不同？",
+  "@question_2": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_3": "每次原子交换需要多长时间？",
+  "@question_3": {
+    "type": "text"
+  },
+  "question_4": "在交换期间我要保持在线吗",
+  "@question_4": {
+    "type": "text"
+  },
+  "question_5": "{appName} 的费用如何计算？",
+  "@question_5": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_6": "你们会提供用户支持吗？",
+  "@question_6": {
+    "type": "text"
+  },
+  "question_7": "你们有地区限制吗？",
+  "@question_7": {
+    "type": "text"
+  },
+  "question_8": "{appName} 的背后是谁？",
+  "@question_8": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "question_9": "是否可以在{appName} 上开发我个人的白标交换？",
+  "@question_9": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "rebrandingAnnouncement": "这是一个新时代！我们已正式将名称从“AtomicDEX”更改为“Komodo Wallet”",
+  "@rebrandingAnnouncement": {
+    "type": "text"
+  },
+  "receive": "接收",
+  "@receive": {
+    "type": "text"
+  },
+  "receiveLower": "接收",
+  "@receiveLower": {
+    "type": "text"
+  },
+  "recommendSeedMessage": "我们建议在线下存档。",
+  "@recommendSeedMessage": {
+    "type": "text"
+  },
+  "remove": "停用",
+  "@remove": {
+    "type": "text"
+  },
+  "requestedTrade": "已请求的交易",
+  "@requestedTrade": {
+    "type": "text"
+  },
+  "reset": "清除",
+  "@reset": {
+    "type": "text"
+  },
+  "resetTitle": "重置表格",
+  "@resetTitle": {
+    "type": "text"
+  },
+  "restoreWallet": "恢复",
+  "@restoreWallet": {
+    "type": "text"
+  },
+  "retryActivating": "正在重试激活所有货币",
+  "@retryActivating": {
+    "type": "text"
+  },
+  "retryAll": "重试激活所有",
+  "@retryAll": {
+    "type": "text"
+  },
+  "rewardsButton": "领取奖励",
+  "@rewardsButton": {
+    "type": "text"
+  },
+  "rewardsCancel": "取消",
+  "@rewardsCancel": {
+    "type": "text"
+  },
+  "rewardsError": "出现错误。请稍后再试。",
+  "@rewardsError": {
+    "type": "text"
+  },
+  "rewardsInProgressLong": "交易正在进行",
+  "@rewardsInProgressLong": {
+    "type": "text"
+  },
+  "rewardsInProgressShort": "处理",
+  "@rewardsInProgressShort": {
+    "type": "text"
+  },
+  "rewardsLowAmountLong": "UTXO金额小于10 KMD",
+  "@rewardsLowAmountLong": {
+    "type": "text"
+  },
+  "rewardsLowAmountShort": "<10KMD",
+  "@rewardsLowAmountShort": {
+    "type": "text"
+  },
+  "rewardsOneHourLong": "还未过去一小时",
+  "@rewardsOneHourLong": {
+    "type": "text"
+  },
+  "rewardsOneHourShort": "<1小时",
+  "@rewardsOneHourShort": {
+    "type": "text"
+  },
+  "rewardsPopupOk": "好的",
+  "@rewardsPopupOk": {
+    "type": "text"
+  },
+  "rewardsPopupTitle": "奖励状态：",
+  "@rewardsPopupTitle": {
+    "type": "text"
+  },
+  "rewardsReadMore": "阅读有关KMD活跃用户奖励的更多信息",
+  "@rewardsReadMore": {
+    "type": "text"
+  },
+  "rewardsReceive": "接收",
+  "@rewardsReceive": {
+    "type": "text"
+  },
+  "rewardsSuccess": "成功！收到 {amount}KMD",
+  "@rewardsSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "rewardsTableFiat": "法币",
+  "@rewardsTableFiat": {
+    "type": "text"
+  },
+  "rewardsTableRewards": "奖励，KMD",
+  "@rewardsTableRewards": {
+    "type": "text"
+  },
+  "rewardsTableStatus": "状态",
+  "@rewardsTableStatus": {
+    "type": "text"
+  },
+  "rewardsTableTime": "剩余时间",
+  "@rewardsTableTime": {
+    "type": "text"
+  },
+  "rewardsTableTitle": "奖励信息",
+  "@rewardsTableTitle": {
+    "type": "text"
+  },
+  "rewardsTableUXTO": "UTXO 数量\nKMD",
+  "@rewardsTableUXTO": {
+    "type": "text"
+  },
+  "rewardsTimeDays": "{dd} 天",
+  "@rewardsTimeDays": {
+    "type": "text",
+    "placeholders": {
+      "dd": {}
+    }
+  },
+  "rewardsTimeHours": "{hh}小时 {minutes}分钟",
+  "@rewardsTimeHours": {
+    "type": "text",
+    "placeholders": {
+      "hh": {},
+      "minutes": {}
+    }
+  },
+  "rewardsTimeMin": "{mm}分钟",
+  "@rewardsTimeMin": {
+    "type": "text",
+    "placeholders": {
+      "mm": {}
+    }
+  },
+  "rewardsTitle": "奖励信息",
+  "@rewardsTitle": {
+    "type": "text"
+  },
+  "russianLanguage": "俄语",
+  "@russianLanguage": {
+    "type": "text"
+  },
+  "saveMerged": "保存合并",
+  "@saveMerged": {
+    "type": "text"
+  },
+  "scrollToContinue": "滚动到底部继续...",
+  "@scrollToContinue": {
+    "type": "text"
+  },
+  "searchFilterCoin": "搜索货币",
+  "@searchFilterCoin": {
+    "type": "text"
+  },
+  "searchFilterSubtitleAVX": "选择所有Avax代币",
+  "@searchFilterSubtitleAVX": {
+    "type": "text"
+  },
+  "searchFilterSubtitleBEP": "选择所有BEP代币",
+  "@searchFilterSubtitleBEP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleCosmos": "选择所有 Cosmos 网络",
+  "@searchFilterSubtitleCosmos": {
+    "type": "text"
+  },
+  "searchFilterSubtitleERC": "选择所有ERC代币",
+  "@searchFilterSubtitleERC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleETC": "选择所有ETC代币",
+  "@searchFilterSubtitleETC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleFTM": "选择所有Fantom代币",
+  "@searchFilterSubtitleFTM": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHCO": "选择所有HecoChain代币",
+  "@searchFilterSubtitleHCO": {
+    "type": "text"
+  },
+  "searchFilterSubtitleHRC": "选择所有Harmony代币",
+  "@searchFilterSubtitleHRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleIris": "选择所有虹膜网络",
+  "@searchFilterSubtitleIris": {
+    "type": "text"
+  },
+  "searchFilterSubtitleKRC": "选择所有Kucoin代币",
+  "@searchFilterSubtitleKRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleMVR": "选择所有Moonriver代币",
+  "@searchFilterSubtitleMVR": {
+    "type": "text"
+  },
+  "searchFilterSubtitlePLG": "选择所有Polygon代币",
+  "@searchFilterSubtitlePLG": {
+    "type": "text"
+  },
+  "searchFilterSubtitleQRC": "选择所有QRC代币",
+  "@searchFilterSubtitleQRC": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSBCH": "选择所有SmartBCH代币",
+  "@searchFilterSubtitleSBCH": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSLP": "选择所有 SLP 代币",
+  "@searchFilterSubtitleSLP": {
+    "type": "text"
+  },
+  "searchFilterSubtitleSmartChain": "选择所有智能链",
+  "@searchFilterSubtitleSmartChain": {
+    "type": "text"
+  },
+  "searchFilterSubtitleTestCoins": "选择所有测试资产",
+  "@searchFilterSubtitleTestCoins": {
+    "type": "text"
+  },
+  "searchFilterSubtitleUBQ": "选择所有Ubiq货币",
+  "@searchFilterSubtitleUBQ": {
+    "type": "text"
+  },
+  "searchFilterSubtitleutxo": "选择所有UTXO货币",
+  "@searchFilterSubtitleutxo": {
+    "type": "text"
+  },
+  "searchFilterSubtitleZHTLC": "选择所有ZHTLC币",
+  "@searchFilterSubtitleZHTLC": {
+    "type": "text"
+  },
+  "searchForTicker": "搜索货币代码",
+  "@searchForTicker": {
+    "type": "text"
+  },
+  "seconds": "秒",
+  "@seconds": {
+    "type": "text"
+  },
+  "security": "证券",
+  "@security": {
+    "type": "text"
+  },
+  "seedPhrase": "助记词",
+  "@seedPhrase": {
+    "type": "text"
+  },
+  "seedPhraseTitle": "您的新助記詞",
+  "@seedPhraseTitle": {
+    "type": "text"
+  },
+  "seeOrders": "点击查看{amount} 交易",
+  "@seeOrders": {
+    "type": "text",
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "seeTxHistory": "查看交易记录",
+  "@seeTxHistory": {
+    "type": "text"
+  },
+  "selectCoin": "选择货币",
+  "@selectCoin": {
+    "type": "text"
+  },
+  "selectCoinInfo": "选择您想要添加到投资组合的货币",
+  "@selectCoinInfo": {
+    "type": "text"
+  },
+  "selectCoinTitle": "激活货币：",
+  "@selectCoinTitle": {
+    "type": "text"
+  },
+  "selectCoinToBuy": "选择您想买入的货币",
+  "@selectCoinToBuy": {
+    "type": "text"
+  },
+  "selectCoinToSell": "选择您想卖出的货币",
+  "@selectCoinToSell": {
+    "type": "text"
+  },
+  "selectDate": "选择日期",
+  "@selectDate": {
+    "type": "text"
+  },
+  "selectedOrder": "选择订单",
+  "@selectedOrder": {
+    "type": "text"
+  },
+  "selectFileImport": "选择文件",
+  "@selectFileImport": {
+    "type": "text"
+  },
+  "selectLanguage": "选择语言",
+  "@selectLanguage": {
+    "type": "text"
+  },
+  "selectPaymentMethod": "选择您的支付方式",
+  "@selectPaymentMethod": {
+    "type": "text"
+  },
+  "sell": "卖出",
+  "@sell": {
+    "type": "text"
+  },
+  "sellTestCoinWarning": "警告，您正在卖出没有实际价值的测试币!",
+  "@sellTestCoinWarning": {
+    "type": "text"
+  },
+  "send": "发送",
+  "@send": {
+    "type": "text"
+  },
+  "settingDialogSpan1": "您确定要删除",
+  "@settingDialogSpan1": {
+    "type": "text"
+  },
+  "settingDialogSpan2": "钱包吗",
+  "@settingDialogSpan2": {
+    "type": "text"
+  },
+  "settingDialogSpan3": "如果是，请确认您已",
+  "@settingDialogSpan3": {
+    "type": "text"
+  },
+  "settingDialogSpan4": "记下助记词",
+  "@settingDialogSpan4": {
+    "type": "text"
+  },
+  "settingDialogSpan5": "以便在将来恢复您的钱包",
+  "@settingDialogSpan5": {
+    "type": "text"
+  },
+  "settingLanguageTitle": "语言",
+  "@settingLanguageTitle": {
+    "type": "text"
+  },
+  "settings": "设置",
+  "@settings": {
+    "type": "text"
+  },
+  "setUpPassword": "创建密码",
+  "@setUpPassword": {
+    "type": "text"
+  },
+  "share": "分享",
+  "@share": {
+    "type": "text"
+  },
+  "shareAddress": "我的{coinName} 地址:\n{address}",
+  "@shareAddress": {
+    "type": "text",
+    "placeholders": {
+      "coinName": {},
+      "address": {}
+    }
+  },
+  "shouldScanPastTransaction": "扫描过去的 {coin} 交易？",
+  "@shouldScanPastTransaction": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "showAddress": "显示地址",
+  "@showAddress": {
+    "type": "text"
+  },
+  "showDetails": "显示详细信息",
+  "@showDetails": {
+    "type": "text"
+  },
+  "showingOrders": "显示 {count} 个订单（共 {maxCount} 个）。",
+  "@showingOrders": {
+    "type": "text",
+    "placeholders": {
+      "count": {},
+      "maxCount": {}
+    }
+  },
+  "showMyOrders": "显示我的订单",
+  "@showMyOrders": {
+    "type": "text"
+  },
+  "signInWithPassword": "使用密码登录",
+  "@signInWithPassword": {
+    "type": "text"
+  },
+  "signInWithSeedPhrase": "忘记密码？用助记词恢复钱包",
+  "@signInWithSeedPhrase": {
+    "type": "text"
+  },
+  "simple": "简单",
+  "@simple": {
+    "type": "text"
+  },
+  "simpleTradeActivate": "激活",
+  "@simpleTradeActivate": {
+    "type": "text"
+  },
+  "simpleTradeBuyHint": "请输入要买入的 {coin} 数量",
+  "@simpleTradeBuyHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeBuyTitle": "买入",
+  "@simpleTradeBuyTitle": {
+    "type": "text"
+  },
+  "simpleTradeClose": "关闭",
+  "@simpleTradeClose": {
+    "type": "text"
+  },
+  "simpleTradeMaxActiveCoins": "货币最大活跃量为{maxCoins}。请停用一些。",
+  "@simpleTradeMaxActiveCoins": {
+    "type": "text",
+    "placeholders": {
+      "maxCoins": {}
+    }
+  },
+  "simpleTradeNotActive": "{coin}未激活！",
+  "@simpleTradeNotActive": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeRecieve": "接收",
+  "@simpleTradeRecieve": {
+    "type": "text"
+  },
+  "simpleTradeSellHint": "请输入要卖出的{coin}数量",
+  "@simpleTradeSellHint": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "simpleTradeSellTitle": "卖出",
+  "@simpleTradeSellTitle": {
+    "type": "text"
+  },
+  "simpleTradeSend": "发送",
+  "@simpleTradeSend": {
+    "type": "text"
+  },
+  "simpleTradeShowLess": "收起",
+  "@simpleTradeShowLess": {
+    "type": "text"
+  },
+  "simpleTradeShowMore": "显示更多",
+  "@simpleTradeShowMore": {
+    "type": "text"
+  },
+  "simpleTradeUnableActivate": "无法激活{coin}",
+  "@simpleTradeUnableActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "skip": "跳过",
+  "@skip": {
+    "type": "text"
+  },
+  "snackbarDismiss": "不予考虑",
+  "@snackbarDismiss": {
+    "type": "text"
+  },
+  "Sound": "声音",
+  "@Sound": {
+    "type": "text"
+  },
+  "soundCantPlayThatMsg": "请选择mp3或wav文件。我们将在{description}时播放它。",
+  "@soundCantPlayThatMsg": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundPlayedWhen": "当{description}播放",
+  "@soundPlayedWhen": {
+    "type": "text",
+    "placeholders": {
+      "description": {
+        "example": "a swap runs to completion"
+      }
+    }
+  },
+  "soundsDialogTitle": "声音",
+  "@soundsDialogTitle": {
+    "type": "text"
+  },
+  "soundsDoNotShowAgain": "已知晓，不再显示",
+  "@soundsDoNotShowAgain": {
+    "type": "text"
+  },
+  "soundSettingsLink": "声音",
+  "@soundSettingsLink": {
+    "type": "text"
+  },
+  "soundSettingsTitle": "声音设置",
+  "@soundSettingsTitle": {
+    "type": "text"
+  },
+  "soundsExplanation": "交换时，如果您有一个活跃的挂单交易，会收到声音提醒。\n原子交换协议要求参与者在线才能成功交易，声音通知可以帮助实现这一点。",
+  "@soundsExplanation": {
+    "type": "text"
+  },
+  "soundsNote": "请注意，您可以在应用程序设置中设置自定义声音。",
+  "@soundsNote": {
+    "type": "text"
+  },
+  "spanishLanguage": "西班牙语",
+  "@spanishLanguage": {
+    "type": "text"
+  },
+  "startDate": "开始日期",
+  "@startDate": {
+    "type": "text"
+  },
+  "startSwap": "开始交换",
+  "@startSwap": {
+    "type": "text"
+  },
+  "step": "步骤",
+  "@step": {
+    "type": "text"
+  },
+  "success": "成功",
+  "@success": {
+    "type": "text"
+  },
+  "support": "支持",
+  "@support": {
+    "type": "text"
+  },
+  "supportLinksDesc": "如果您有任何问题，或者认为您发现{appName} 应用程序存在技术问题，请联系我们获取我们团队的支持。",
+  "@supportLinksDesc": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "swap": "交换",
+  "@swap": {
+    "type": "text"
+  },
+  "swapCurrent": "现状",
+  "@swapCurrent": {
+    "type": "text"
+  },
+  "swapDetailTitle": "确认兑换细节",
+  "@swapDetailTitle": {
+    "type": "text"
+  },
+  "swapEstimated": "预估",
+  "@swapEstimated": {
+    "type": "text"
+  },
+  "swapFailed": "交换失败",
+  "@swapFailed": {
+    "type": "text"
+  },
+  "swapGasActivate": "请先激活 {coin} 并充值余额",
+  "@swapGasActivate": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmount": "{coin} 余额不足以支付交易费用。",
+  "@swapGasAmount": {
+    "type": "text",
+    "placeholders": {
+      "coin": {}
+    }
+  },
+  "swapGasAmountRequired": "{coin} 余额不足以支付交易费用。需要 {coin} {amount}",
+  "@swapGasAmountRequired": {
+    "type": "text",
+    "placeholders": {
+      "coin": {},
+      "amount": {}
+    }
+  },
+  "swapOngoing": "正在交换",
+  "@swapOngoing": {
+    "type": "text"
+  },
+  "swapProgress": "进度详情",
+  "@swapProgress": {
+    "type": "text"
+  },
+  "swapStarted": "已开始",
+  "@swapStarted": {
+    "type": "text"
+  },
+  "swapSucceful": "交换成功",
+  "@swapSucceful": {
+    "type": "text"
+  },
+  "swapTotal": "总共",
+  "@swapTotal": {
+    "type": "text"
+  },
+  "swapUUID": "UUID交换",
+  "@swapUUID": {
+    "type": "text"
+  },
+  "switchTheme": "切换主题",
+  "@switchTheme": {
+    "type": "text"
+  },
+  "syncFromDate": "从指定日期同步",
+  "@syncFromDate": {
+    "type": "text"
+  },
+  "syncFromSaplingActivation": "从树苗激活同步",
+  "@syncFromSaplingActivation": {
+    "type": "text"
+  },
+  "syncNewTransactions": "同步新交易",
+  "@syncNewTransactions": {
+    "type": "text"
+  },
+  "syncTransactionsQuestion": "您想要同步哪些{name}交易？",
+  "@syncTransactionsQuestion": {
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "tagAVX20": "AVX20",
+  "@tagAVX20": {
+    "type": "text"
+  },
+  "tagBEP20": "BEP20",
+  "@tagBEP20": {
+    "type": "text"
+  },
+  "tagERC20": "ERC20",
+  "@tagERC20": {
+    "type": "text"
+  },
+  "tagETC": "ETC",
+  "@tagETC": {
+    "type": "text"
+  },
+  "tagFTM20": "FTM20",
+  "@tagFTM20": {
+    "type": "text"
+  },
+  "tagHCO20": "HCO20",
+  "@tagHCO20": {
+    "type": "text"
+  },
+  "tagHRC20": "HRC20",
+  "@tagHRC20": {
+    "type": "text"
+  },
+  "tagKMD": "KMD",
+  "@tagKMD": {
+    "type": "text"
+  },
+  "tagKRC20": "KRC20",
+  "@tagKRC20": {
+    "type": "text"
+  },
+  "tagMVR20": "MVR20",
+  "@tagMVR20": {
+    "type": "text"
+  },
+  "tagPLG20": "PLG20",
+  "@tagPLG20": {
+    "type": "text"
+  },
+  "tagQRC20": "QRC20",
+  "@tagQRC20": {
+    "type": "text"
+  },
+  "tagSBCH": "SBCH",
+  "@tagSBCH": {
+    "type": "text"
+  },
+  "tagUBQ": "UBQ",
+  "@tagUBQ": {
+    "type": "text"
+  },
+  "tagZHTLC": "ZHTLC",
+  "@tagZHTLC": {
+    "type": "text"
+  },
+  "Taker": "吃单",
+  "@Taker": {
+    "type": "text"
+  },
+  "takerOrder": "吃单交易",
+  "@takerOrder": {
+    "type": "text"
+  },
+  "timeOut": "超时",
+  "@timeOut": {
+    "type": "text"
+  },
+  "titleCreatePassword": "创建密码",
+  "@titleCreatePassword": {
+    "type": "text"
+  },
+  "titleCurrentAsk": "选择订单",
+  "@titleCurrentAsk": {
+    "type": "text"
+  },
+  "to": "至",
+  "@to": {
+    "type": "text"
+  },
+  "toAddress": "接收地址",
+  "@toAddress": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan1": "您已",
+  "@tooManyAssetsEnabledSpan1": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan2": "启用资产。启用资产上限为",
+  "@tooManyAssetsEnabledSpan2": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledSpan3": "请在启用新资产前停用一些资产",
+  "@tooManyAssetsEnabledSpan3": {
+    "type": "text"
+  },
+  "tooManyAssetsEnabledTitle": "已启用的资产太多",
+  "@tooManyAssetsEnabledTitle": {
+    "type": "text"
+  },
+  "totalFees": "总费用",
+  "@totalFees": {
+    "type": "text"
+  },
+  "trade": "交易",
+  "@trade": {
+    "type": "text"
+  },
+  "tradeCompleted": "交换完成！",
+  "@tradeCompleted": {
+    "type": "text"
+  },
+  "tradeDetail": "交易详情",
+  "@tradeDetail": {
+    "type": "text"
+  },
+  "tradePreimageError": "无法计算交易费用",
+  "@tradePreimageError": {
+    "type": "text"
+  },
+  "tradingFee": "交易费用：",
+  "@tradingFee": {
+    "type": "text"
+  },
+  "tradingMode": "交易模式：",
+  "@tradingMode": {
+    "type": "text"
+  },
+  "transactionAddress": "交易地址",
+  "@transactionAddress": {
+    "type": "text"
+  },
+  "transactionHidden": "交易隐藏",
+  "@transactionHidden": {
+    "type": "text"
+  },
+  "transactionHiddenPhishing": "由于可能存在网络钓鱼尝试，该交易被隐藏。",
+  "@transactionHiddenPhishing": {
+    "type": "text"
+  },
+  "tryRestarting": "如果还是有一些货币未被激活，请尝试重启应用程序。",
+  "@tryRestarting": {
+    "type": "text"
+  },
+  "turkishLanguage": "土耳其语",
+  "@turkishLanguage": {
+    "type": "text"
+  },
+  "txBlock": "区块",
+  "@txBlock": {
+    "type": "text"
+  },
+  "txConfirmations": "确认",
+  "@txConfirmations": {
+    "type": "text"
+  },
+  "txConfirmed": "已确认",
+  "@txConfirmed": {
+    "type": "text"
+  },
+  "txFee": "费用",
+  "@txFee": {
+    "type": "text"
+  },
+  "txFeeTitle": "交易费用",
+  "@txFeeTitle": {
+    "type": "text"
+  },
+  "txHash": "交易ID",
+  "@txHash": {
+    "type": "text"
+  },
+  "txleft": "剩余交易: {left}",
+  "@txleft": {
+    "type": "text",
+    "placeholders": {
+      "left": {}
+    }
+  },
+  "txLimitExceeded": "请求过多。超出交易历史请求限制。请稍后重试",
+  "@txLimitExceeded": {
+    "type": "text"
+  },
+  "txNotConfirmed": "未确认",
+  "@txNotConfirmed": {
+    "type": "text"
+  },
+  "ukrainianLanguage": "乌克兰",
+  "@ukrainianLanguage": {
+    "type": "text"
+  },
+  "unlock": "解锁",
+  "@unlock": {
+    "type": "text"
+  },
+  "unlockFunds": "解锁基金",
+  "@unlockFunds": {
+    "type": "text"
+  },
+  "unlockSuccess": "成功解锁 {amnt} 基金 - 交易: {hash}",
+  "@unlockSuccess": {
+    "type": "text",
+    "placeholders": {
+      "amnt": {},
+      "hash": {}
+    }
+  },
+  "unspendable": "不可交易",
+  "@unspendable": {
+    "type": "text"
+  },
+  "updatesAvailable": "已有新版本",
+  "@updatesAvailable": {
+    "type": "text"
+  },
+  "updatesChecking": "正在检查更新",
+  "@updatesChecking": {
+    "type": "text"
+  },
+  "updatesCurrentVersion": "您正在使用版本{version}",
+  "@updatesCurrentVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifAvailable": "已有新版本。请更新。",
+  "@updatesNotifAvailable": {
+    "type": "text"
+  },
+  "updatesNotifAvailableVersion": "版本{version}可用。请更新。",
+  "@updatesNotifAvailableVersion": {
+    "type": "text",
+    "placeholders": {
+      "version": {}
+    }
+  },
+  "updatesNotifTitle": "可更新",
+  "@updatesNotifTitle": {
+    "type": "text"
+  },
+  "updatesSkip": "暂时跳过",
+  "@updatesSkip": {
+    "type": "text"
+  },
+  "updatesTitle": "更新{appName}",
+  "@updatesTitle": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "updatesUpdate": "已更新",
+  "@updatesUpdate": {
+    "type": "text"
+  },
+  "updatesUpToDate": "准备更新",
+  "@updatesUpToDate": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan1": "余额不足，无法扫描",
+  "@uriInsufficientBalanceSpan1": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceSpan2": "付款请求。",
+  "@uriInsufficientBalanceSpan2": {
+    "type": "text"
+  },
+  "uriInsufficientBalanceTitle": "余额不足",
+  "@uriInsufficientBalanceTitle": {
+    "type": "text"
+  },
+  "value": "价值",
+  "@value": {
+    "type": "text"
+  },
+  "version": "版本",
+  "@version": {
+    "type": "text"
+  },
+  "viewInExplorerButton": "资源管理器",
+  "@viewInExplorerButton": {
+    "type": "text"
+  },
+  "viewSeedAndKeys": "助记词和私钥",
+  "@viewSeedAndKeys": {
+    "type": "text"
+  },
+  "volumes": "交易量",
+  "@volumes": {
+    "type": "text"
+  },
+  "walletInUse": "钱包名称已被使用",
+  "@walletInUse": {
+    "type": "text"
+  },
+  "walletMaxChar": "钱包名称最多40个字符",
+  "@walletMaxChar": {
+    "type": "text"
+  },
+  "walletOnly": "仅钱包",
+  "@walletOnly": {
+    "type": "text"
+  },
+  "warning": "警告",
+  "@warning": {
+    "type": "text"
+  },
+  "warningOkBtn": "好的",
+  "@warningOkBtn": {
+    "type": "text"
+  },
+  "warningShareLogs": "警告-在特殊情况下，此登录数据包含敏感信息，可用于消费交换失败的货币！",
+  "@warningShareLogs": {
+    "type": "text"
+  },
+  "weFailedTo": "我们无法激活 {coinAbbr}",
+  "@weFailedTo": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "weFailedToActivate": "我们无法激活{coinAbbr}.\n请重启应用程序后重试",
+  "@weFailedToActivate": {
+    "type": "text",
+    "placeholders": {
+      "coinAbbr": {}
+    }
+  },
+  "welcomeInfo": "{appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。",
+  "@welcomeInfo": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "welcomeLetSetUp": "让我们开始吧",
+  "@welcomeLetSetUp": {
+    "type": "text"
+  },
+  "welcomeTitle": "欢迎",
+  "@welcomeTitle": {
+    "type": "text"
+  },
+  "welcomeWallet": "钱包",
+  "@welcomeWallet": {
+    "type": "text"
+  },
+  "willBeRedirected": "完成后，您将跳转至投资组合页面",
+  "@willBeRedirected": {
+    "type": "text"
+  },
+  "willTakeTime": "这将需要一段时间，并且应用程序必须保持在前台。\n在激活过程中终止应用程序可能会导致问题。",
+  "@willTakeTime": {
+    "type": "text"
+  },
+  "withdraw": "提取",
+  "@withdraw": {
+    "type": "text"
+  },
+  "withdrawCameraAccessText": "您之前禁止{appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描",
+  "@withdrawCameraAccessText": {
+    "type": "text",
+    "placeholders": {
+      "appName": {}
+    }
+  },
+  "withdrawCameraAccessTitle": "被拒绝使用",
+  "@withdrawCameraAccessTitle": {
+    "type": "text"
+  },
+  "withdrawConfirm": "确认提取",
+  "@withdrawConfirm": {
+    "type": "text"
+  },
+  "withdrawConfirmError": "出现错误。请稍后重试。",
+  "@withdrawConfirmError": {
+    "type": "text"
+  },
+  "withdrawValue": "提取 {amount} {coinName}",
+  "@withdrawValue": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coinName": {}
+    }
+  },
+  "wrongCoinSpan1": "您正在尝试扫描付款二维码",
+  "@wrongCoinSpan1": {
+    "type": "text"
+  },
+  "wrongCoinSpan2": "但您在",
+  "@wrongCoinSpan2": {
+    "type": "text"
+  },
+  "wrongCoinSpan3": "提取页面",
+  "@wrongCoinSpan3": {
+    "type": "text"
+  },
+  "wrongCoinTitle": "错误货币",
+  "@wrongCoinTitle": {
+    "type": "text"
+  },
+  "wrongPassword": "密码不匹配。请重试",
+  "@wrongPassword": {
+    "type": "text"
+  },
+  "yes": "对",
+  "@yes": {
+    "type": "text"
+  },
+  "youAreSending": "您正在发送：",
+  "@youAreSending": {
+    "type": "text"
+  },
+  "you have a fresh order that is trying to match with an existing order": "您有一个新订单正在尝试与现有订单匹配",
+  "@you have a fresh order that is trying to match with an existing order": {
+    "type": "text"
+  },
+  "you have an active swap in progress": "您有一个正在进行的活跃交换",
+  "@you have an active swap in progress": {
+    "type": "text"
+  },
+  "you have an order that new orders can match with": "你有一个新订单可以匹配的订单",
+  "@you have an order that new orders can match with": {
+    "type": "text"
+  },
+  "yourWallet": "您的钱包",
+  "@yourWallet": {
+    "type": "text"
+  },
+  "youWillReceiveClaim": "您将获得 {amount} {coin}",
+  "@youWillReceiveClaim": {
+    "type": "text",
+    "placeholders": {
+      "amount": {},
+      "coin": {}
+    }
+  },
+  "youWillReceived": "您将收到：",
+  "@youWillReceived": {
+    "type": "text"
+  }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,3726 +1,5540 @@
 {
-  "@@locale": "zh",
-  "accepteula": "同意接受终端使用者授权协议 (EULA)",
-  "@accepteula": {
-    "type": "text"
-  },
-  "accepttac": "接受条款与条件",
-  "@accepttac": {
-    "type": "text"
-  },
-  "activateAccessBiometric": "启动生物识别功能",
-  "@activateAccessBiometric": {
-    "type": "text"
-  },
-  "activateAccessPin": "启动PIN码保护",
-  "@activateAccessPin": {
-    "type": "text"
-  },
-  "activateCoins": "激活 {protocolName} 币？",
-  "@activateCoins": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
+    "mobileDataWarning": "请注意，您现在正在使用流量，使用{appName} P2P网络会消耗互联网流量。如果您的手机流量很贵，最好连接WIFI。",
+    "@mobileDataWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "withdrawCameraAccessTitle": "被拒绝使用",
+    "@withdrawCameraAccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawCameraAccessText": "您之前禁止{appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描",
+    "@withdrawCameraAccessText": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeTitle": "欢迎",
+    "@welcomeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeWallet": "钱包",
+    "@welcomeWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "welcomeInfo": "{appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。",
+    "@welcomeInfo": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "welcomeLetSetUp": "让我们开始吧",
+    "@welcomeLetSetUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
+    "@eulaTitle1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
+    "@eulaTitle2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
+    "@eulaTitle3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle4": "GENERAL USE",
+    "@eulaTitle4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle5": "MODIFICATIONS",
+    "@eulaTitle5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle6": "LIMITATIONS ON USE",
+    "@eulaTitle6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
+    "@eulaTitle7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle8": "BACKUPS",
+    "@eulaTitle8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle9": "GENERAL WARNING",
+    "@eulaTitle9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle10": "ACCESS AND SECURITY",
+    "@eulaTitle10": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
+    "@eulaTitle11": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle12": "DISCLAIMER",
+    "@eulaTitle12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
+    "@eulaTitle13": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle14": "GENERAL RISK FACTORS",
+    "@eulaTitle14": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle15": "INDEMNIFICATION",
+    "@eulaTitle15": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
+    "@eulaTitle16": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
+    "@eulaTitle17": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle18": "TERMINATION",
+    "@eulaTitle18": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle19": "THIRD PARTY RIGHTS",
+    "@eulaTitle19": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaTitle20": "OUR LEGAL OBLIGATIONS",
+    "@eulaTitle20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
+    "@eulaParagraphe2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
+    "@eulaParagraphe3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
+    "@eulaParagraphe4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
+    "@eulaParagraphe5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
+    "@eulaParagraphe6": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
+    "@eulaParagraphe7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
+    "@eulaParagraphe8": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
+    "@eulaParagraphe9": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
+    "@eulaParagraphe10": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
+    "@eulaParagraphe11": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
+    "@eulaParagraphe12": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
+    "@eulaParagraphe13": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
+    "@eulaParagraphe14": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
+    "@eulaParagraphe15": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
+    "@eulaParagraphe16": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyShort": {},
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
+    "@eulaParagraphe17": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
+    "@eulaParagraphe18": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appCompanyLong": {}
+        }
+    },
+    "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
+    "@eulaParagraphe19": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyLong"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyLong": {}
+        }
+    },
+    "updatesTitle": "更新{appName}",
+    "@updatesTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "updatesCurrentVersion": "您正在使用版本{version}",
+    "@updatesCurrentVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "updatesChecking": "正在检查更新",
+    "@updatesChecking": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpToDate": "准备更新",
+    "@updatesUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesAvailable": "已有新版本",
+    "@updatesAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesUpdate": "已更新",
+    "@updatesUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesSkip": "暂时跳过",
+    "@updatesSkip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifTitle": "可更新",
+    "@updatesNotifTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailable": "已有新版本。请更新。",
+    "@updatesNotifAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "updatesNotifAvailableVersion": "版本{version}可用。请更新。",
+    "@updatesNotifAvailableVersion": {
+        "type": "text",
+        "placeholders_order": [
+            "version"
+        ],
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "helpLink": "帮助",
+    "@helpLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "helpTitle": "帮助和支持",
+    "@helpTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faqTitle": "常见问题",
+    "@faqTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "support": "支持",
+    "@support": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "supportLinksDesc": "如果您有任何问题，或者认为您发现{appName} 应用程序存在技术问题，请联系我们获取我们团队的支持。",
+    "@supportLinksDesc": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_1": "你们会保存我的私钥吗？",
+    "@question_1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_1": "不{appName}是非托管应用。我们不会存储任何敏感数据，包括您的私钥、助记词或PIN。此数据仅存储在用户的设备上，不会转移。您的资产只由您掌控。",
+    "@answer_1": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_2": "在{appName} 上交易与在其他DEX上交易有何不同？",
+    "@question_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_2": "其他DEX（去中心化交易所）通常只允许您使用代理代币交易基于单个区块链网络的资产，并且只能用一个基金下一个订单。\n但用{appName}您可以在两个不同的区块链网络之间进行交易，且无需代理代币。您还可以用一个基金下多个订单。例如，您可以用KMD、QTUM或VRSC兑0.1 BTC，第一个订单成交后自动取消其他所有订单",
+    "@answer_2": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_3": "每次原子交换需要多长时间？",
+    "@question_3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_3": "几个因素决定了每次交易的处理时间。交易资产的区块时间取决于各自的网络（比特币通常是最慢的）。此外，用户可以自定义安全偏好。例如，您可以要求{appName}在确认KMD交易为最终交易前确认3次，这使得交易时间短于等待公证的<a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">时间</a>.",
+    "@answer_3": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_4": "在交换期间我要保持在线吗",
+    "@question_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_4": "是的，必须保持互联网连接，并确保您的应用程序在运行，才能成功完成原子交换（网络短暂中断通常是可以的）。否则，如果是挂单，会有交易取消的风险，如果是吃单，会有资金损失的风险。原子交换协议要求双方参与者保持在线，并监控所涉及的区块链，确保该过程保持原子性。",
+    "@answer_4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "question_5": "{appName} 的费用如何计算？",
+    "@question_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_5": "在｛appName｝上进行交易时，需要考虑两种费用。\n1.｛appName｝收取约0.13%（交易量的1/777，但不低于0.0001）作为吃单交易的交易费用，挂单交易不收费。\n2.在进行原子交换交易时，无论挂单还是吃单，都需要向相关区块链支付常规的网络费用\n网络费用具体取决于你选择的交易对，不同交易对费用可能大大不同。",
+    "@answer_5": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_6": "你们会提供用户支持吗？",
+    "@question_6": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_6": "是的 {appName} 通过 <a href=\"{link}\">{appCompanyShort} {name}</a>提供支持。团队和社区总是乐于提供帮助！",
+    "@answer_6": {
+        "type": "text",
+        "placeholders_order": [
+            "name",
+            "link",
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "name": {},
+            "link": {},
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_7": "你们有地区限制吗？",
+    "@question_7": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "answer_7": "不是{appName} 是完全去中心化的。不会限制任何第三方用户访问。",
+    "@answer_7": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_8": "{appName} 的背后是谁？",
+    "@question_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_8": "{appName} 由{appCompanyShort}团队开发。{appCompanyShort}是最成熟的区块链项目之一，致力于开发创新解决方案，如原子交换、延迟工作量证明和可互操作的多链架构。",
+    "@answer_8": {
+        "type": "text",
+        "placeholders_order": [
+            "appName",
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appName": {},
+            "appCompanyShort": {}
+        }
+    },
+    "question_9": "是否可以在{appName} 上开发我个人的白标交换？",
+    "@question_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_9": "绝对地！您可以阅读我们的<a href=\"https://developers.komodoplatform.com/\">开发者文档</a>了解更多详细信息，或者联系我们咨询您的合作伙伴关系。有具体的技术问题吗？ {appName} 开发者社区随时准备提供帮助！",
+    "@answer_9": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "question_10": "我可以在哪些设备上使用{appName} ？",
+    "@question_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "answer_10": "{appName} 适用于 Android 和 iPhone 上的移动设备，以及 <a href=\"https://komodoplatform.com/\">Windows、Mac 和 Linux 操作系统</a> 上的桌面设备。",
+    "@answer_10": {
+        "type": "text",
+        "placeholders_order": [
+            "appName"
+        ],
+        "placeholders": {
+            "appName": {}
+        }
+    },
+    "feedTab": "Feed",
+    "@feedTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedTitle": "Feed新闻",
+    "@feedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedReadMore": "阅读更多",
+    "@feedReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotFound": "无内容",
+    "@feedNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpdated": "Feed新闻已更新",
+    "@feedUpdated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "snackbarDismiss": "不予考虑",
+    "@snackbarDismiss": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNewsTab": "新闻",
+    "@feedNewsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "duration": "有效期",
+    "@duration": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToUpdate": "无法获取新闻更新",
+    "@feedUnableToUpdate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUnableToProceed": "无法继续更新新闻",
+    "@feedUnableToProceed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedUpToDate": "已更新",
+    "@feedUpToDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "date": "日期",
+    "@date": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedNotifTitle": "{appCompanyShort} 新闻",
+    "@feedNotifTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "appCompanyShort"
+        ],
+        "placeholders": {
+            "appCompanyShort": {}
+        }
+    },
+    "createPin": "创建PIN码",
+    "@createPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterPinCode": "输入您的PIN码",
+    "@enterPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "login": "登录",
+    "@login": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccount": "新帳戶",
+    "@newAccount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newAccountUpper": "新帳戶",
+    "@newAccountUpper": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addingCoinSuccess": "成功新增 {name}!",
+    "@addingCoinSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "connecting": "连接中",
+    "@connecting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addCoin": "新增货币",
+    "@addCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "numberAssets": "{assets} 资产",
+    "@numberAssets": {
+        "type": "text",
+        "placeholders_order": [
+            "assets"
+        ],
+        "placeholders": {
+            "assets": {}
+        }
+    },
+    "enterSeedPhrase": "输入您的助记词",
+    "@enterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exampleHintSeed": "例如：build case level ...",
+    "@exampleHintSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirm": "确认",
+    "@confirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyTestCoinWarning": "警告，你正在购买没有实际价值的测试币!",
+    "@buyTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "batteryCriticalError": "您的电池电量过低 ({batteryLevelCritical}%) ，无法安全地进行交换。请先充电，然后重试。",
+    "@batteryCriticalError": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelCritical"
+        ],
+        "placeholders": {
+            "batteryLevelCritical": {}
+        }
+    },
+    "batteryLowWarning": "您的电池电量低于 {batteryLevelLow}%。请充电。",
+    "@batteryLowWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "batteryLevelLow"
+        ],
+        "placeholders": {
+            "batteryLevelLow": {}
+        }
+    },
+    "batterySavingWarning": "您的手机处于省电模式。请停用此模式或不要将应用程序置于后台，否则，应用程序可能会被系统自动清除，导致交换失败。",
+    "@batterySavingWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sellTestCoinWarning": "警告，您正在卖出没有实际价值的测试币!",
+    "@sellTestCoinWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buy": "买入",
+    "@buy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "sell": "卖出",
+    "@sell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shareAddress": "我的{coinName} 地址:\n{address}",
+    "@shareAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "address"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "address": {}
+        }
+    },
+    "withdraw": "提取",
+    "@withdraw": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueEmpty": "价值太高或太低",
+    "@errorValueEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amount": "数量",
+    "@amount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSend": "收款人钱包地址",
+    "@addressSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawValue": "提取 {amount} {coinName}",
+    "@withdrawValue": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coinName"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coinName": {}
+        }
+    },
+    "withdrawConfirm": "确认提取",
+    "@withdrawConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "withdrawConfirmError": "出现错误。请稍后重试。",
+    "@withdrawConfirmError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "close": "关闭",
+    "@close": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmSeed": "确认助记词",
+    "@confirmSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhraseTitle": "您的新助記詞",
+    "@seedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "getBackupPhrase": "重要提醒: 請在繼續之前備份助記詞 !",
+    "@getBackupPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "recommendSeedMessage": "我们建议在线下存档。",
+    "@recommendSeedMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "next": "继续",
+    "@next": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPin": "确认PIN",
+    "@confirmPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camouflageSetup": "伪装PIN设置",
+    "@camouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCamouflageSetup": "确认伪装PIN",
+    "@confirmCamouflageSetup": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryAgain": "出现错误, 請重试",
+    "@errorTryAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settings": "设置",
+    "@settings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "security": "证券",
+    "@security": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessPin": "启动PIN码保护",
+    "@activateAccessPin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disableScreenshots": "禁用屏幕截图/预览",
+    "@disableScreenshots": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreen": "屏幕已锁定",
+    "@lockScreen": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "changePin": "更改PIN",
+    "@changePin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logout": "注销",
+    "@logout": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "max": "最大",
+    "@max": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "min": "最小",
+    "@min": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "totalFees": "总费用",
+    "@totalFees": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromBalance": "用余额支付：",
+    "@paidFromBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingMode": "交易模式：",
+    "@tradingMode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "skip": "跳过",
+    "@skip": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "merge": "合并",
+    "@merge": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "overwrite": "覆盖",
+    "@overwrite": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currentValue": "当前值",
+    "@currentValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newValue": "新价值",
+    "@newValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mergedValue": "合并值",
+    "@mergedValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "saveMerged": "保存合并",
+    "@saveMerged": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "alreadyExists": "已存在",
+    "@alreadyExists": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simple": "简单",
+    "@simple": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "advanced": "高级",
+    "@advanced": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidFromVolume": "用已接收的交易量支付",
+    "@paidFromVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "amountToSell": "卖出量",
+    "@amountToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youWillReceived": "您将收到：",
+    "@youWillReceived": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToSell": "选择您想卖出的货币",
+    "@selectCoinToSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinToBuy": "选择您想买入的货币",
+    "@selectCoinToBuy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swap": "交换",
+    "@swap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaiting": "交换已发起，请等待!",
+    "@buySuccessWaiting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buySuccessWaitingError": "正在进行交易匹配，请等待 {seconde} 秒!",
+    "@buySuccessWaitingError": {
+        "type": "text",
+        "placeholders_order": [
+            "seconde"
+        ],
+        "placeholders": {
+            "seconde": {}
+        }
+    },
+    "networkFee": "网络费用",
+    "@networkFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commissionFee": "手续费",
+    "@commissionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "portfolio": "投资组合",
+    "@portfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkOut": "退出",
+    "@checkOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "estimateValue": "预估总价",
+    "@estimateValue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectPaymentMethod": "选择您的支付方式",
+    "@selectPaymentMethod": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "volumes": "交易量",
+    "@volumes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "placeOrder": "下单",
+    "@placeOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comingSoon": "即将上线，敬请期待。。。",
+    "@comingSoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketplace": "市场",
+    "@marketplace": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "youAreSending": "您正在发送：",
+    "@youAreSending": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "code": "代码",
+    "@code": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "value": "价值",
+    "@value": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paidWith": "支付方式：",
+    "@paidWith": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorValueNotEmpty": "请输入数据",
+    "@errorValueNotEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorAmountBalance": "余额不足",
+    "@errorAmountBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gweiError": "Gwei 必须达到 {value}",
+    "@gweiError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "feesError": "费用必须高达 {value}",
+    "@feesError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "limitError": "限制必须达到 {value}",
+    "@limitError": {
+        "type": "text",
+        "placeholders_order": [
+            "value"
+        ],
+        "placeholders": {
+            "value": {}
+        }
+    },
+    "errorNotAValidAddress": "钱包地址错误",
+    "@errorNotAValidAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotAValidAddressSegWit": "尚不支持Segwit地址",
+    "@errorNotAValidAddressSegWit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "toAddress": "接收地址",
+    "@toAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receive": "接收",
+    "@receive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "send": "发送",
+    "@send": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pubkey": "公钥",
+    "@pubkey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "back": "上一步",
+    "@back": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancel": "取消",
+    "@cancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "details": "详细信息",
+    "@details": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yes": "对",
+    "@yes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "no": "不",
+    "@no": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noteOnOrder": "备注：不能取消已匹配的订单",
+    "@noteOnOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontAskAgain": "不再询问",
+    "@dontAskAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelOrder": "取消交易",
+    "@cancelOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmCancel": "您确定要取消交易吗",
+    "@confirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unspendable": "不可交易",
+    "@unspendable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoon": "交易明细加载中！",
+    "@commingsoon": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "history": "历史记录",
+    "@history": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "create": "交易",
+    "@create": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "commingsoonGeneral": "详情载入中！",
+    "@commingsoonGeneral": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatching": "订单匹配中",
+    "@orderMatching": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderMatched": "已匹配订单",
+    "@orderMatched": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapOngoing": "正在交换",
+    "@swapOngoing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapSucceful": "交换成功",
+    "@swapSucceful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "timeOut": "超时",
+    "@timeOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "convert": "转换",
+    "@convert": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapFailed": "交换失败",
+    "@swapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorTryLater": "出现错误，請稍後重试",
+    "@errorTryLater": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "latestTxs": "最新交易",
+    "@latestTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gettingTxWait": "正在获取交易，请稍候",
+    "@gettingTxWait": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "finishingUp": "已完成，请稍候",
+    "@finishingUp": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "feedback": "共享日志文件",
+    "@feedback": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loadingOrderbook": "正在加载订单记录",
+    "@loadingOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claim": "领取",
+    "@claim": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "claimTitle": "领取您的KMD奖励？",
+    "@claimTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "success": "成功",
+    "@success": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewardYet": "没有奖励可领取-请一小时后重试",
+    "@noRewardYet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "loading": "載入中",
+    "@loading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txleft": "剩余交易: {left}",
+    "@txleft": {
+        "type": "text",
+        "placeholders_order": [
+            "left"
+        ],
+        "placeholders": {
+            "left": {}
+        }
+    },
+    "insufficientBalanceToPay": "{abbr}余额不足以支付交易费",
+    "@insufficientBalanceToPay": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "dex": "DEX",
+    "@dex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "media": "消息",
+    "@media": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "newsFeed": "Feed新闻",
+    "@newsFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboard": "复制到剪贴板",
+    "@clipboard": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "from": "起始日期",
+    "@from": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "to": "至",
+    "@to": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmed": "已确认",
+    "@txConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txNotConfirmed": "未确认",
+    "@txNotConfirmed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txBlock": "区块",
+    "@txBlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txConfirmations": "确认",
+    "@txConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFee": "费用",
+    "@txFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txHash": "交易ID",
+    "@txHash": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "memo": "备忘录",
+    "@memo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSwaps": "没有历史记录",
+    "@noSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "trade": "交易",
+    "@trade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "reset": "清除",
+    "@reset": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "resetTitle": "重置表格",
+    "@resetTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeCompleted": "交换完成！",
+    "@tradeCompleted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "step": "步骤",
+    "@step": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradeDetail": "交易详情",
+    "@tradeDetail": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "requestedTrade": "已请求的交易",
+    "@requestedTrade": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapUUID": "UUID交换",
+    "@swapUUID": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowse": "浏览",
+    "@mediaBrowse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaSaved": "已收藏",
+    "@mediaSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enable": "您仍然可以启用{remains}，已选择：{selected}",
+    "@enable": {
+        "type": "text",
+        "placeholders_order": [
+            "selected",
+            "remains"
+        ],
+        "placeholders": {
+            "selected": {},
+            "remains": {}
+        }
+    },
+    "mediaNotSavedDescription": "您没有收藏的文章",
+    "@mediaNotSavedDescription": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBrowseFeed": "浏览Feed",
+    "@mediaBrowseFeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "mediaBy": "通过",
+    "@mediaBy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lockScreenAuth": "请验证！",
+    "@lockScreenAuth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noTxs": "没有交易",
+    "@noTxs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "done": "完成",
+    "@done": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinTitle": "激活货币：",
+    "@selectCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoinInfo": "选择您想要添加到投资组合的货币",
+    "@selectCoinInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noArticles": "没有新闻-请稍后再查看",
+    "@noArticles": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade1": "無法撤銷交换请求！",
+    "@infoTrade1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoTrade2": "交换最长需要60分钟。不要关闭此应用程序！",
+    "@infoTrade2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapDetailTitle": "确认兑换细节",
+    "@swapDetailTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeTitle": "所需最小量",
+    "@minVolumeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeToggle": "使用自定义最小量",
+    "@minVolumeToggle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nonNumericInput": "该值必须是数字",
+    "@nonNumericInput": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeIsTDH": "必须低于售出量",
+    "@minVolumeIsTDH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minVolumeInput": "必须大于{minValue} {coin}",
+    "@minVolumeInput": {
+        "type": "text",
+        "placeholders_order": [
+            "minValue",
+            "coin"
+        ],
+        "placeholders": {
+            "minValue": {},
+            "coin": {}
+        }
+    },
+    "checkSeedPhrase": "检查助记词",
+    "@checkSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseTitle": "请再次确认助记词",
+    "@checkSeedPhraseTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseInfo": "您的助记词很重要——因此我们要确保它是正确的。我们将问您三个关于您的助记词的问题，以确保您可以随时轻松地恢复钱包。",
+    "@checkSeedPhraseInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseSubtile": "您的助記詞的第 {index}個单词是什麼？",
+    "@checkSeedPhraseSubtile": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseHint": "请输入第 {index}个单词",
+    "@checkSeedPhraseHint": {
+        "type": "text",
+        "placeholders_order": [
+            "index"
+        ],
+        "placeholders": {
+            "index": {}
+        }
+    },
+    "checkSeedPhraseButton1": "继续",
+    "@checkSeedPhraseButton1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkSeedPhraseButton2": "返回並再次檢查",
+    "@checkSeedPhraseButton2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewInExplorerButton": "资源管理器",
+    "@viewInExplorerButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activateAccessBiometric": "启动生物识别功能",
+    "@activateAccessBiometric": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allowCustomSeed": "允许自定义助记词",
+    "@allowCustomSeed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warning": "警告",
+    "@warning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "iUnderstand": "我已了解",
+    "@iUnderstand": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customSeedWarning": "自定义助记词的安全性可能比自动生成的符合BIP39规范的助记词或私钥（WIF）低，更容易被破解。如您已了解风险并知道您正在做什么，请在下面的框中输入\"{iUnderstand}\"。",
+    "@customSeedWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "iUnderstand"
+        ],
+        "placeholders": {
+            "iUnderstand": {}
+        }
+    },
+    "hintEnterPassword": "请输入您的密码",
+    "@hintEnterPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "yourWallet": "您的钱包",
+    "@yourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithSeedPhrase": "忘记密码？用助记词恢复钱包",
+    "@signInWithSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "signInWithPassword": "使用密码登录",
+    "@signInWithPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintEnterSeedPhrase": "请输入您的助记词",
+    "@hintEnterSeedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongPassword": "密码不匹配。请重试",
+    "@wrongPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintNameYourWallet": "命名您的钱包",
+    "@hintNameYourWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoWalletPassword": "安全起见，您必须为加密钱包设置密码。",
+    "@infoWalletPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmPassword": "确认密码",
+    "@confirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dontWantPassword": "我不想要使用密碼",
+    "@dontWantPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "areYouSure": "您确定吗？",
+    "@areYouSure": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "infoPasswordDialog": "使用安全密码，不要将其存储在同一设备上",
+    "@infoPasswordDialog": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "setUpPassword": "创建密码",
+    "@setUpPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "createAWallet": "创建钱包",
+    "@createAWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "restoreWallet": "恢复",
+    "@restoreWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintPassword": "密码",
+    "@hintPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "passwordRequirement": "密码必须至少包含12个字符，包括一个小写、一个大写和一个特殊符号",
+    "@passwordRequirement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCreatePassword": "创建密码",
+    "@hintCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintConfirmPassword": "确认密码",
+    "@hintConfirmPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hintCurrentPassword": "当前密码",
+    "@hintCurrentPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutsettings": "注销设置",
+    "@logoutsettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutOnExit": "退出时注销",
+    "@logoutOnExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteWallet": "删除钱包",
+    "@deleteWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "delete": "删除",
+    "@delete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan1": "您确定要删除",
+    "@settingDialogSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan2": "钱包吗",
+    "@settingDialogSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan3": "如果是，请确认您已",
+    "@settingDialogSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan4": "记下助记词",
+    "@settingDialogSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingDialogSpan5": "以便在将来恢复您的钱包",
+    "@settingDialogSpan5": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "backupTitle": "备份",
+    "@backupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "version": "版本",
+    "@version": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "viewSeedAndKeys": "助记词和私钥",
+    "@viewSeedAndKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seedPhrase": "助记词",
+    "@seedPhrase": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKeys": "私钥",
+    "@privateKeys": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "privateKey": "私钥",
+    "@privateKey": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterpassword": "继续前请输入密码",
+    "@enterpassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "clipboardCopy": "复制到剪贴板",
+    "@clipboardCopy": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlock": "解锁",
+    "@unlock": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "unlockSuccess": "成功解锁 {amnt} 基金 - 交易: {hash}",
+    "@unlockSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amnt",
+            "hash"
+        ],
+        "placeholders": {
+            "amnt": {},
+            "hash": {}
+        }
+    },
+    "unlockFunds": "解锁基金",
+    "@unlockFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrders": "没有订单，请先交易",
+    "@noOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrder": "请输入 {coinName} 量",
+    "@noOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "bestAvailableRate": "兑换率",
+    "@bestAvailableRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "receiveLower": "接收",
+    "@receiveLower": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makeAorder": "下订单",
+    "@makeAorder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeTitle": "兑换",
+    "@exchangeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orders": "订单",
+    "@orders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectCoin": "选择货币",
+    "@selectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "lessThanCaution": "❗注意！ {coinName} 市场的 24 小时交易量不到 1 万美元！",
+    "@lessThanCaution": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "selectLanguage": "选择语言",
+    "@selectLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFunds": "无基金",
+    "@noFunds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noFundsDetected": "没有可用基金-请先存入",
+    "@noFundsDetected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "goToPorfolio": "前往投资组合",
+    "@goToPorfolio": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noOrderAvailable": "点击创建订单",
+    "@noOrderAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientTitle": "交易量不足",
+    "@insufficientTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "insufficientText": "此订单最小交易量为",
+    "@insufficientText": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreated": "订单已创建",
+    "@orderCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderCreatedInfo": "订单已成功创建",
+    "@orderCreatedInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showMyOrders": "显示我的订单",
+    "@showMyOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValue": "最低售出量为{number} {coinName}",
+    "@minValue": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "titleCreatePassword": "创建密码",
+    "@titleCreatePassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minValueBuy": "最低买入量为{number} {coinName}",
+    "@minValueBuy": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueSell": "最低售出量为 {number} {coinName}",
+    "@minValueSell": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName",
+            "number"
+        ],
+        "placeholders": {
+            "coinName": {},
+            "number": {}
+        }
+    },
+    "minValueOrder": "最小交易量为 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
+    "@minValueOrder": {
+        "type": "text",
+        "placeholders_order": [
+            "buyCoin",
+            "buyAmount",
+            "sellCoin",
+            "sellAmount"
+        ],
+        "placeholders": {
+            "buyCoin": {},
+            "buyAmount": {},
+            "sellCoin": {},
+            "sellAmount": {}
+        }
+    },
+    "enterSellAmount": "您必须先输入卖出数量",
+    "@enterSellAmount": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "encryptingWallet": "錢包加密中",
+    "@encryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "decryptingWallet": "钱包解密中",
+    "@decryptingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notEnoughtBalanceForFee": "手续费余额不足-减少交易量",
+    "@notEnoughtBalanceForFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noInternet": "无互联网连接",
+    "@noInternet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtKomodo": "基于Komodo",
+    "@builtKomodo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pleaseAddCoin": "请添加货币",
+    "@pleaseAddCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRestored": "已重新连接互联网",
+    "@internetRestored": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "internetRefreshButton": "刷新",
+    "@internetRefreshButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "legalTitle": "合法的",
+    "@legalTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "disclaimerAndTos": "免责声明 & 使用条款",
+    "@disclaimerAndTos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepteula": "同意接受终端使用者授权协议 (EULA)",
+    "@accepteula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "accepttac": "接受条款与条件",
+    "@accepttac": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "confirmeula": "我已了解点击以下的按钮即代表我已阅读并接受终端使用者授权协议(EULA) & 使用条款与条件",
+    "@confirmeula": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasFee": "{coin} 费用",
+    "@gasFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notEnoughGas": "没有足够的{coin} 用于交易！",
+    "@notEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "gasNotActive": "请激活{coin}.",
+    "@gasNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "youWillReceiveClaim": "您将获得 {amount} {coin}",
+    "@youWillReceiveClaim": {
+        "type": "text",
+        "placeholders_order": [
+            "amount",
+            "coin"
+        ],
+        "placeholders": {
+            "amount": {},
+            "coin": {}
+        }
+    },
+    "seeOrders": "点击查看{amount} 交易",
+    "@seeOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "clickToSee": "点击查看",
+    "@clickToSee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "price": "价格",
+    "@price": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "availableVolume": "最大交易量",
+    "@availableVolume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "configureWallet": "正在配置您的钱包，请稍候。。。",
+    "@configureWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "titleCurrentAsk": "选择订单",
+    "@titleCurrentAsk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txFeeTitle": "交易费用",
+    "@txFeeTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tradingFee": "交易费用：",
+    "@tradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasAmount": "{coin} 余额不足以支付交易费用。",
+    "@swapGasAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "swapGasAmountRequired": "{coin} 余额不足以支付交易费用。需要 {coin} {amount}",
+    "@swapGasAmountRequired": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "amount"
+        ],
+        "placeholders": {
+            "coin": {},
+            "amount": {}
+        }
+    },
+    "invalidSwap": "无法继续交换",
+    "@invalidSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showDetails": "显示详细信息",
+    "@showDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeRate": "兑换率",
+    "@exchangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectedOrder": "选择订单",
+    "@selectedOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minOrder": "最小交易量",
+    "@minOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "maxOrder": "最大交易量",
+    "@maxOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidSwapDetailsLink": "详细信息",
+    "@invalidSwapDetailsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapGasActivate": "请先激活 {coin} 并充值余额",
+    "@swapGasActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "tradePreimageError": "无法计算交易费用",
+    "@tradePreimageError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "remove": "停用",
+    "@remove": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletOnly": "仅钱包",
+    "@walletOnly": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyWallet": "钱包名称不能为空",
+    "@emptyWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletMaxChar": "钱包名称最多40个字符",
+    "@walletMaxChar": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "walletInUse": "钱包名称已被使用",
+    "@walletInUse": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dexIsNotAvailable": "DEX不适合该货币",
+    "@dexIsNotAvailable": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterCoin": "搜索货币",
+    "@searchFilterCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSmartChain": "选择所有智能链",
+    "@searchFilterSubtitleSmartChain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleTestCoins": "选择所有测试资产",
+    "@searchFilterSubtitleTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleERC": "选择所有ERC代币",
+    "@searchFilterSubtitleERC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSLP": "选择所有 SLP 代币",
+    "@searchFilterSubtitleSLP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleCosmos": "选择所有 Cosmos 网络",
+    "@searchFilterSubtitleCosmos": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleIris": "选择所有虹膜网络",
+    "@searchFilterSubtitleIris": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleKRC": "选择所有Kucoin代币",
+    "@searchFilterSubtitleKRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHRC": "选择所有Harmony代币",
+    "@searchFilterSubtitleHRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleETC": "选择所有ETC代币",
+    "@searchFilterSubtitleETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleSBCH": "选择所有SmartBCH代币",
+    "@searchFilterSubtitleSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleAVX": "选择所有Avax代币",
+    "@searchFilterSubtitleAVX": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleUBQ": "选择所有Ubiq货币",
+    "@searchFilterSubtitleUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleBEP": "选择所有BEP代币",
+    "@searchFilterSubtitleBEP": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitlePLG": "选择所有Polygon代币",
+    "@searchFilterSubtitlePLG": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleQRC": "选择所有QRC代币",
+    "@searchFilterSubtitleQRC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleHCO": "选择所有HecoChain代币",
+    "@searchFilterSubtitleHCO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleZHTLC": "选择所有ZHTLC币",
+    "@searchFilterSubtitleZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleFTM": "选择所有Fantom代币",
+    "@searchFilterSubtitleFTM": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleMVR": "选择所有Moonriver代币",
+    "@searchFilterSubtitleMVR": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFee": "定制费用",
+    "@customFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasLimit": "燃料上限",
+    "@gasLimit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "gasPrice": "燃料价格",
+    "@gasPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "customFeeWarning": "选择定制费用前务必明确知晓自己的行为",
+    "@customFeeWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchFilterSubtitleutxo": "选择所有UTXO货币",
+    "@searchFilterSubtitleutxo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHRC20": "HRC20",
+    "@tagHRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagMVR20": "MVR20",
+    "@tagMVR20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagHCO20": "HCO20",
+    "@tagHCO20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKRC20": "KRC20",
+    "@tagKRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagERC20": "ERC20",
+    "@tagERC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagAVX20": "AVX20",
+    "@tagAVX20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagBEP20": "BEP20",
+    "@tagBEP20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagQRC20": "QRC20",
+    "@tagQRC20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagPLG20": "PLG20",
+    "@tagPLG20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagFTM20": "FTM20",
+    "@tagFTM20": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagZHTLC": "ZHTLC",
+    "@tagZHTLC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagKMD": "KMD",
+    "@tagKMD": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagETC": "ETC",
+    "@tagETC": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagSBCH": "SBCH",
+    "@tagSBCH": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tagUBQ": "UBQ",
+    "@tagUBQ": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "builtOnKmd": "基于Komodo",
+    "@builtOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "poweredOnKmd": "由Komodo支持",
+    "@poweredOnKmd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "errorNotEnoughGas": "燃料不足-至少使用｛gas｝Gwei",
+    "@errorNotEnoughGas": {
+        "type": "text",
+        "placeholders_order": [
+            "gas"
+        ],
+        "placeholders": {
+            "gas": {}
+        }
+    },
+    "orderCancel": "所有{coin}订单将被取消。",
+    "@orderCancel": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "deleteConfirm": "确认停用",
+    "@deleteConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan1": "是否要",
+    "@deleteSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan2": "从投资组合中删除？所有不匹配的订单将被取消。",
+    "@deleteSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deleteSpan3": " 也将被停用",
+    "@deleteSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinTitle": "无法停用",
+    "@cantDeleteDefaultCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinSpan": "是默认币。无法停用默认币。",
+    "@cantDeleteDefaultCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cantDeleteDefaultCoinOk": "好的",
+    "@cantDeleteDefaultCoinOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "share": "分享",
+    "@share": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "warningShareLogs": "警告-在特殊情况下，此登录数据包含敏感信息，可用于消费交换失败的货币！",
+    "@warningShareLogs": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterOldPinCode": "输入您的旧PIN",
+    "@enterOldPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enterNewPinCode": "输入您的新PIN",
+    "@enterNewPinCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "authenticate": "身份验证",
+    "@authenticate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "settingLanguageTitle": "语言",
+    "@settingLanguageTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "englishLanguage": "英文",
+    "@englishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "frenchLanguage": "法语",
+    "@frenchLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deutscheLanguage": "德语",
+    "@deutscheLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "chineseLanguage": "中文",
+    "@chineseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "russianLanguage": "俄语",
+    "@russianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "japaneseLanguage": "日文",
+    "@japaneseLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "turkishLanguage": "土耳其语",
+    "@turkishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hungarianLanguage": "匈牙利语",
+    "@hungarianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "spanishLanguage": "西班牙语",
+    "@spanishLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "koreanLanguage": "韩国人",
+    "@koreanLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ukrainianLanguage": "乌克兰",
+    "@ukrainianLanguage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetName": "水龙头",
+    "@faucetName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetSuccess": "成功",
+    "@faucetSuccess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetError": "错误",
+    "@faucetError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetTimedOut": "请求超时",
+    "@faucetTimedOut": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "faucetInProgress": "正在向 {coin} 水龙头发送请求",
+    "@faucetInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "Optional": "选修的",
+    "@Optional": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Sound": "声音",
+    "@Sound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Play at full volume": "音量开到最大",
+    "@Play at full volume": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Taker": "吃单",
+    "@Taker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have a fresh order that is trying to match with an existing order": "您有一个新订单正在尝试与现有订单匹配",
+    "@you have a fresh order that is trying to match with an existing order": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Maker": "挂单",
+    "@Maker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an order that new orders can match with": "你有一个新订单可以匹配的订单",
+    "@you have an order that new orders can match with": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Active": "活跃",
+    "@Active": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "you have an active swap in progress": "您有一个正在进行的活跃交换",
+    "@you have an active swap in progress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Failed": "失败",
+    "@Failed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap fails": "交换失败",
+    "@a swap fails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Applause": "掌声",
+    "@Applause": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "a swap runs to completion": "交换完成",
+    "@a swap runs to completion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "Can't play that": "不能播放",
+    "@Can't play that": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundCantPlayThatMsg": "请选择mp3或wav文件。我们将在{description}时播放它。",
+    "@soundCantPlayThatMsg": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundPlayedWhen": "当{description}播放",
+    "@soundPlayedWhen": {
+        "type": "text",
+        "placeholders_order": [
+            "description"
+        ],
+        "placeholders": {
+            "description": {
+                "example": "a swap runs to completion"
+            }
+        }
+    },
+    "soundsDialogTitle": "声音",
+    "@soundsDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsExplanation": "交换时，如果您有一个活跃的挂单交易，会收到声音提醒。\n原子交换协议要求参与者在线才能成功交易，声音通知可以帮助实现这一点。",
+    "@soundsExplanation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsNote": "请注意，您可以在应用程序设置中设置自定义声音。",
+    "@soundsNote": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundsDoNotShowAgain": "已知晓，不再显示",
+    "@soundsDoNotShowAgain": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsTitle": "声音设置",
+    "@soundSettingsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "soundSettingsLink": "声音",
+    "@soundSettingsLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTab": "市场",
+    "@marketsTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsTitle": "市场",
+    "@marketsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsPrice": "价格",
+    "@marketsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderbook": "订单记录",
+    "@marketsOrderbook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsChart": "图表",
+    "@marketsChart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsDepth": "交易深度",
+    "@marketsDepth": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsPrice": "价格",
+    "@orderDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSells": "卖出",
+    "@orderDetailsSells": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsFor": "与",
+    "@orderDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsMin": "最小量",
+    "@orderDetailsMin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsAddress": "地址",
+    "@orderDetailsAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsExpedient": "划算的: CEX +{delta}%",
+    "@orderDetailsExpedient": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsExpensive": "昂贵的: CEX {delta}%",
+    "@orderDetailsExpensive": {
+        "type": "text",
+        "placeholders_order": [
+            "delta"
+        ],
+        "placeholders": {
+            "delta": {}
+        }
+    },
+    "orderDetailsIdentical": "CEX相同",
+    "@orderDetailsIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsReceive": "接收",
+    "@orderDetailsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSpend": "花费",
+    "@orderDetailsSpend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ownOrder": "这是您个人的订单",
+    "@ownOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsSelectCoins": "请选择货币",
+    "@marketsSelectCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectTitle": "选择货币",
+    "@coinSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectNotFound": "没有活跃币",
+    "@coinSelectNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinSelectClear": "清除",
+    "@coinSelectClear": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersTablePrice": "价格 ({coin})",
+    "@ordersTablePrice": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableAmount": "数量({coin})",
+    "@ordersTableAmount": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "ordersTableTotal": "总计 ({coin})",
+    "@ordersTableTotal": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "marketsNoBids": "未找到出价",
+    "@marketsNoBids": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsNoAsks": "未找到问题",
+    "@marketsNoAsks": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "marketsOrderDetails": "订单详细信息",
+    "@marketsOrderDetails": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "candleChartError": "出现错误，稍后重试",
+    "@candleChartError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTitle": "奖励信息",
+    "@rewardsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReadMore": "阅读有关KMD活跃用户奖励的更多信息",
+    "@rewardsReadMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsCancel": "取消",
+    "@rewardsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsReceive": "接收",
+    "@rewardsReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noRewards": "没有奖励可领取",
+    "@noRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTitle": "奖励信息",
+    "@rewardsTableTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableUXTO": "UTXO 数量\nKMD",
+    "@rewardsTableUXTO": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableRewards": "奖励，KMD",
+    "@rewardsTableRewards": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableFiat": "法币",
+    "@rewardsTableFiat": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableTime": "剩余时间",
+    "@rewardsTableTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTableStatus": "状态",
+    "@rewardsTableStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupTitle": "奖励状态：",
+    "@rewardsPopupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsPopupOk": "好的",
+    "@rewardsPopupOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsTimeDays": "{dd} 天",
+    "@rewardsTimeDays": {
+        "type": "text",
+        "placeholders_order": [
+            "dd"
+        ],
+        "placeholders": {
+            "dd": {}
+        }
+    },
+    "rewardsTimeHours": "{hh}小时 {minutes}分钟",
+    "@rewardsTimeHours": {
+        "type": "text",
+        "placeholders_order": [
+            "hh",
+            "minutes"
+        ],
+        "placeholders": {
+            "hh": {},
+            "minutes": {}
+        }
+    },
+    "rewardsTimeMin": "{mm}分钟",
+    "@rewardsTimeMin": {
+        "type": "text",
+        "placeholders_order": [
+            "mm"
+        ],
+        "placeholders": {
+            "mm": {}
+        }
+    },
+    "rewardsSuccess": "成功！收到 {amount}KMD",
+    "@rewardsSuccess": {
+        "type": "text",
+        "placeholders_order": [
+            "amount"
+        ],
+        "placeholders": {
+            "amount": {}
+        }
+    },
+    "rewardsError": "出现错误。请稍后再试。",
+    "@rewardsError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountShort": "<10KMD",
+    "@rewardsLowAmountShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsLowAmountLong": "UTXO金额小于10 KMD",
+    "@rewardsLowAmountLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressShort": "处理",
+    "@rewardsInProgressShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsInProgressLong": "交易正在进行",
+    "@rewardsInProgressLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourShort": "<1小时",
+    "@rewardsOneHourShort": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsOneHourLong": "还未过去一小时",
+    "@rewardsOneHourLong": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rewardsButton": "领取奖励",
+    "@rewardsButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seeTxHistory": "查看交易记录",
+    "@seeTxHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryActivating": "正在重试激活所有货币",
+    "@retryActivating": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willBeRedirected": "完成后，您将跳转至投资组合页面",
+    "@willBeRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tryRestarting": "如果还是有一些货币未被激活，请尝试重启应用程序。",
+    "@tryRestarting": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedTo": "我们无法激活 {coinAbbr}",
+    "@weFailedTo": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "pleaseRestart": "请重启应用程序后重试，或按下面的按钮。",
+    "@pleaseRestart": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "retryAll": "重试激活所有",
+    "@retryAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "automaticRedirected": "重新激活后，您将自动跳转至投资组合页面。",
+    "@automaticRedirected": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "weFailedToActivate": "我们无法激活{coinAbbr}.\n请重启应用程序后重试",
+    "@weFailedToActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "isUnavailable": "{coinAbbr} 不可用:(",
+    "@isUnavailable": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
+    "multiTab": "多个",
+    "@multiTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFixErrors": "请在继续之前修复所有错误",
+    "@multiFixErrors": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreate": "创建",
+    "@multiCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrder": "订单",
+    "@multiCreateOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiCreateOrders": "订单",
+    "@multiCreateOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBasePlaceholder": "货币",
+    "@multiBasePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiSellTitle": "卖出",
+    "@multiSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseSelectTitle": "卖出",
+    "@multiBaseSelectTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiBaseAmtPlaceholder": "数量",
+    "@multiBaseAmtPlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiReceiveTitle": "接收：",
+    "@multiReceiveTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTablePrice": "价格/CEX",
+    "@multiTablePrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiTableAmt": "接收量",
+    "@multiTableAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatDesc": "请输入要接收的法币数量",
+    "@multiFiatDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatCancel": "取消",
+    "@multiFiatCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiFiatFill": "自动填充",
+    "@multiFiatFill": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiEthFee": "费用",
+    "@multiEthFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiLowerThanFee": "{coin}不足支付。最低余额为 {fee} {coin}",
+    "@multiLowerThanFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coin",
+            "fee"
+        ],
+        "placeholders": {
+            "coin": {},
+            "fee": {}
+        }
+    },
+    "multiConfirmTitle": "创建{number}订单：",
+    "@multiConfirmTitle": {
+        "type": "text",
+        "placeholders_order": [
+            "number"
+        ],
+        "placeholders": {
+            "number": {}
+        }
+    },
+    "multiConfirmCancel": "取消",
+    "@multiConfirmCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiConfirmConfirm": "确认",
+    "@multiConfirmConfirm": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidSellAmt": "售出量无效",
+    "@multiInvalidSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMaxSellAmt": "最大售出量为",
+    "@multiMaxSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiMinSellAmt": "最小售出量为",
+    "@multiMinSellAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "multiInvalidAmt": "数量无效",
+    "@multiInvalidAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "invalidCoinAddress": "{coin} 地址无效",
+    "@invalidCoinAddress": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiActivateGas": "先激活{coin}并充值余额",
+    "@multiActivateGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiLowGas": "{coin}余额过低",
+    "@multiLowGas": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "multiMinReceiveAmt": "最小接收量为",
+    "@multiMinReceiveAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBook": "地址簿",
+    "@addressBook": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookTitle": "地址簿",
+    "@addressBookTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitle": "联系人详细信息",
+    "@contactTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookEmpty": "地址簿为空",
+    "@addressBookEmpty": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressBookFilter": "仅显示具有{title}地址的联系人",
+    "@addressBookFilter": {
+        "type": "text",
+        "placeholders_order": [
+            "title"
+        ],
+        "placeholders": {
+            "title": {}
+        }
+    },
+    "createContact": "创建联系人",
+    "@createContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactTitleName": "名称",
+    "@contactTitleName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "editContact": "编辑联系人",
+    "@editContact": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactCancel": "取消",
+    "@contactCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactSave": "保存",
+    "@contactSave": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDiscardBtn": "放弃",
+    "@contactDiscardBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExit": "退出",
+    "@contactExit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactExitWarning": "放弃更改？",
+    "@contactExitWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressAdd": "添加地址",
+    "@addressAdd": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressSelectCoin": "选择货币",
+    "@addressSelectCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "searchForTicker": "搜索货币代码",
+    "@searchForTicker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDelete": "删除联系人",
+    "@contactDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactDeleteWarning": "确认删除该联系人{name}？",
+    "@contactDeleteWarning": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contactDeleteBtn": "删除",
+    "@contactDeleteBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactNotFound": "未找到联系人",
+    "@contactNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contactEdit": "编辑",
+    "@contactEdit": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressNotFound": "未找到任何内容",
+    "@addressNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noSuchCoin": "没有该货币",
+    "@noSuchCoin": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "addressCoinInactive": "您无法将基金发送到{abbr}地址，因为{abbr}未激活。请转到投资组合页面",
+    "@addressCoinInactive": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "warningOkBtn": "好的",
+    "@warningOkBtn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyName": "联系人名称不能为空",
+    "@emptyName": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyCoin": "输入{abbr}地址",
+    "@emptyCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "camoPinTitle": "伪装PIN",
+    "@camoPinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinLink": "伪装PIN",
+    "@camoPinLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOn": "开启",
+    "@camoPinOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinOff": "关闭",
+    "@camoPinOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoTitle": "无效PIN",
+    "@matchingCamoTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoChange": "改变",
+    "@matchingCamoChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinDesc": "如果您用伪装PIN解锁应用程序，将显示一个虚假的低余额，并且设置中不会显示伪装PIN配置选项。",
+    "@camoPinDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchingCamoPinError": "您的通用PIN码和伪装PIN码相同。伪装模式将不可用。请更改伪装PIN",
+    "@matchingCamoPinError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflict": "不能同时启用伪装PIN和生物识别保护",
+    "@camoPinBioProtectionConflict": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinBioProtectionConflictTitle": "伪装PIN和生物识别保护冲突",
+    "@camoPinBioProtectionConflictTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "generalPinNotActive": "常规PIN保护未激活。\n伪装模式将失效\n请激活PIN保护",
+    "@generalPinNotActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fakeBalanceAmt": "虚假余额",
+    "@fakeBalanceAmt": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinNotFound": "未找到伪装PIN",
+    "@camoPinNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinCreate": "创建伪装PIN",
+    "@camoPinCreate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinSaved": "已保存的伪装PIN",
+    "@camoPinSaved": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinInvalid": "无效的伪装PIN",
+    "@camoPinInvalid": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoPinChange": "更改伪装PIN",
+    "@camoPinChange": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupTitle": "伪装PIN设置",
+    "@camoSetupTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "camoSetupSubtitle": "输入新的伪装PIN",
+    "@camoSetupSubtitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOn": "开启",
+    "@protectionCtrlOn": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlOff": "关闭",
+    "@protectionCtrlOff": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlConfirmations": "确认",
+    "@protectionCtrlConfirmations": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "dPow": "Komodo dPoW安全",
+    "@dPow": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlCustom": "使用自定义保护设置",
+    "@protectionCtrlCustom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "protectionCtrlWarning": "警告，此原子交换不受dPoW保护。",
+    "@protectionCtrlWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "buyOrderType": "如果不匹配，则转为挂单",
+    "@buyOrderType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexChangeRate": "CEX兑换率",
+    "@cexChangeRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpedient": "划算的",
+    "@exchangeExpedient": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeExpensive": "昂贵的",
+    "@exchangeExpensive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exchangeIdentical": "与CEX相同",
+    "@exchangeIdentical": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedToCex": "与CEX比较",
+    "@comparedToCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "comparedTo24hrCex": "与平均值相比24小时CEX价格",
+    "@comparedTo24hrCex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersActive": "活跃",
+    "@ordersActive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "ordersHistory": "历史记录",
+    "@ordersHistory": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsTitle": "详细信息",
+    "@orderDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSettings": "单击打开详细信息，然后长按选择订购",
+    "@orderDetailsSettings": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsCancel": "取消",
+    "@orderDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderDetailsSelect": "选择",
+    "@orderDetailsSelect": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noMatchingOrders": "无匹配订单",
+    "@noMatchingOrders": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerOrder": "挂单交易",
+    "@makerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "takerOrder": "吃单交易",
+    "@takerOrder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapCurrent": "现状",
+    "@swapCurrent": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapEstimated": "预估",
+    "@swapEstimated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapStarted": "已开始",
+    "@swapStarted": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapTotal": "总共",
+    "@swapTotal": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "swapProgress": "进度详情",
+    "@swapProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closeMessage": "关闭错误信息",
+    "@closeMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "openMessage": "打开错误消息",
+    "@openMessage": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxTitle": "应记交易",
+    "@notifTxTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifTxText": "您已收到｛coin｝交易！",
+    "@notifTxText": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "notifSwapCompletedTitle": "交换已完成",
+    "@notifSwapCompletedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapCompletedText": "{sell}/{buy} 已成功完成交换",
+    "@notifSwapCompletedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapFailedTitle": "交换失败",
+    "@notifSwapFailedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapFailedText": "{sell}/{buy}交换失败",
+    "@notifSwapFailedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapTimeoutTitle": "交换超时",
+    "@notifSwapTimeoutTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapTimeoutText": "{sell}/{buy}交换超时",
+    "@notifSwapTimeoutText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "notifSwapStatusTitle": "交换状态已更改",
+    "@notifSwapStatusTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedTitle": "已开始新交换",
+    "@notifSwapStartedTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notifSwapStartedText": "{sell}/{buy}交换开始",
+    "@notifSwapStartedText": {
+        "type": "text",
+        "placeholders_order": [
+            "sell",
+            "buy"
+        ],
+        "placeholders": {
+            "sell": {},
+            "buy": {}
+        }
+    },
+    "language": "语言",
+    "@language": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currency": "货币",
+    "@currency": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hideBalance": "隐藏余额",
+    "@hideBalance": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "switchTheme": "切换主题",
+    "@switchTheme": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cex": "CEX(中心化交易所)",
+    "@cex": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexData": "CEX 数据",
+    "@cexData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexDataDesc": "带有此图标的市场数据（价格、图表等）来源于第三方(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
+    "@cexDataDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "checkForUpdates": "检查更新",
+    "@checkForUpdates": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "logoutWarning": "您确定要立即注销吗？",
+    "@logoutWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "currencyDialogTitle": "货币",
+    "@currencyDialogTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "txLimitExceeded": "请求过多。超出交易历史请求限制。请稍后重试",
+    "@txLimitExceeded": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "milliseconds": "毫秒",
+    "@milliseconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "seconds": "秒",
+    "@seconds": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minutes": "分钟",
+    "@minutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "longMinutes": "分钟",
+    "@longMinutes": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "hours": "小时",
+    "@hours": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "moreTab": "更多",
+    "@moreTab": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "less": "较少",
+    "@less": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsTitle": "历史记录",
+    "@oldLogsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsDelete": "删除",
+    "@oldLogsDelete": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "deletingWallet": "删除钱包中",
+    "@deletingWallet": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "oldLogsUsed": "占用的空间",
+    "@oldLogsUsed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "okButton": "好的",
+    "@okButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "closePreview": "关闭预览",
+    "@closePreview": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelButton": "取消",
+    "@cancelButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "scrollToContinue": "滚动到底部继续...",
+    "@scrollToContinue": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "developerTitle": "开发者",
+    "@developerTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableTestCoins": "启用测试币",
+    "@enableTestCoins": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsTitle": "挂单交易详细信息",
+    "@makerDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSell": "卖出",
+    "@makerDetailsSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsFor": "接收",
+    "@makerDetailsFor": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsPrice": "价格",
+    "@makerDetailsPrice": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCancel": "取消订单",
+    "@makerDetailsCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsId": "订单ID",
+    "@makerDetailsId": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsCreated": "创建",
+    "@makerDetailsCreated": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsNoSwaps": "此订单未启动交换",
+    "@makerDetailsNoSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "makerDetailsSwaps": "此订单开始交换",
+    "@makerDetailsSwaps": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderFilled": "{fill}%已填充",
+    "@orderFilled": {
+        "type": "text",
+        "placeholders_order": [
+            "fill"
+        ],
+        "placeholders": {
+            "fill": {}
+        }
+    },
+    "noteTitle": "备注",
+    "@noteTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "notePlaceholder": "添加备注",
+    "@notePlaceholder": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLink": "导入",
+    "@importLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapLink": "导入单个交换",
+    "@importSingleSwapLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportLink": "导出",
+    "@exportLink": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importTitle": "导入",
+    "@importTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSingleSwapTitle": "导入交换",
+    "@importSingleSwapTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportTitle": "导出",
+    "@exportTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportDesc": "请选择要导出到加密文件中的项目。",
+    "@exportDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadDesc": "请选择要导入的加密文件。",
+    "@importLoadDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoadSwapDesc": "请选择要导入的纯文本交换文件。",
+    "@importLoadSwapDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importLoading": "开始",
+    "@importLoading": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDesc": "要导入的项目：",
+    "@importDesc": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportNotesTitle": "备注",
+    "@exportNotesTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportContactsTitle": "联系人",
+    "@exportContactsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSwapsTitle": "交换",
+    "@exportSwapsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "nothingFound": "无内容",
+    "@nothingFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportButton": "导出",
+    "@exportButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importButton": "导入",
+    "@importButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyExportPass": "加密密码不能为空",
+    "@emptyExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "emptyImportPass": "密码不能为空",
+    "@emptyImportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "matchExportPass": "密码必须匹配",
+    "@matchExportPass": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToExport": "未选择项目",
+    "@noItemsToExport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noItemsToImport": "未选择项目",
+    "@noItemsToImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectFileImport": "选择文件",
+    "@selectFileImport": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importFileNotFound": "找不到文件",
+    "@importFileNotFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "fingerprint": "指纹",
+    "@fingerprint": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassword": "密码",
+    "@importPassword": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassCancel": "取消",
+    "@importPassCancel": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importPassOk": "好的",
+    "@importPassOk": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "exportSuccessTitle": "项目成功导出",
+    "@exportSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSuccessTitle": "已成功导入项目：",
+    "@importSuccessTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importDecryptError": "密码无效或数据损坏",
+    "@importDecryptError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapJsonDecodingError": "解码json文件时出错",
+    "@importSwapJsonDecodingError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypePartial": "订单",
+    "@orderTypePartial": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderTypeUnknown": "未知类型订单",
+    "@orderTypeUnknown": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldntImportError": "无法导入：",
+    "@couldntImportError": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSomeItemsSkippedWarning": "已跳过某些项目",
+    "@importSomeItemsSkippedWarning": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importSwapFailed": "无法导入交换",
+    "@importSwapFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "importInvalidSwapData": "交换数据无效。请提供有效的交换状态JSON文件。",
+    "@importInvalidSwapData": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activating": "激活{coinName}",
+    "@activating": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "doNotCloseTheAppTapForMoreInfo": "不要关闭应用程序。点按了解更多信息...",
+    "@doNotCloseTheAppTapForMoreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "activation": "{coinName} 激活",
+    "@activation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "coinsAreActivated": "{protocolName} 币已激活",
+    "@coinsAreActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreNotActivated": "{protocolName} 代币未激活",
+    "@coinsAreNotActivated": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "coinsAreActivatedSuccessfully": "{protocolName}币激活成功",
+    "@coinsAreActivatedSuccessfully": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activationInProgress": "{protocolName} 激活正在进行中",
+    "@activationInProgress": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "activateCoins": "激活 {protocolName} 币？",
+    "@activateCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "protocolName"
+        ],
+        "placeholders": {
+            "protocolName": {}
+        }
+    },
+    "moreInfo": "更多信息",
+    "@moreInfo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "showAddress": "显示地址",
+    "@showAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHiddenPhishing": "由于可能存在网络钓鱼尝试，该交易被隐藏。",
+    "@transactionHiddenPhishing": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionAddress": "交易地址",
+    "@transactionAddress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "transactionHidden": "交易隐藏",
+    "@transactionHidden": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "couldNotLaunchUrl": "无法启动 URL",
+    "@couldNotLaunchUrl": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "willTakeTime": "这将需要一段时间，并且应用程序必须保持在前台。\n在激活过程中终止应用程序可能会导致问题。",
+    "@willTakeTime": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "minimizingWillTerminate": "警告：最小化 iOS 上的应用程序将终止激活过程。",
+    "@minimizingWillTerminate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enableNotificationsForActivationProgress": "请启用通知以获取有关激活进度的更新。",
+    "@enableNotificationsForActivationProgress": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "qrCodeScanner": "二维码扫描仪",
+    "@qrCodeScanner": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "foundQrCode": "找到二维码",
+    "@foundQrCode": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "contract": "合同",
+    "@contract": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startSwap": "开始交换",
+    "@startSwap": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "none": "没有任何",
+    "@none": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cexRate": "CEX 汇率",
+    "@cexRate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "incomingTransactionsProtectionSettings": "传入 {coinName} 交易保护设置",
+    "@incomingTransactionsProtectionSettings": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "showingOrders": "显示 {count} 个订单（共 {maxCount} 个）。",
+    "@showingOrders": {
+        "type": "text",
+        "placeholders_order": [
+            "count",
+            "maxCount"
+        ],
+        "placeholders": {
+            "count": {},
+            "maxCount": {}
+        }
+    },
+    "orderBookLess": "较少的",
+    "@orderBookLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "orderBookMore": "更多的",
+    "@orderBookMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "basedOnCoinRatio": "基于{coinName1}/{coinName2}",
+    "@basedOnCoinRatio": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName1",
+            "coinName2"
+        ],
+        "placeholders": {
+            "coinName1": {},
+            "coinName2": {}
+        }
+    },
+    "detailedFeesSendTradingFeeTransactionFee": "发送交易费 交易费",
+    "@detailedFeesSendTradingFeeTransactionFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesTradingFee": "交易费",
+    "@detailedFeesTradingFee": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "detailedFeesSendCoinTransactionFee": "发送 {coinName} 交易费",
+    "@detailedFeesSendCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "detailedFeesReceiveCoinTransactionFee": "接收{coinName}交易费",
+    "@detailedFeesReceiveCoinTransactionFee": {
+        "type": "text",
+        "placeholders_order": [
+            "coinName"
+        ],
+        "placeholders": {
+            "coinName": {}
+        }
+    },
+    "filtersButton": "过滤器",
+    "@filtersButton": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersStatus": "状态",
+    "@filtersStatus": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersAll": "全部",
+    "@filtersAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSuccessful": "成功",
+    "@filtersSuccessful": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFailed": "失败",
+    "@filtersFailed": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersFrom": "起始日期",
+    "@filtersFrom": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTo": "截止日期",
+    "@filtersTo": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersType": "吃单/挂单",
+    "@filtersType": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersMaker": "挂单",
+    "@filtersMaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "all": "全部",
+    "@all": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersTaker": "吃单",
+    "@filtersTaker": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersSell": "出售货币",
+    "@filtersSell": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersReceive": "接收货币",
+    "@filtersReceive": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "filtersClearAll": "清除所有过滤器",
+    "@filtersClearAll": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceTitle": "余额不足",
+    "@uriInsufficientBalanceTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan1": "余额不足，无法扫描",
+    "@uriInsufficientBalanceSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "uriInsufficientBalanceSpan2": "付款请求。",
+    "@uriInsufficientBalanceSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsTitle": "试图启用太多资产",
+    "@enablingTooManyAssetsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan1": "您已启用",
+    "@enablingTooManyAssetsSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan2": "资产并尝试启用",
+    "@enablingTooManyAssetsSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan3": "更多。最多启用",
+    "@enablingTooManyAssetsSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "enablingTooManyAssetsSpan4": "请在添加新资产前停用一些资产。",
+    "@enablingTooManyAssetsSpan4": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinsActivatedLimitReached": "您已选择最大资产数量",
+    "@coinsActivatedLimitReached": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledTitle": "已启用的资产太多",
+    "@tooManyAssetsEnabledTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan1": "您已",
+    "@tooManyAssetsEnabledSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan2": "启用资产。启用资产上限为",
+    "@tooManyAssetsEnabledSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "tooManyAssetsEnabledSpan3": "请在启用新资产前停用一些资产",
+    "@tooManyAssetsEnabledSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsTitle": "已请求的付款",
+    "@paymentUriDetailsTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsCoinSpan": "货币：",
+    "@paymentUriDetailsCoinSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAddressSpan": "接收方地址",
+    "@paymentUriDetailsAddressSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAmountSpan": "数量：",
+    "@paymentUriDetailsAmountSpan": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAcceptQuestion": "您接受这笔交易吗？",
+    "@paymentUriDetailsAcceptQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsAccept": "支付",
+    "@paymentUriDetailsAccept": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriDetailsDeny": "取消",
+    "@paymentUriDetailsDeny": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "paymentUriInactiveCoin": "{abbr} 未激活。请激活后重试。",
+    "@paymentUriInactiveCoin": {
+        "type": "text",
+        "placeholders_order": [
+            "abbr"
+        ],
+        "placeholders": {
+            "abbr": {}
+        }
+    },
+    "wrongCoinTitle": "错误货币",
+    "@wrongCoinTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan1": "您正在尝试扫描付款二维码",
+    "@wrongCoinSpan1": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan2": "但您在",
+    "@wrongCoinSpan2": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "wrongCoinSpan3": "提取页面",
+    "@wrongCoinSpan3": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSellTitle": "卖出",
+    "@simpleTradeSellTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeBuyTitle": "买入",
+    "@simpleTradeBuyTitle": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeRecieve": "接收",
+    "@simpleTradeRecieve": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeSend": "发送",
+    "@simpleTradeSend": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeClose": "关闭",
+    "@simpleTradeClose": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeActivate": "激活",
+    "@simpleTradeActivate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeMaxActiveCoins": "货币最大活跃量为{maxCoins}。请停用一些。",
+    "@simpleTradeMaxActiveCoins": {
+        "type": "text",
+        "placeholders_order": [
+            "maxCoins"
+        ],
+        "placeholders": {
+            "maxCoins": {}
+        }
+    },
+    "simpleTradeUnableActivate": "无法激活{coin}",
+    "@simpleTradeUnableActivate": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeNotActive": "{coin}未激活！",
+    "@simpleTradeNotActive": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeBuyHint": "请输入要买入的 {coin} 数量",
+    "@simpleTradeBuyHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeSellHint": "请输入要卖出的{coin}数量",
+    "@simpleTradeSellHint": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "simpleTradeShowLess": "收起",
+    "@simpleTradeShowLess": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "simpleTradeShowMore": "显示更多",
+    "@simpleTradeShowMore": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "noCoinFound": "未找到货币",
+    "@noCoinFound": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "rebrandingAnnouncement": "这是一个新时代！我们已正式将名称从“AtomicDEX”更改为“Komodo Wallet”",
+    "@rebrandingAnnouncement": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "officialPressRelease": "官方新闻稿",
+    "@officialPressRelease": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "shouldScanPastTransaction": "扫描过去的 {coin} 交易？",
+    "@shouldScanPastTransaction": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "cancelActivation": "取消激活",
+    "@cancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cancelActivationQuestion": "您确定要取消激活吗？",
+    "@cancelActivationQuestion": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "cofirmCancelActivation": "您确定要取消激活吗？",
+    "@cofirmCancelActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncTransactionsQuestion": "您想要同步哪些{name}交易？",
+    "@syncTransactionsQuestion": {
+        "type": "text",
+        "placeholders_order": [
+            "name"
+        ],
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "syncNewTransactions": "同步新交易",
+    "@syncNewTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromDate": "从指定日期同步",
+    "@syncFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "syncFromSaplingActivation": "从树苗激活同步",
+    "@syncFromSaplingActivation": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "selectDate": "选择日期",
+    "@selectDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "startDate": "开始日期",
+    "@startDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "futureTransactions": "我们将同步与您的公钥关联的激活后进行的未来交易。这是最快的选项，占用的存储空间最少。",
+    "@futureTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "allPastTransactions": "您的钱包将显示任何过去的交易。这将占用大量存储空间和时间，因为所有块都将被下载和扫描。",
+    "@allPastTransactions": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "pastTransactionsFromDate": "您的钱包将显示您过去在指定日期之后进行的交易。",
+    "@pastTransactionsFromDate": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     }
-  },
-  "activating": "激活{coinName}",
-  "@activating": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activation": "{coinName} 激活",
-  "@activation": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "activationInProgress": "{protocolName} 激活正在进行中",
-  "@activationInProgress": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "Active": "活跃",
-  "@Active": {
-    "type": "text"
-  },
-  "addCoin": "新增货币",
-  "@addCoin": {
-    "type": "text"
-  },
-  "addingCoinSuccess": "成功新增 {name}!",
-  "@addingCoinSuccess": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "addressAdd": "添加地址",
-  "@addressAdd": {
-    "type": "text"
-  },
-  "addressBook": "地址簿",
-  "@addressBook": {
-    "type": "text"
-  },
-  "addressBookEmpty": "地址簿为空",
-  "@addressBookEmpty": {
-    "type": "text"
-  },
-  "addressBookFilter": "仅显示具有{title}地址的联系人",
-  "@addressBookFilter": {
-    "type": "text",
-    "placeholders": {
-      "title": {}
-    }
-  },
-  "addressBookTitle": "地址簿",
-  "@addressBookTitle": {
-    "type": "text"
-  },
-  "addressCoinInactive": "您无法将基金发送到{abbr}地址，因为{abbr}未激活。请转到投资组合页面",
-  "@addressCoinInactive": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "addressNotFound": "未找到任何内容",
-  "@addressNotFound": {
-    "type": "text"
-  },
-  "addressSelectCoin": "选择货币",
-  "@addressSelectCoin": {
-    "type": "text"
-  },
-  "addressSend": "收款人钱包地址",
-  "@addressSend": {
-    "type": "text"
-  },
-  "advanced": "高级",
-  "@advanced": {
-    "type": "text"
-  },
-  "all": "全部",
-  "@all": {
-    "type": "text"
-  },
-  "allowCustomSeed": "允许自定义助记词",
-  "@allowCustomSeed": {
-    "type": "text"
-  },
-  "allPastTransactions": "您的钱包将显示任何过去的交易。这将占用大量存储空间和时间，因为所有块都将被下载和扫描。",
-  "@allPastTransactions": {
-    "type": "text"
-  },
-  "alreadyExists": "已存在",
-  "@alreadyExists": {
-    "type": "text"
-  },
-  "amount": "数量",
-  "@amount": {
-    "type": "text"
-  },
-  "amountToSell": "卖出量",
-  "@amountToSell": {
-    "type": "text"
-  },
-  "answer_1": "不{appName}是非托管应用。我们不会存储任何敏感数据，包括您的私钥、助记词或PIN。此数据仅存储在用户的设备上，不会转移。您的资产只由您掌控。",
-  "@answer_1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_10": "{appName} 适用于 Android 和 iPhone 上的移动设备，以及 <a href=\"https://komodoplatform.com/\">Windows、Mac 和 Linux 操作系统</a> 上的桌面设备。",
-  "@answer_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_2": "其他DEX（去中心化交易所）通常只允许您使用代理代币交易基于单个区块链网络的资产，并且只能用一个基金下一个订单。\n但用{appName}您可以在两个不同的区块链网络之间进行交易，且无需代理代币。您还可以用一个基金下多个订单。例如，您可以用KMD、QTUM或VRSC兑0.1 BTC，第一个订单成交后自动取消其他所有订单",
-  "@answer_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_3": "几个因素决定了每次交易的处理时间。交易资产的区块时间取决于各自的网络（比特币通常是最慢的）。此外，用户可以自定义安全偏好。例如，您可以要求{appName}在确认KMD交易为最终交易前确认3次，这使得交易时间短于等待公证的<a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">时间</a>.",
-  "@answer_3": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_4": "是的，必须保持互联网连接，并确保您的应用程序在运行，才能成功完成原子交换（网络短暂中断通常是可以的）。否则，如果是挂单，会有交易取消的风险，如果是吃单，会有资金损失的风险。原子交换协议要求双方参与者保持在线，并监控所涉及的区块链，确保该过程保持原子性。",
-  "@answer_4": {
-    "type": "text"
-  },
-  "answer_5": "在｛appName｝上进行交易时，需要考虑两种费用。\n1.｛appName｝收取约0.13%（交易量的1/777，但不低于0.0001）作为吃单交易的交易费用，挂单交易不收费。\n2.在进行原子交换交易时，无论挂单还是吃单，都需要向相关区块链支付常规的网络费用\n网络费用具体取决于你选择的交易对，不同交易对费用可能大大不同。",
-  "@answer_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_6": "是的 {appName} 通过 <a href=\"{link}\">{appCompanyShort} {name}</a>提供支持。团队和社区总是乐于提供帮助！",
-  "@answer_6": {
-    "type": "text",
-    "placeholders": {
-      "name": {},
-      "link": {},
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_7": "不是{appName} 是完全去中心化的。不会限制任何第三方用户访问。",
-  "@answer_7": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "answer_8": "{appName} 由{appCompanyShort}团队开发。{appCompanyShort}是最成熟的区块链项目之一，致力于开发创新解决方案，如原子交换、延迟工作量证明和可互操作的多链架构。",
-  "@answer_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyShort": {}
-    }
-  },
-  "answer_9": "绝对地！您可以阅读我们的<a href=\"https://developers.komodoplatform.com/\">开发者文档</a>了解更多详细信息，或者联系我们咨询您的合作伙伴关系。有具体的技术问题吗？ {appName} 开发者社区随时准备提供帮助！",
-  "@answer_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "Applause": "掌声",
-  "@Applause": {
-    "type": "text"
-  },
-  "areYouSure": "您确定吗？",
-  "@areYouSure": {
-    "type": "text"
-  },
-  "a swap fails": "交换失败",
-  "@a swap fails": {
-    "type": "text"
-  },
-  "a swap runs to completion": "交换完成",
-  "@a swap runs to completion": {
-    "type": "text"
-  },
-  "authenticate": "身份验证",
-  "@authenticate": {
-    "type": "text"
-  },
-  "automaticRedirected": "重新激活后，您将自动跳转至投资组合页面。",
-  "@automaticRedirected": {
-    "type": "text"
-  },
-  "availableVolume": "最大交易量",
-  "@availableVolume": {
-    "type": "text"
-  },
-  "back": "上一步",
-  "@back": {
-    "type": "text"
-  },
-  "backupTitle": "备份",
-  "@backupTitle": {
-    "type": "text"
-  },
-  "basedOnCoinRatio": "基于{coinName1}/{coinName2}",
-  "@basedOnCoinRatio": {
-    "type": "text",
-    "placeholders": {
-      "coinName1": {},
-      "coinName2": {}
-    }
-  },
-  "batteryCriticalError": "您的电池电量过低 ({batteryLevelCritical}%) ，无法安全地进行交换。请先充电，然后重试。",
-  "@batteryCriticalError": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelCritical": {}
-    }
-  },
-  "batteryLowWarning": "您的电池电量低于 {batteryLevelLow}%。请充电。",
-  "@batteryLowWarning": {
-    "type": "text",
-    "placeholders": {
-      "batteryLevelLow": {}
-    }
-  },
-  "batterySavingWarning": "您的手机处于省电模式。请停用此模式或不要将应用程序置于后台，否则，应用程序可能会被系统自动清除，导致交换失败。",
-  "@batterySavingWarning": {
-    "type": "text"
-  },
-  "bestAvailableRate": "兑换率",
-  "@bestAvailableRate": {
-    "type": "text"
-  },
-  "builtKomodo": "基于Komodo",
-  "@builtKomodo": {
-    "type": "text"
-  },
-  "builtOnKmd": "基于Komodo",
-  "@builtOnKmd": {
-    "type": "text"
-  },
-  "buy": "买入",
-  "@buy": {
-    "type": "text"
-  },
-  "buyOrderType": "如果不匹配，则转为挂单",
-  "@buyOrderType": {
-    "type": "text"
-  },
-  "buySuccessWaiting": "交换已发起，请等待!",
-  "@buySuccessWaiting": {
-    "type": "text"
-  },
-  "buySuccessWaitingError": "正在进行交易匹配，请等待 {seconde} 秒!",
-  "@buySuccessWaitingError": {
-    "type": "text",
-    "placeholders": {
-      "seconde": {}
-    }
-  },
-  "buyTestCoinWarning": "警告，你正在购买没有实际价值的测试币!",
-  "@buyTestCoinWarning": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflict": "不能同时启用伪装PIN和生物识别保护",
-  "@camoPinBioProtectionConflict": {
-    "type": "text"
-  },
-  "camoPinBioProtectionConflictTitle": "伪装PIN和生物识别保护冲突",
-  "@camoPinBioProtectionConflictTitle": {
-    "type": "text"
-  },
-  "camoPinChange": "更改伪装PIN",
-  "@camoPinChange": {
-    "type": "text"
-  },
-  "camoPinCreate": "创建伪装PIN",
-  "@camoPinCreate": {
-    "type": "text"
-  },
-  "camoPinDesc": "如果您用伪装PIN解锁应用程序，将显示一个虚假的低余额，并且设置中不会显示伪装PIN配置选项。",
-  "@camoPinDesc": {
-    "type": "text"
-  },
-  "camoPinInvalid": "无效的伪装PIN",
-  "@camoPinInvalid": {
-    "type": "text"
-  },
-  "camoPinLink": "伪装PIN",
-  "@camoPinLink": {
-    "type": "text"
-  },
-  "camoPinNotFound": "未找到伪装PIN",
-  "@camoPinNotFound": {
-    "type": "text"
-  },
-  "camoPinOff": "关闭",
-  "@camoPinOff": {
-    "type": "text"
-  },
-  "camoPinOn": "开启",
-  "@camoPinOn": {
-    "type": "text"
-  },
-  "camoPinSaved": "已保存的伪装PIN",
-  "@camoPinSaved": {
-    "type": "text"
-  },
-  "camoPinTitle": "伪装PIN",
-  "@camoPinTitle": {
-    "type": "text"
-  },
-  "camoSetupSubtitle": "输入新的伪装PIN",
-  "@camoSetupSubtitle": {
-    "type": "text"
-  },
-  "camoSetupTitle": "伪装PIN设置",
-  "@camoSetupTitle": {
-    "type": "text"
-  },
-  "camouflageSetup": "伪装PIN设置",
-  "@camouflageSetup": {
-    "type": "text"
-  },
-  "cancel": "取消",
-  "@cancel": {
-    "type": "text"
-  },
-  "cancelActivation": "取消激活",
-  "@cancelActivation": {
-    "type": "text"
-  },
-  "cancelActivationQuestion": "您确定要取消激活吗？",
-  "@cancelActivationQuestion": {
-    "type": "text"
-  },
-  "cancelButton": "取消",
-  "@cancelButton": {
-    "type": "text"
-  },
-  "cancelOrder": "取消交易",
-  "@cancelOrder": {
-    "type": "text"
-  },
-  "candleChartError": "出现错误，稍后重试",
-  "@candleChartError": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinOk": "好的",
-  "@cantDeleteDefaultCoinOk": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinSpan": "是默认币。无法停用默认币。",
-  "@cantDeleteDefaultCoinSpan": {
-    "type": "text"
-  },
-  "cantDeleteDefaultCoinTitle": "无法停用",
-  "@cantDeleteDefaultCoinTitle": {
-    "type": "text"
-  },
-  "Can't play that": "不能播放",
-  "@Can't play that": {
-    "type": "text"
-  },
-  "cex": "CEX(中心化交易所)",
-  "@cex": {
-    "type": "text"
-  },
-  "cexChangeRate": "CEX兑换率",
-  "@cexChangeRate": {
-    "type": "text"
-  },
-  "cexData": "CEX 数据",
-  "@cexData": {
-    "type": "text"
-  },
-  "cexDataDesc": "带有此图标的市场数据（价格、图表等）来源于第三方(<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href=\"https://openrates.io/\">openrates.io</a>).",
-  "@cexDataDesc": {
-    "type": "text"
-  },
-  "cexRate": "CEX 汇率",
-  "@cexRate": {
-    "type": "text"
-  },
-  "changePin": "更改PIN",
-  "@changePin": {
-    "type": "text"
-  },
-  "checkForUpdates": "检查更新",
-  "@checkForUpdates": {
-    "type": "text"
-  },
-  "checkOut": "退出",
-  "@checkOut": {
-    "type": "text"
-  },
-  "checkSeedPhrase": "检查助记词",
-  "@checkSeedPhrase": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton1": "继续",
-  "@checkSeedPhraseButton1": {
-    "type": "text"
-  },
-  "checkSeedPhraseButton2": "返回並再次檢查",
-  "@checkSeedPhraseButton2": {
-    "type": "text"
-  },
-  "checkSeedPhraseHint": "请输入第 {index}个单词",
-  "@checkSeedPhraseHint": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseInfo": "您的助记词很重要——因此我们要确保它是正确的。我们将问您三个关于您的助记词的问题，以确保您可以随时轻松地恢复钱包。",
-  "@checkSeedPhraseInfo": {
-    "type": "text"
-  },
-  "checkSeedPhraseSubtile": "您的助記詞的第 {index}個单词是什麼？",
-  "@checkSeedPhraseSubtile": {
-    "type": "text",
-    "placeholders": {
-      "index": {}
-    }
-  },
-  "checkSeedPhraseTitle": "请再次确认助记词",
-  "@checkSeedPhraseTitle": {
-    "type": "text"
-  },
-  "chineseLanguage": "中文",
-  "@chineseLanguage": {
-    "type": "text"
-  },
-  "claim": "领取",
-  "@claim": {
-    "type": "text"
-  },
-  "claimTitle": "领取您的KMD奖励？",
-  "@claimTitle": {
-    "type": "text"
-  },
-  "clickToSee": "点击查看",
-  "@clickToSee": {
-    "type": "text"
-  },
-  "clipboard": "复制到剪贴板",
-  "@clipboard": {
-    "type": "text"
-  },
-  "clipboardCopy": "复制到剪贴板",
-  "@clipboardCopy": {
-    "type": "text"
-  },
-  "close": "关闭",
-  "@close": {
-    "type": "text"
-  },
-  "closeMessage": "关闭错误信息",
-  "@closeMessage": {
-    "type": "text"
-  },
-  "closePreview": "关闭预览",
-  "@closePreview": {
-    "type": "text"
-  },
-  "code": "代码",
-  "@code": {
-    "type": "text"
-  },
-  "cofirmCancelActivation": "您确定要取消激活吗？",
-  "@cofirmCancelActivation": {
-    "type": "text"
-  },
-  "coinsActivatedLimitReached": "您已选择最大资产数量",
-  "@coinsActivatedLimitReached": {
-    "type": "text"
-  },
-  "coinsAreActivated": "{protocolName} 币已激活",
-  "@coinsAreActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreActivatedSuccessfully": "{protocolName}币激活成功",
-  "@coinsAreActivatedSuccessfully": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinsAreNotActivated": "{protocolName} 代币未激活",
-  "@coinsAreNotActivated": {
-    "type": "text",
-    "placeholders": {
-      "protocolName": {}
-    }
-  },
-  "coinSelectClear": "清除",
-  "@coinSelectClear": {
-    "type": "text"
-  },
-  "coinSelectNotFound": "没有活跃币",
-  "@coinSelectNotFound": {
-    "type": "text"
-  },
-  "coinSelectTitle": "选择货币",
-  "@coinSelectTitle": {
-    "type": "text"
-  },
-  "comingSoon": "即将上线，敬请期待。。。",
-  "@comingSoon": {
-    "type": "text"
-  },
-  "commingsoon": "交易明细加载中！",
-  "@commingsoon": {
-    "type": "text"
-  },
-  "commingsoonGeneral": "详情载入中！",
-  "@commingsoonGeneral": {
-    "type": "text"
-  },
-  "commissionFee": "手续费",
-  "@commissionFee": {
-    "type": "text"
-  },
-  "comparedTo24hrCex": "与平均值相比24小时CEX价格",
-  "@comparedTo24hrCex": {
-    "type": "text"
-  },
-  "comparedToCex": "与CEX比较",
-  "@comparedToCex": {
-    "type": "text"
-  },
-  "configureWallet": "正在配置您的钱包，请稍候。。。",
-  "@configureWallet": {
-    "type": "text"
-  },
-  "confirm": "确认",
-  "@confirm": {
-    "type": "text"
-  },
-  "confirmCamouflageSetup": "确认伪装PIN",
-  "@confirmCamouflageSetup": {
-    "type": "text"
-  },
-  "confirmCancel": "您确定要取消交易吗",
-  "@confirmCancel": {
-    "type": "text"
-  },
-  "confirmeula": "我已了解点击以下的按钮即代表我已阅读并接受终端使用者授权协议(EULA) & 使用条款与条件",
-  "@confirmeula": {
-    "type": "text"
-  },
-  "confirmPassword": "确认密码",
-  "@confirmPassword": {
-    "type": "text"
-  },
-  "confirmPin": "确认PIN",
-  "@confirmPin": {
-    "type": "text"
-  },
-  "confirmSeed": "确认助记词",
-  "@confirmSeed": {
-    "type": "text"
-  },
-  "connecting": "连接中",
-  "@connecting": {
-    "type": "text"
-  },
-  "contactCancel": "取消",
-  "@contactCancel": {
-    "type": "text"
-  },
-  "contactDelete": "删除联系人",
-  "@contactDelete": {
-    "type": "text"
-  },
-  "contactDeleteBtn": "删除",
-  "@contactDeleteBtn": {
-    "type": "text"
-  },
-  "contactDeleteWarning": "确认删除该联系人{name}？",
-  "@contactDeleteWarning": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "contactDiscardBtn": "放弃",
-  "@contactDiscardBtn": {
-    "type": "text"
-  },
-  "contactEdit": "编辑",
-  "@contactEdit": {
-    "type": "text"
-  },
-  "contactExit": "退出",
-  "@contactExit": {
-    "type": "text"
-  },
-  "contactExitWarning": "放弃更改？",
-  "@contactExitWarning": {
-    "type": "text"
-  },
-  "contactNotFound": "未找到联系人",
-  "@contactNotFound": {
-    "type": "text"
-  },
-  "contactSave": "保存",
-  "@contactSave": {
-    "type": "text"
-  },
-  "contactTitle": "联系人详细信息",
-  "@contactTitle": {
-    "type": "text"
-  },
-  "contactTitleName": "名称",
-  "@contactTitleName": {
-    "type": "text"
-  },
-  "contract": "合同",
-  "@contract": {
-    "type": "text"
-  },
-  "convert": "转换",
-  "@convert": {
-    "type": "text"
-  },
-  "couldNotLaunchUrl": "无法启动 URL",
-  "@couldNotLaunchUrl": {
-    "type": "text"
-  },
-  "couldntImportError": "无法导入：",
-  "@couldntImportError": {
-    "type": "text"
-  },
-  "create": "交易",
-  "@create": {
-    "type": "text"
-  },
-  "createAWallet": "创建钱包",
-  "@createAWallet": {
-    "type": "text"
-  },
-  "createContact": "创建联系人",
-  "@createContact": {
-    "type": "text"
-  },
-  "createPin": "创建PIN码",
-  "@createPin": {
-    "type": "text"
-  },
-  "currency": "货币",
-  "@currency": {
-    "type": "text"
-  },
-  "currencyDialogTitle": "货币",
-  "@currencyDialogTitle": {
-    "type": "text"
-  },
-  "currentValue": "当前值",
-  "@currentValue": {
-    "type": "text"
-  },
-  "customFee": "定制费用",
-  "@customFee": {
-    "type": "text"
-  },
-  "customFeeWarning": "选择定制费用前务必明确知晓自己的行为",
-  "@customFeeWarning": {
-    "type": "text"
-  },
-  "customSeedWarning": "自定义助记词的安全性可能比自动生成的符合BIP39规范的助记词或私钥（WIF）低，更容易被破解。如您已了解风险并知道您正在做什么，请在下面的框中输入\"{iUnderstand}\"。",
-  "@customSeedWarning": {
-    "type": "text",
-    "placeholders": {
-      "iUnderstand": {}
-    }
-  },
-  "date": "日期",
-  "@date": {
-    "type": "text"
-  },
-  "decryptingWallet": "钱包解密中",
-  "@decryptingWallet": {
-    "type": "text"
-  },
-  "delete": "删除",
-  "@delete": {
-    "type": "text"
-  },
-  "deleteConfirm": "确认停用",
-  "@deleteConfirm": {
-    "type": "text"
-  },
-  "deleteSpan1": "是否要",
-  "@deleteSpan1": {
-    "type": "text"
-  },
-  "deleteSpan2": "从投资组合中删除？所有不匹配的订单将被取消。",
-  "@deleteSpan2": {
-    "type": "text"
-  },
-  "deleteSpan3": " 也将被停用",
-  "@deleteSpan3": {
-    "type": "text"
-  },
-  "deleteWallet": "删除钱包",
-  "@deleteWallet": {
-    "type": "text"
-  },
-  "deletingWallet": "删除钱包中",
-  "@deletingWallet": {
-    "type": "text"
-  },
-  "detailedFeesReceiveCoinTransactionFee": "接收{coinName}交易费",
-  "@detailedFeesReceiveCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendCoinTransactionFee": "发送 {coinName} 交易费",
-  "@detailedFeesSendCoinTransactionFee": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "detailedFeesSendTradingFeeTransactionFee": "发送交易费 交易费",
-  "@detailedFeesSendTradingFeeTransactionFee": {
-    "type": "text"
-  },
-  "detailedFeesTradingFee": "交易费",
-  "@detailedFeesTradingFee": {
-    "type": "text"
-  },
-  "details": "详细信息",
-  "@details": {
-    "type": "text"
-  },
-  "deutscheLanguage": "德语",
-  "@deutscheLanguage": {
-    "type": "text"
-  },
-  "developerTitle": "开发者",
-  "@developerTitle": {
-    "type": "text"
-  },
-  "dex": "DEX",
-  "@dex": {
-    "type": "text"
-  },
-  "dexIsNotAvailable": "DEX不适合该货币",
-  "@dexIsNotAvailable": {
-    "type": "text"
-  },
-  "disableScreenshots": "禁用屏幕截图/预览",
-  "@disableScreenshots": {
-    "type": "text"
-  },
-  "disclaimerAndTos": "免责声明 & 使用条款",
-  "@disclaimerAndTos": {
-    "type": "text"
-  },
-  "done": "完成",
-  "@done": {
-    "type": "text"
-  },
-  "doNotCloseTheAppTapForMoreInfo": "不要关闭应用程序。点按了解更多信息...",
-  "@doNotCloseTheAppTapForMoreInfo": {
-    "type": "text"
-  },
-  "dontAskAgain": "不再询问",
-  "@dontAskAgain": {
-    "type": "text"
-  },
-  "dontWantPassword": "我不想要使用密碼",
-  "@dontWantPassword": {
-    "type": "text"
-  },
-  "dPow": "Komodo dPoW安全",
-  "@dPow": {
-    "type": "text"
-  },
-  "duration": "有效期",
-  "@duration": {
-    "type": "text"
-  },
-  "editContact": "编辑联系人",
-  "@editContact": {
-    "type": "text"
-  },
-  "emptyCoin": "输入{abbr}地址",
-  "@emptyCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "emptyExportPass": "加密密码不能为空",
-  "@emptyExportPass": {
-    "type": "text"
-  },
-  "emptyImportPass": "密码不能为空",
-  "@emptyImportPass": {
-    "type": "text"
-  },
-  "emptyName": "联系人名称不能为空",
-  "@emptyName": {
-    "type": "text"
-  },
-  "emptyWallet": "钱包名称不能为空",
-  "@emptyWallet": {
-    "type": "text"
-  },
-  "enable": "您仍然可以启用{remains}，已选择：{selected}",
-  "@enable": {
-    "type": "text",
-    "placeholders": {
-      "selected": {},
-      "remains": {}
-    }
-  },
-  "enableNotificationsForActivationProgress": "请启用通知以获取有关激活进度的更新。",
-  "@enableNotificationsForActivationProgress": {
-    "type": "text"
-  },
-  "enableTestCoins": "启用测试币",
-  "@enableTestCoins": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan1": "您已启用",
-  "@enablingTooManyAssetsSpan1": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan2": "资产并尝试启用",
-  "@enablingTooManyAssetsSpan2": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan3": "更多。最多启用",
-  "@enablingTooManyAssetsSpan3": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsSpan4": "请在添加新资产前停用一些资产。",
-  "@enablingTooManyAssetsSpan4": {
-    "type": "text"
-  },
-  "enablingTooManyAssetsTitle": "试图启用太多资产",
-  "@enablingTooManyAssetsTitle": {
-    "type": "text"
-  },
-  "encryptingWallet": "錢包加密中",
-  "@encryptingWallet": {
-    "type": "text"
-  },
-  "englishLanguage": "英文",
-  "@englishLanguage": {
-    "type": "text"
-  },
-  "enterNewPinCode": "输入您的新PIN",
-  "@enterNewPinCode": {
-    "type": "text"
-  },
-  "enterOldPinCode": "输入您的旧PIN",
-  "@enterOldPinCode": {
-    "type": "text"
-  },
-  "enterpassword": "继续前请输入密码",
-  "@enterpassword": {
-    "type": "text"
-  },
-  "enterPinCode": "输入您的PIN码",
-  "@enterPinCode": {
-    "type": "text"
-  },
-  "enterSeedPhrase": "输入您的助记词",
-  "@enterSeedPhrase": {
-    "type": "text"
-  },
-  "enterSellAmount": "您必须先输入卖出数量",
-  "@enterSellAmount": {
-    "type": "text"
-  },
-  "errorAmountBalance": "余额不足",
-  "@errorAmountBalance": {
-    "type": "text"
-  },
-  "errorNotAValidAddress": "钱包地址错误",
-  "@errorNotAValidAddress": {
-    "type": "text"
-  },
-  "errorNotAValidAddressSegWit": "尚不支持Segwit地址",
-  "@errorNotAValidAddressSegWit": {
-    "type": "text"
-  },
-  "errorNotEnoughGas": "燃料不足-至少使用｛gas｝Gwei",
-  "@errorNotEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "gas": {}
-    }
-  },
-  "errorTryAgain": "出现错误, 請重试",
-  "@errorTryAgain": {
-    "type": "text"
-  },
-  "errorTryLater": "出现错误，請稍後重试",
-  "@errorTryLater": {
-    "type": "text"
-  },
-  "errorValueEmpty": "价值太高或太低",
-  "@errorValueEmpty": {
-    "type": "text"
-  },
-  "errorValueNotEmpty": "请输入数据",
-  "@errorValueNotEmpty": {
-    "type": "text"
-  },
-  "estimateValue": "预估总价",
-  "@estimateValue": {
-    "type": "text"
-  },
-  "eulaParagraphe1": "This End-User License Agreement ('EULA') is a legal agreement between you and {appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our {appName} mobile software ('Software', 'Mobile Application', 'Application' or 'App') directly from {appCompanyLong} or indirectly through a {appCompanyLong} authorized entity, reseller or distributor (a 'Distributor').\nPlease read this EULA agreement carefully before completing the installation process and using the {appName} mobile software. It provides a license to use the {appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the {appName} mobile software, this EULA agreement will also govern that trial. By clicking 'accept' or installing and/or using the {appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by {appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any {appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n{appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the {appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the {appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the {appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that {appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n{appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of {appCompanyLong}.\n\n{appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to {appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe10": "{appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of {appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by {appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.",
-  "@eulaParagraphe10": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe11": "{appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n{appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n{appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an 'as is' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to {appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.",
-  "@eulaParagraphe11": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe12": "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.",
-  "@eulaParagraphe12": {
-    "type": "text"
-  },
-  "eulaParagraphe13": "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that {appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that {appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.",
-  "@eulaParagraphe13": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe14": "You agree to indemnify, defend and hold harmless {appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify {appCompanyLong} against any claims that information or material which You have submitted to {appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).",
-  "@eulaParagraphe14": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe15": "In order to be completed, any Virtual Currency transaction created with the {appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by {appCompanyLong}.\n{appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. {appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, {appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. {appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall {appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of {appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.",
-  "@eulaParagraphe15": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe16": "For the avoidance of doubt, {appCompanyLong} does not provide investment, tax or legal advice, nor does {appCompanyLong} broker trades on your behalf. All {appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither {appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. {appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. {appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that {appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, {appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. {appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the {appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the {appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the {appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by {appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application {appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after {appCompanyShort} has distributed positive information regarding the crypto-assets and companies. {appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. {appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.",
-  "@eulaParagraphe16": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe17": "The Terms are effective until terminated by {appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to {appCompanyLong} against You up to the date of termination. \n{appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ",
-  "@eulaParagraphe17": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe18": "The provisions of previous paragraphs are for the benefit of {appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.",
-  "@eulaParagraphe18": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe19": "{appName} mobile is a non-custodial, decentralized and blockchain based application and as such does {appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020",
-  "@eulaParagraphe19": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe2": "This disclaimer applies to the contents and services of the app {appName} and is valid for all users of the “Application” ('Software', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by {appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “{appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.",
-  "@eulaParagraphe2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe3": "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time.",
-  "@eulaParagraphe3": {
-    "type": "text"
-  },
-  "eulaParagraphe4": "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.",
-  "@eulaParagraphe4": {
-    "type": "text"
-  },
-  "eulaParagraphe5": "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the {appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.",
-  "@eulaParagraphe5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaParagraphe6": "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n{appName} mobile is a non-custodial wallet implementation and thus {appCompanyLong} can not access nor restore your account in case of (data) loss.",
-  "@eulaParagraphe6": {
-    "type": "text",
-    "placeholders": {
-      "appName": {},
-      "appCompanyLong": {}
-    }
-  },
-  "eulaParagraphe7": "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.",
-  "@eulaParagraphe7": {
-    "type": "text"
-  },
-  "eulaParagraphe8": "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.",
-  "@eulaParagraphe8": {
-    "type": "text"
-  },
-  "eulaParagraphe9": "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). ",
-  "@eulaParagraphe9": {
-    "type": "text"
-  },
-  "eulaTitle1": "End-User License Agreement (EULA) of {appName} mobile:",
-  "@eulaTitle1": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "eulaTitle10": "ACCESS AND SECURITY",
-  "@eulaTitle10": {
-    "type": "text"
-  },
-  "eulaTitle11": "INTELLECTUAL PROPERTY RIGHTS",
-  "@eulaTitle11": {
-    "type": "text"
-  },
-  "eulaTitle12": "DISCLAIMER",
-  "@eulaTitle12": {
-    "type": "text"
-  },
-  "eulaTitle13": "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY",
-  "@eulaTitle13": {
-    "type": "text"
-  },
-  "eulaTitle14": "GENERAL RISK FACTORS",
-  "@eulaTitle14": {
-    "type": "text"
-  },
-  "eulaTitle15": "INDEMNIFICATION",
-  "@eulaTitle15": {
-    "type": "text"
-  },
-  "eulaTitle16": "RISK DISCLOSURES RELATING TO THE WALLET",
-  "@eulaTitle16": {
-    "type": "text"
-  },
-  "eulaTitle17": "NO INVESTMENT ADVICE OR BROKERAGE",
-  "@eulaTitle17": {
-    "type": "text"
-  },
-  "eulaTitle18": "TERMINATION",
-  "@eulaTitle18": {
-    "type": "text"
-  },
-  "eulaTitle19": "THIRD PARTY RIGHTS",
-  "@eulaTitle19": {
-    "type": "text"
-  },
-  "eulaTitle2": "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)",
-  "@eulaTitle2": {
-    "type": "text"
-  },
-  "eulaTitle20": "OUR LEGAL OBLIGATIONS",
-  "@eulaTitle20": {
-    "type": "text"
-  },
-  "eulaTitle3": "TERMS AND CONDITIONS OF USE AND DISCLAIMER",
-  "@eulaTitle3": {
-    "type": "text"
-  },
-  "eulaTitle4": "GENERAL USE",
-  "@eulaTitle4": {
-    "type": "text"
-  },
-  "eulaTitle5": "MODIFICATIONS",
-  "@eulaTitle5": {
-    "type": "text"
-  },
-  "eulaTitle6": "LIMITATIONS ON USE",
-  "@eulaTitle6": {
-    "type": "text"
-  },
-  "eulaTitle7": "ACCOUNTS AND MEMBERSHIP",
-  "@eulaTitle7": {
-    "type": "text"
-  },
-  "eulaTitle8": "BACKUPS",
-  "@eulaTitle8": {
-    "type": "text"
-  },
-  "eulaTitle9": "GENERAL WARNING",
-  "@eulaTitle9": {
-    "type": "text"
-  },
-  "exampleHintSeed": "例如：build case level ...",
-  "@exampleHintSeed": {
-    "type": "text"
-  },
-  "exchangeExpedient": "划算的",
-  "@exchangeExpedient": {
-    "type": "text"
-  },
-  "exchangeExpensive": "昂贵的",
-  "@exchangeExpensive": {
-    "type": "text"
-  },
-  "exchangeIdentical": "与CEX相同",
-  "@exchangeIdentical": {
-    "type": "text"
-  },
-  "exchangeRate": "兑换率",
-  "@exchangeRate": {
-    "type": "text"
-  },
-  "exchangeTitle": "兑换",
-  "@exchangeTitle": {
-    "type": "text"
-  },
-  "exportButton": "导出",
-  "@exportButton": {
-    "type": "text"
-  },
-  "exportContactsTitle": "联系人",
-  "@exportContactsTitle": {
-    "type": "text"
-  },
-  "exportDesc": "请选择要导出到加密文件中的项目。",
-  "@exportDesc": {
-    "type": "text"
-  },
-  "exportLink": "导出",
-  "@exportLink": {
-    "type": "text"
-  },
-  "exportNotesTitle": "备注",
-  "@exportNotesTitle": {
-    "type": "text"
-  },
-  "exportSuccessTitle": "项目成功导出",
-  "@exportSuccessTitle": {
-    "type": "text"
-  },
-  "exportSwapsTitle": "交换",
-  "@exportSwapsTitle": {
-    "type": "text"
-  },
-  "exportTitle": "导出",
-  "@exportTitle": {
-    "type": "text"
-  },
-  "Failed": "失败",
-  "@Failed": {
-    "type": "text"
-  },
-  "fakeBalanceAmt": "虚假余额",
-  "@fakeBalanceAmt": {
-    "type": "text"
-  },
-  "faqTitle": "常见问题",
-  "@faqTitle": {
-    "type": "text"
-  },
-  "faucetError": "错误",
-  "@faucetError": {
-    "type": "text"
-  },
-  "faucetInProgress": "正在向 {coin} 水龙头发送请求",
-  "@faucetInProgress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "faucetName": "水龙头",
-  "@faucetName": {
-    "type": "text"
-  },
-  "faucetSuccess": "成功",
-  "@faucetSuccess": {
-    "type": "text"
-  },
-  "faucetTimedOut": "请求超时",
-  "@faucetTimedOut": {
-    "type": "text"
-  },
-  "feedback": "共享日志文件",
-  "@feedback": {
-    "type": "text"
-  },
-  "feedNewsTab": "新闻",
-  "@feedNewsTab": {
-    "type": "text"
-  },
-  "feedNotFound": "无内容",
-  "@feedNotFound": {
-    "type": "text"
-  },
-  "feedNotifTitle": "{appCompanyShort} 新闻",
-  "@feedNotifTitle": {
-    "type": "text",
-    "placeholders": {
-      "appCompanyShort": {}
-    }
-  },
-  "feedReadMore": "阅读更多",
-  "@feedReadMore": {
-    "type": "text"
-  },
-  "feedTab": "Feed",
-  "@feedTab": {
-    "type": "text"
-  },
-  "feedTitle": "Feed新闻",
-  "@feedTitle": {
-    "type": "text"
-  },
-  "feedUnableToProceed": "无法继续更新新闻",
-  "@feedUnableToProceed": {
-    "type": "text"
-  },
-  "feedUnableToUpdate": "无法获取新闻更新",
-  "@feedUnableToUpdate": {
-    "type": "text"
-  },
-  "feedUpdated": "Feed新闻已更新",
-  "@feedUpdated": {
-    "type": "text"
-  },
-  "feedUpToDate": "已更新",
-  "@feedUpToDate": {
-    "type": "text"
-  },
-  "feesError": "费用必须高达 {value}",
-  "@feesError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "filtersAll": "全部",
-  "@filtersAll": {
-    "type": "text"
-  },
-  "filtersButton": "过滤器",
-  "@filtersButton": {
-    "type": "text"
-  },
-  "filtersClearAll": "清除所有过滤器",
-  "@filtersClearAll": {
-    "type": "text"
-  },
-  "filtersFailed": "失败",
-  "@filtersFailed": {
-    "type": "text"
-  },
-  "filtersFrom": "起始日期",
-  "@filtersFrom": {
-    "type": "text"
-  },
-  "filtersMaker": "挂单",
-  "@filtersMaker": {
-    "type": "text"
-  },
-  "filtersReceive": "接收货币",
-  "@filtersReceive": {
-    "type": "text"
-  },
-  "filtersSell": "出售货币",
-  "@filtersSell": {
-    "type": "text"
-  },
-  "filtersStatus": "状态",
-  "@filtersStatus": {
-    "type": "text"
-  },
-  "filtersSuccessful": "成功",
-  "@filtersSuccessful": {
-    "type": "text"
-  },
-  "filtersTaker": "吃单",
-  "@filtersTaker": {
-    "type": "text"
-  },
-  "filtersTo": "截止日期",
-  "@filtersTo": {
-    "type": "text"
-  },
-  "filtersType": "吃单/挂单",
-  "@filtersType": {
-    "type": "text"
-  },
-  "fingerprint": "指纹",
-  "@fingerprint": {
-    "type": "text"
-  },
-  "finishingUp": "已完成，请稍候",
-  "@finishingUp": {
-    "type": "text"
-  },
-  "foundQrCode": "找到二维码",
-  "@foundQrCode": {
-    "type": "text"
-  },
-  "frenchLanguage": "法语",
-  "@frenchLanguage": {
-    "type": "text"
-  },
-  "from": "起始日期",
-  "@from": {
-    "type": "text"
-  },
-  "futureTransactions": "我们将同步与您的公钥关联的激活后进行的未来交易。这是最快的选项，占用的存储空间最少。",
-  "@futureTransactions": {
-    "type": "text"
-  },
-  "gasFee": "{coin} 费用",
-  "@gasFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasLimit": "燃料上限",
-  "@gasLimit": {
-    "type": "text"
-  },
-  "gasNotActive": "请激活{coin}.",
-  "@gasNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "gasPrice": "燃料价格",
-  "@gasPrice": {
-    "type": "text"
-  },
-  "generalPinNotActive": "常规PIN保护未激活。\n伪装模式将失效\n请激活PIN保护",
-  "@generalPinNotActive": {
-    "type": "text"
-  },
-  "getBackupPhrase": "重要提醒: 請在繼續之前備份助記詞 !",
-  "@getBackupPhrase": {
-    "type": "text"
-  },
-  "gettingTxWait": "正在获取交易，请稍候",
-  "@gettingTxWait": {
-    "type": "text"
-  },
-  "goToPorfolio": "前往投资组合",
-  "@goToPorfolio": {
-    "type": "text"
-  },
-  "gweiError": "Gwei 必须达到 {value}",
-  "@gweiError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "helpLink": "帮助",
-  "@helpLink": {
-    "type": "text"
-  },
-  "helpTitle": "帮助和支持",
-  "@helpTitle": {
-    "type": "text"
-  },
-  "hideBalance": "隐藏余额",
-  "@hideBalance": {
-    "type": "text"
-  },
-  "hintConfirmPassword": "确认密码",
-  "@hintConfirmPassword": {
-    "type": "text"
-  },
-  "hintCreatePassword": "创建密码",
-  "@hintCreatePassword": {
-    "type": "text"
-  },
-  "hintCurrentPassword": "当前密码",
-  "@hintCurrentPassword": {
-    "type": "text"
-  },
-  "hintEnterPassword": "请输入您的密码",
-  "@hintEnterPassword": {
-    "type": "text"
-  },
-  "hintEnterSeedPhrase": "请输入您的助记词",
-  "@hintEnterSeedPhrase": {
-    "type": "text"
-  },
-  "hintNameYourWallet": "命名您的钱包",
-  "@hintNameYourWallet": {
-    "type": "text"
-  },
-  "hintPassword": "密码",
-  "@hintPassword": {
-    "type": "text"
-  },
-  "history": "历史记录",
-  "@history": {
-    "type": "text"
-  },
-  "hours": "小时",
-  "@hours": {
-    "type": "text"
-  },
-  "hungarianLanguage": "匈牙利语",
-  "@hungarianLanguage": {
-    "type": "text"
-  },
-  "importButton": "导入",
-  "@importButton": {
-    "type": "text"
-  },
-  "importDecryptError": "密码无效或数据损坏",
-  "@importDecryptError": {
-    "type": "text"
-  },
-  "importDesc": "要导入的项目：",
-  "@importDesc": {
-    "type": "text"
-  },
-  "importFileNotFound": "找不到文件",
-  "@importFileNotFound": {
-    "type": "text"
-  },
-  "importInvalidSwapData": "交换数据无效。请提供有效的交换状态JSON文件。",
-  "@importInvalidSwapData": {
-    "type": "text"
-  },
-  "importLink": "导入",
-  "@importLink": {
-    "type": "text"
-  },
-  "importLoadDesc": "请选择要导入的加密文件。",
-  "@importLoadDesc": {
-    "type": "text"
-  },
-  "importLoading": "开始",
-  "@importLoading": {
-    "type": "text"
-  },
-  "importLoadSwapDesc": "请选择要导入的纯文本交换文件。",
-  "@importLoadSwapDesc": {
-    "type": "text"
-  },
-  "importPassCancel": "取消",
-  "@importPassCancel": {
-    "type": "text"
-  },
-  "importPassOk": "好的",
-  "@importPassOk": {
-    "type": "text"
-  },
-  "importPassword": "密码",
-  "@importPassword": {
-    "type": "text"
-  },
-  "importSingleSwapLink": "导入单个交换",
-  "@importSingleSwapLink": {
-    "type": "text"
-  },
-  "importSingleSwapTitle": "导入交换",
-  "@importSingleSwapTitle": {
-    "type": "text"
-  },
-  "importSomeItemsSkippedWarning": "已跳过某些项目",
-  "@importSomeItemsSkippedWarning": {
-    "type": "text"
-  },
-  "importSuccessTitle": "已成功导入项目：",
-  "@importSuccessTitle": {
-    "type": "text"
-  },
-  "importSwapFailed": "无法导入交换",
-  "@importSwapFailed": {
-    "type": "text"
-  },
-  "importSwapJsonDecodingError": "解码json文件时出错",
-  "@importSwapJsonDecodingError": {
-    "type": "text"
-  },
-  "importTitle": "导入",
-  "@importTitle": {
-    "type": "text"
-  },
-  "incomingTransactionsProtectionSettings": "传入 {coinName} 交易保护设置",
-  "@incomingTransactionsProtectionSettings": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "infoPasswordDialog": "使用安全密码，不要将其存储在同一设备上",
-  "@infoPasswordDialog": {
-    "type": "text"
-  },
-  "infoTrade1": "無法撤銷交换请求！",
-  "@infoTrade1": {
-    "type": "text"
-  },
-  "infoTrade2": "交换最长需要60分钟。不要关闭此应用程序！",
-  "@infoTrade2": {
-    "type": "text"
-  },
-  "infoWalletPassword": "安全起见，您必须为加密钱包设置密码。",
-  "@infoWalletPassword": {
-    "type": "text"
-  },
-  "insufficientBalanceToPay": "{abbr}余额不足以支付交易费",
-  "@insufficientBalanceToPay": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "insufficientText": "此订单最小交易量为",
-  "@insufficientText": {
-    "type": "text"
-  },
-  "insufficientTitle": "交易量不足",
-  "@insufficientTitle": {
-    "type": "text"
-  },
-  "internetRefreshButton": "刷新",
-  "@internetRefreshButton": {
-    "type": "text"
-  },
-  "internetRestored": "已重新连接互联网",
-  "@internetRestored": {
-    "type": "text"
-  },
-  "invalidCoinAddress": "{coin} 地址无效",
-  "@invalidCoinAddress": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "invalidSwap": "无法继续交换",
-  "@invalidSwap": {
-    "type": "text"
-  },
-  "invalidSwapDetailsLink": "详细信息",
-  "@invalidSwapDetailsLink": {
-    "type": "text"
-  },
-  "isUnavailable": "{coinAbbr} 不可用:(",
-  "@isUnavailable": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "iUnderstand": "我已了解",
-  "@iUnderstand": {
-    "type": "text"
-  },
-  "japaneseLanguage": "日文",
-  "@japaneseLanguage": {
-    "type": "text"
-  },
-  "koreanLanguage": "韩国人",
-  "@koreanLanguage": {
-    "type": "text"
-  },
-  "language": "语言",
-  "@language": {
-    "type": "text"
-  },
-  "latestTxs": "最新交易",
-  "@latestTxs": {
-    "type": "text"
-  },
-  "legalTitle": "合法的",
-  "@legalTitle": {
-    "type": "text"
-  },
-  "less": "较少",
-  "@less": {
-    "type": "text"
-  },
-  "lessThanCaution": "❗注意！ {coinName} 市场的 24 小时交易量不到 1 万美元！",
-  "@lessThanCaution": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "limitError": "限制必须达到 {value}",
-  "@limitError": {
-    "type": "text",
-    "placeholders": {
-      "value": {}
-    }
-  },
-  "loading": "載入中",
-  "@loading": {
-    "type": "text"
-  },
-  "loadingOrderbook": "正在加载订单记录",
-  "@loadingOrderbook": {
-    "type": "text"
-  },
-  "lockScreen": "屏幕已锁定",
-  "@lockScreen": {
-    "type": "text"
-  },
-  "lockScreenAuth": "请验证！",
-  "@lockScreenAuth": {
-    "type": "text"
-  },
-  "login": "登录",
-  "@login": {
-    "type": "text"
-  },
-  "logout": "注销",
-  "@logout": {
-    "type": "text"
-  },
-  "logoutOnExit": "退出时注销",
-  "@logoutOnExit": {
-    "type": "text"
-  },
-  "logoutsettings": "注销设置",
-  "@logoutsettings": {
-    "type": "text"
-  },
-  "logoutWarning": "您确定要立即注销吗？",
-  "@logoutWarning": {
-    "type": "text"
-  },
-  "longMinutes": "分钟",
-  "@longMinutes": {
-    "type": "text"
-  },
-  "makeAorder": "下订单",
-  "@makeAorder": {
-    "type": "text"
-  },
-  "Maker": "挂单",
-  "@Maker": {
-    "type": "text"
-  },
-  "makerDetailsCancel": "取消订单",
-  "@makerDetailsCancel": {
-    "type": "text"
-  },
-  "makerDetailsCreated": "创建",
-  "@makerDetailsCreated": {
-    "type": "text"
-  },
-  "makerDetailsFor": "接收",
-  "@makerDetailsFor": {
-    "type": "text"
-  },
-  "makerDetailsId": "订单ID",
-  "@makerDetailsId": {
-    "type": "text"
-  },
-  "makerDetailsNoSwaps": "此订单未启动交换",
-  "@makerDetailsNoSwaps": {
-    "type": "text"
-  },
-  "makerDetailsPrice": "价格",
-  "@makerDetailsPrice": {
-    "type": "text"
-  },
-  "makerDetailsSell": "卖出",
-  "@makerDetailsSell": {
-    "type": "text"
-  },
-  "makerDetailsSwaps": "此订单开始交换",
-  "@makerDetailsSwaps": {
-    "type": "text"
-  },
-  "makerDetailsTitle": "挂单交易详细信息",
-  "@makerDetailsTitle": {
-    "type": "text"
-  },
-  "makerOrder": "挂单交易",
-  "@makerOrder": {
-    "type": "text"
-  },
-  "marketplace": "市场",
-  "@marketplace": {
-    "type": "text"
-  },
-  "marketsChart": "图表",
-  "@marketsChart": {
-    "type": "text"
-  },
-  "marketsDepth": "交易深度",
-  "@marketsDepth": {
-    "type": "text"
-  },
-  "marketsNoAsks": "未找到问题",
-  "@marketsNoAsks": {
-    "type": "text"
-  },
-  "marketsNoBids": "未找到出价",
-  "@marketsNoBids": {
-    "type": "text"
-  },
-  "marketsOrderbook": "订单记录",
-  "@marketsOrderbook": {
-    "type": "text"
-  },
-  "marketsOrderDetails": "订单详细信息",
-  "@marketsOrderDetails": {
-    "type": "text"
-  },
-  "marketsPrice": "价格",
-  "@marketsPrice": {
-    "type": "text"
-  },
-  "marketsSelectCoins": "请选择货币",
-  "@marketsSelectCoins": {
-    "type": "text"
-  },
-  "marketsTab": "市场",
-  "@marketsTab": {
-    "type": "text"
-  },
-  "marketsTitle": "市场",
-  "@marketsTitle": {
-    "type": "text"
-  },
-  "matchExportPass": "密码必须匹配",
-  "@matchExportPass": {
-    "type": "text"
-  },
-  "matchingCamoChange": "改变",
-  "@matchingCamoChange": {
-    "type": "text"
-  },
-  "matchingCamoPinError": "您的通用PIN码和伪装PIN码相同。伪装模式将不可用。请更改伪装PIN",
-  "@matchingCamoPinError": {
-    "type": "text"
-  },
-  "matchingCamoTitle": "无效PIN",
-  "@matchingCamoTitle": {
-    "type": "text"
-  },
-  "max": "最大",
-  "@max": {
-    "type": "text"
-  },
-  "maxOrder": "最大交易量",
-  "@maxOrder": {
-    "type": "text"
-  },
-  "media": "消息",
-  "@media": {
-    "type": "text"
-  },
-  "mediaBrowse": "浏览",
-  "@mediaBrowse": {
-    "type": "text"
-  },
-  "mediaBrowseFeed": "浏览Feed",
-  "@mediaBrowseFeed": {
-    "type": "text"
-  },
-  "mediaBy": "通过",
-  "@mediaBy": {
-    "type": "text"
-  },
-  "mediaNotSavedDescription": "您没有收藏的文章",
-  "@mediaNotSavedDescription": {
-    "type": "text"
-  },
-  "mediaSaved": "已收藏",
-  "@mediaSaved": {
-    "type": "text"
-  },
-  "memo": "备忘录",
-  "@memo": {
-    "type": "text"
-  },
-  "merge": "合并",
-  "@merge": {
-    "type": "text"
-  },
-  "mergedValue": "合并值",
-  "@mergedValue": {
-    "type": "text"
-  },
-  "milliseconds": "毫秒",
-  "@milliseconds": {
-    "type": "text"
-  },
-  "min": "最小",
-  "@min": {
-    "type": "text"
-  },
-  "minimizingWillTerminate": "警告：最小化 iOS 上的应用程序将终止激活过程。",
-  "@minimizingWillTerminate": {
-    "type": "text"
-  },
-  "minOrder": "最小交易量",
-  "@minOrder": {
-    "type": "text"
-  },
-  "minutes": "分钟",
-  "@minutes": {
-    "type": "text"
-  },
-  "minValue": "最低售出量为{number} {coinName}",
-  "@minValue": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueBuy": "最低买入量为{number} {coinName}",
-  "@minValueBuy": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minValueOrder": "最小交易量为 {buyAmount} {buyCoin}\n({sellAmount} {sellCoin})",
-  "@minValueOrder": {
-    "type": "text",
-    "placeholders": {
-      "buyCoin": {},
-      "buyAmount": {},
-      "sellCoin": {},
-      "sellAmount": {}
-    }
-  },
-  "minValueSell": "最低售出量为 {number} {coinName}",
-  "@minValueSell": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "number": {}
-    }
-  },
-  "minVolumeInput": "必须大于{minValue} {coin}",
-  "@minVolumeInput": {
-    "type": "text",
-    "placeholders": {
-      "minValue": {},
-      "coin": {}
-    }
-  },
-  "minVolumeIsTDH": "必须低于售出量",
-  "@minVolumeIsTDH": {
-    "type": "text"
-  },
-  "minVolumeTitle": "所需最小量",
-  "@minVolumeTitle": {
-    "type": "text"
-  },
-  "minVolumeToggle": "使用自定义最小量",
-  "@minVolumeToggle": {
-    "type": "text"
-  },
-  "mobileDataWarning": "请注意，您现在正在使用流量，使用{appName} P2P网络会消耗互联网流量。如果您的手机流量很贵，最好连接WIFI。",
-  "@mobileDataWarning": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "moreInfo": "更多信息",
-  "@moreInfo": {
-    "type": "text"
-  },
-  "moreTab": "更多",
-  "@moreTab": {
-    "type": "text"
-  },
-  "multiActivateGas": "先激活{coin}并充值余额",
-  "@multiActivateGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiBaseAmtPlaceholder": "数量",
-  "@multiBaseAmtPlaceholder": {
-    "type": "text"
-  },
-  "multiBasePlaceholder": "货币",
-  "@multiBasePlaceholder": {
-    "type": "text"
-  },
-  "multiBaseSelectTitle": "卖出",
-  "@multiBaseSelectTitle": {
-    "type": "text"
-  },
-  "multiConfirmCancel": "取消",
-  "@multiConfirmCancel": {
-    "type": "text"
-  },
-  "multiConfirmConfirm": "确认",
-  "@multiConfirmConfirm": {
-    "type": "text"
-  },
-  "multiConfirmTitle": "创建{number}订单：",
-  "@multiConfirmTitle": {
-    "type": "text",
-    "placeholders": {
-      "number": {}
-    }
-  },
-  "multiCreate": "创建",
-  "@multiCreate": {
-    "type": "text"
-  },
-  "multiCreateOrder": "订单",
-  "@multiCreateOrder": {
-    "type": "text"
-  },
-  "multiCreateOrders": "订单",
-  "@multiCreateOrders": {
-    "type": "text"
-  },
-  "multiEthFee": "费用",
-  "@multiEthFee": {
-    "type": "text"
-  },
-  "multiFiatCancel": "取消",
-  "@multiFiatCancel": {
-    "type": "text"
-  },
-  "multiFiatDesc": "请输入要接收的法币数量",
-  "@multiFiatDesc": {
-    "type": "text"
-  },
-  "multiFiatFill": "自动填充",
-  "@multiFiatFill": {
-    "type": "text"
-  },
-  "multiFixErrors": "请在继续之前修复所有错误",
-  "@multiFixErrors": {
-    "type": "text"
-  },
-  "multiInvalidAmt": "数量无效",
-  "@multiInvalidAmt": {
-    "type": "text"
-  },
-  "multiInvalidSellAmt": "售出量无效",
-  "@multiInvalidSellAmt": {
-    "type": "text"
-  },
-  "multiLowerThanFee": "{coin}不足支付。最低余额为 {fee} {coin}",
-  "@multiLowerThanFee": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "fee": {}
-    }
-  },
-  "multiLowGas": "{coin}余额过低",
-  "@multiLowGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "multiMaxSellAmt": "最大售出量为",
-  "@multiMaxSellAmt": {
-    "type": "text"
-  },
-  "multiMinReceiveAmt": "最小接收量为",
-  "@multiMinReceiveAmt": {
-    "type": "text"
-  },
-  "multiMinSellAmt": "最小售出量为",
-  "@multiMinSellAmt": {
-    "type": "text"
-  },
-  "multiReceiveTitle": "接收：",
-  "@multiReceiveTitle": {
-    "type": "text"
-  },
-  "multiSellTitle": "卖出",
-  "@multiSellTitle": {
-    "type": "text"
-  },
-  "multiTab": "多个",
-  "@multiTab": {
-    "type": "text"
-  },
-  "multiTableAmt": "接收量",
-  "@multiTableAmt": {
-    "type": "text"
-  },
-  "multiTablePrice": "价格/CEX",
-  "@multiTablePrice": {
-    "type": "text"
-  },
-  "networkFee": "网络费用",
-  "@networkFee": {
-    "type": "text"
-  },
-  "newAccount": "新帳戶",
-  "@newAccount": {
-    "type": "text"
-  },
-  "newAccountUpper": "新帳戶",
-  "@newAccountUpper": {
-    "type": "text"
-  },
-  "newsFeed": "Feed新闻",
-  "@newsFeed": {
-    "type": "text"
-  },
-  "newValue": "新价值",
-  "@newValue": {
-    "type": "text"
-  },
-  "next": "继续",
-  "@next": {
-    "type": "text"
-  },
-  "no": "不",
-  "@no": {
-    "type": "text"
-  },
-  "noArticles": "没有新闻-请稍后再查看",
-  "@noArticles": {
-    "type": "text"
-  },
-  "noCoinFound": "未找到货币",
-  "@noCoinFound": {
-    "type": "text"
-  },
-  "noFunds": "无基金",
-  "@noFunds": {
-    "type": "text"
-  },
-  "noFundsDetected": "没有可用基金-请先存入",
-  "@noFundsDetected": {
-    "type": "text"
-  },
-  "noInternet": "无互联网连接",
-  "@noInternet": {
-    "type": "text"
-  },
-  "noItemsToExport": "未选择项目",
-  "@noItemsToExport": {
-    "type": "text"
-  },
-  "noItemsToImport": "未选择项目",
-  "@noItemsToImport": {
-    "type": "text"
-  },
-  "noMatchingOrders": "无匹配订单",
-  "@noMatchingOrders": {
-    "type": "text"
-  },
-  "none": "没有任何",
-  "@none": {
-    "type": "text"
-  },
-  "nonNumericInput": "该值必须是数字",
-  "@nonNumericInput": {
-    "type": "text"
-  },
-  "noOrder": "请输入 {coinName} 量",
-  "@noOrder": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {}
-    }
-  },
-  "noOrderAvailable": "点击创建订单",
-  "@noOrderAvailable": {
-    "type": "text"
-  },
-  "noOrders": "没有订单，请先交易",
-  "@noOrders": {
-    "type": "text"
-  },
-  "noRewards": "没有奖励可领取",
-  "@noRewards": {
-    "type": "text"
-  },
-  "noRewardYet": "没有奖励可领取-请一小时后重试",
-  "@noRewardYet": {
-    "type": "text"
-  },
-  "noSuchCoin": "没有该货币",
-  "@noSuchCoin": {
-    "type": "text"
-  },
-  "noSwaps": "没有历史记录",
-  "@noSwaps": {
-    "type": "text"
-  },
-  "notEnoughGas": "没有足够的{coin} 用于交易！",
-  "@notEnoughGas": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notEnoughtBalanceForFee": "手续费余额不足-减少交易量",
-  "@notEnoughtBalanceForFee": {
-    "type": "text"
-  },
-  "noteOnOrder": "备注：不能取消已匹配的订单",
-  "@noteOnOrder": {
-    "type": "text"
-  },
-  "notePlaceholder": "添加备注",
-  "@notePlaceholder": {
-    "type": "text"
-  },
-  "noteTitle": "备注",
-  "@noteTitle": {
-    "type": "text"
-  },
-  "nothingFound": "无内容",
-  "@nothingFound": {
-    "type": "text"
-  },
-  "notifSwapCompletedText": "{sell}/{buy} 已成功完成交换",
-  "@notifSwapCompletedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapCompletedTitle": "交换已完成",
-  "@notifSwapCompletedTitle": {
-    "type": "text"
-  },
-  "notifSwapFailedText": "{sell}/{buy}交换失败",
-  "@notifSwapFailedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapFailedTitle": "交换失败",
-  "@notifSwapFailedTitle": {
-    "type": "text"
-  },
-  "notifSwapStartedText": "{sell}/{buy}交换开始",
-  "@notifSwapStartedText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapStartedTitle": "已开始新交换",
-  "@notifSwapStartedTitle": {
-    "type": "text"
-  },
-  "notifSwapStatusTitle": "交换状态已更改",
-  "@notifSwapStatusTitle": {
-    "type": "text"
-  },
-  "notifSwapTimeoutText": "{sell}/{buy}交换超时",
-  "@notifSwapTimeoutText": {
-    "type": "text",
-    "placeholders": {
-      "sell": {},
-      "buy": {}
-    }
-  },
-  "notifSwapTimeoutTitle": "交换超时",
-  "@notifSwapTimeoutTitle": {
-    "type": "text"
-  },
-  "notifTxText": "您已收到｛coin｝交易！",
-  "@notifTxText": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "notifTxTitle": "应记交易",
-  "@notifTxTitle": {
-    "type": "text"
-  },
-  "noTxs": "没有交易",
-  "@noTxs": {
-    "type": "text"
-  },
-  "numberAssets": "{assets} 资产",
-  "@numberAssets": {
-    "type": "text",
-    "placeholders": {
-      "assets": {}
-    }
-  },
-  "officialPressRelease": "官方新闻稿",
-  "@officialPressRelease": {
-    "type": "text"
-  },
-  "okButton": "好的",
-  "@okButton": {
-    "type": "text"
-  },
-  "oldLogsDelete": "删除",
-  "@oldLogsDelete": {
-    "type": "text"
-  },
-  "oldLogsTitle": "历史记录",
-  "@oldLogsTitle": {
-    "type": "text"
-  },
-  "oldLogsUsed": "占用的空间",
-  "@oldLogsUsed": {
-    "type": "text"
-  },
-  "openMessage": "打开错误消息",
-  "@openMessage": {
-    "type": "text"
-  },
-  "Optional": "选修的",
-  "@Optional": {
-    "type": "text"
-  },
-  "orderBookLess": "较少的",
-  "@orderBookLess": {
-    "type": "text"
-  },
-  "orderBookMore": "更多的",
-  "@orderBookMore": {
-    "type": "text"
-  },
-  "orderCancel": "所有{coin}订单将被取消。",
-  "@orderCancel": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderCreated": "订单已创建",
-  "@orderCreated": {
-    "type": "text"
-  },
-  "orderCreatedInfo": "订单已成功创建",
-  "@orderCreatedInfo": {
-    "type": "text"
-  },
-  "orderDetailsAddress": "地址",
-  "@orderDetailsAddress": {
-    "type": "text"
-  },
-  "orderDetailsCancel": "取消",
-  "@orderDetailsCancel": {
-    "type": "text"
-  },
-  "orderDetailsExpedient": "划算的: CEX +{delta}%",
-  "@orderDetailsExpedient": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsExpensive": "昂贵的: CEX {delta}%",
-  "@orderDetailsExpensive": {
-    "type": "text",
-    "placeholders": {
-      "delta": {}
-    }
-  },
-  "orderDetailsFor": "与",
-  "@orderDetailsFor": {
-    "type": "text"
-  },
-  "orderDetailsIdentical": "CEX相同",
-  "@orderDetailsIdentical": {
-    "type": "text"
-  },
-  "orderDetailsMin": "最小量",
-  "@orderDetailsMin": {
-    "type": "text"
-  },
-  "orderDetailsPrice": "价格",
-  "@orderDetailsPrice": {
-    "type": "text"
-  },
-  "orderDetailsReceive": "接收",
-  "@orderDetailsReceive": {
-    "type": "text"
-  },
-  "orderDetailsSelect": "选择",
-  "@orderDetailsSelect": {
-    "type": "text"
-  },
-  "orderDetailsSells": "卖出",
-  "@orderDetailsSells": {
-    "type": "text"
-  },
-  "orderDetailsSettings": "单击打开详细信息，然后长按选择订购",
-  "@orderDetailsSettings": {
-    "type": "text"
-  },
-  "orderDetailsSpend": "花费",
-  "@orderDetailsSpend": {
-    "type": "text"
-  },
-  "orderDetailsTitle": "详细信息",
-  "@orderDetailsTitle": {
-    "type": "text"
-  },
-  "orderFilled": "{fill}%已填充",
-  "@orderFilled": {
-    "type": "text",
-    "placeholders": {
-      "fill": {}
-    }
-  },
-  "orderMatched": "已匹配订单",
-  "@orderMatched": {
-    "type": "text"
-  },
-  "orderMatching": "订单匹配中",
-  "@orderMatching": {
-    "type": "text"
-  },
-  "orders": "订单",
-  "@orders": {
-    "type": "text"
-  },
-  "ordersActive": "活跃",
-  "@ordersActive": {
-    "type": "text"
-  },
-  "ordersHistory": "历史记录",
-  "@ordersHistory": {
-    "type": "text"
-  },
-  "ordersTableAmount": "数量({coin})",
-  "@ordersTableAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTablePrice": "价格 ({coin})",
-  "@ordersTablePrice": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "ordersTableTotal": "总计 ({coin})",
-  "@ordersTableTotal": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "orderTypePartial": "订单",
-  "@orderTypePartial": {
-    "type": "text"
-  },
-  "orderTypeUnknown": "未知类型订单",
-  "@orderTypeUnknown": {
-    "type": "text"
-  },
-  "overwrite": "覆盖",
-  "@overwrite": {
-    "type": "text"
-  },
-  "ownOrder": "这是您个人的订单",
-  "@ownOrder": {
-    "type": "text"
-  },
-  "paidFromBalance": "用余额支付：",
-  "@paidFromBalance": {
-    "type": "text"
-  },
-  "paidFromVolume": "用已接收的交易量支付",
-  "@paidFromVolume": {
-    "type": "text"
-  },
-  "paidWith": "支付方式：",
-  "@paidWith": {
-    "type": "text"
-  },
-  "passwordRequirement": "密码必须至少包含12个字符，包括一个小写、一个大写和一个特殊符号",
-  "@passwordRequirement": {
-    "type": "text"
-  },
-  "pastTransactionsFromDate": "您的钱包将显示您过去在指定日期之后进行的交易。",
-  "@pastTransactionsFromDate": {
-    "type": "text"
-  },
-  "paymentUriDetailsAccept": "支付",
-  "@paymentUriDetailsAccept": {
-    "type": "text"
-  },
-  "paymentUriDetailsAcceptQuestion": "您接受这笔交易吗？",
-  "@paymentUriDetailsAcceptQuestion": {
-    "type": "text"
-  },
-  "paymentUriDetailsAddressSpan": "接收方地址",
-  "@paymentUriDetailsAddressSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsAmountSpan": "数量：",
-  "@paymentUriDetailsAmountSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsCoinSpan": "货币：",
-  "@paymentUriDetailsCoinSpan": {
-    "type": "text"
-  },
-  "paymentUriDetailsDeny": "取消",
-  "@paymentUriDetailsDeny": {
-    "type": "text"
-  },
-  "paymentUriDetailsTitle": "已请求的付款",
-  "@paymentUriDetailsTitle": {
-    "type": "text"
-  },
-  "paymentUriInactiveCoin": "{abbr} 未激活。请激活后重试。",
-  "@paymentUriInactiveCoin": {
-    "type": "text",
-    "placeholders": {
-      "abbr": {}
-    }
-  },
-  "placeOrder": "下单",
-  "@placeOrder": {
-    "type": "text"
-  },
-  "Play at full volume": "音量开到最大",
-  "@Play at full volume": {
-    "type": "text"
-  },
-  "pleaseAddCoin": "请添加货币",
-  "@pleaseAddCoin": {
-    "type": "text"
-  },
-  "pleaseRestart": "请重启应用程序后重试，或按下面的按钮。",
-  "@pleaseRestart": {
-    "type": "text"
-  },
-  "portfolio": "投资组合",
-  "@portfolio": {
-    "type": "text"
-  },
-  "poweredOnKmd": "由Komodo支持",
-  "@poweredOnKmd": {
-    "type": "text"
-  },
-  "price": "价格",
-  "@price": {
-    "type": "text"
-  },
-  "privateKey": "私钥",
-  "@privateKey": {
-    "type": "text"
-  },
-  "privateKeys": "私钥",
-  "@privateKeys": {
-    "type": "text"
-  },
-  "protectionCtrlConfirmations": "确认",
-  "@protectionCtrlConfirmations": {
-    "type": "text"
-  },
-  "protectionCtrlCustom": "使用自定义保护设置",
-  "@protectionCtrlCustom": {
-    "type": "text"
-  },
-  "protectionCtrlOff": "关闭",
-  "@protectionCtrlOff": {
-    "type": "text"
-  },
-  "protectionCtrlOn": "开启",
-  "@protectionCtrlOn": {
-    "type": "text"
-  },
-  "protectionCtrlWarning": "警告，此原子交换不受dPoW保护。",
-  "@protectionCtrlWarning": {
-    "type": "text"
-  },
-  "pubkey": "公钥",
-  "@pubkey": {
-    "type": "text"
-  },
-  "qrCodeScanner": "二维码扫描仪",
-  "@qrCodeScanner": {
-    "type": "text"
-  },
-  "question_1": "你们会保存我的私钥吗？",
-  "@question_1": {
-    "type": "text"
-  },
-  "question_10": "我可以在哪些设备上使用{appName} ？",
-  "@question_10": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_2": "在{appName} 上交易与在其他DEX上交易有何不同？",
-  "@question_2": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_3": "每次原子交换需要多长时间？",
-  "@question_3": {
-    "type": "text"
-  },
-  "question_4": "在交换期间我要保持在线吗",
-  "@question_4": {
-    "type": "text"
-  },
-  "question_5": "{appName} 的费用如何计算？",
-  "@question_5": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_6": "你们会提供用户支持吗？",
-  "@question_6": {
-    "type": "text"
-  },
-  "question_7": "你们有地区限制吗？",
-  "@question_7": {
-    "type": "text"
-  },
-  "question_8": "{appName} 的背后是谁？",
-  "@question_8": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "question_9": "是否可以在{appName} 上开发我个人的白标交换？",
-  "@question_9": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "rebrandingAnnouncement": "这是一个新时代！我们已正式将名称从“AtomicDEX”更改为“Komodo Wallet”",
-  "@rebrandingAnnouncement": {
-    "type": "text"
-  },
-  "receive": "接收",
-  "@receive": {
-    "type": "text"
-  },
-  "receiveLower": "接收",
-  "@receiveLower": {
-    "type": "text"
-  },
-  "recommendSeedMessage": "我们建议在线下存档。",
-  "@recommendSeedMessage": {
-    "type": "text"
-  },
-  "remove": "停用",
-  "@remove": {
-    "type": "text"
-  },
-  "requestedTrade": "已请求的交易",
-  "@requestedTrade": {
-    "type": "text"
-  },
-  "reset": "清除",
-  "@reset": {
-    "type": "text"
-  },
-  "resetTitle": "重置表格",
-  "@resetTitle": {
-    "type": "text"
-  },
-  "restoreWallet": "恢复",
-  "@restoreWallet": {
-    "type": "text"
-  },
-  "retryActivating": "正在重试激活所有货币",
-  "@retryActivating": {
-    "type": "text"
-  },
-  "retryAll": "重试激活所有",
-  "@retryAll": {
-    "type": "text"
-  },
-  "rewardsButton": "领取奖励",
-  "@rewardsButton": {
-    "type": "text"
-  },
-  "rewardsCancel": "取消",
-  "@rewardsCancel": {
-    "type": "text"
-  },
-  "rewardsError": "出现错误。请稍后再试。",
-  "@rewardsError": {
-    "type": "text"
-  },
-  "rewardsInProgressLong": "交易正在进行",
-  "@rewardsInProgressLong": {
-    "type": "text"
-  },
-  "rewardsInProgressShort": "处理",
-  "@rewardsInProgressShort": {
-    "type": "text"
-  },
-  "rewardsLowAmountLong": "UTXO金额小于10 KMD",
-  "@rewardsLowAmountLong": {
-    "type": "text"
-  },
-  "rewardsLowAmountShort": "<10KMD",
-  "@rewardsLowAmountShort": {
-    "type": "text"
-  },
-  "rewardsOneHourLong": "还未过去一小时",
-  "@rewardsOneHourLong": {
-    "type": "text"
-  },
-  "rewardsOneHourShort": "<1小时",
-  "@rewardsOneHourShort": {
-    "type": "text"
-  },
-  "rewardsPopupOk": "好的",
-  "@rewardsPopupOk": {
-    "type": "text"
-  },
-  "rewardsPopupTitle": "奖励状态：",
-  "@rewardsPopupTitle": {
-    "type": "text"
-  },
-  "rewardsReadMore": "阅读有关KMD活跃用户奖励的更多信息",
-  "@rewardsReadMore": {
-    "type": "text"
-  },
-  "rewardsReceive": "接收",
-  "@rewardsReceive": {
-    "type": "text"
-  },
-  "rewardsSuccess": "成功！收到 {amount}KMD",
-  "@rewardsSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "rewardsTableFiat": "法币",
-  "@rewardsTableFiat": {
-    "type": "text"
-  },
-  "rewardsTableRewards": "奖励，KMD",
-  "@rewardsTableRewards": {
-    "type": "text"
-  },
-  "rewardsTableStatus": "状态",
-  "@rewardsTableStatus": {
-    "type": "text"
-  },
-  "rewardsTableTime": "剩余时间",
-  "@rewardsTableTime": {
-    "type": "text"
-  },
-  "rewardsTableTitle": "奖励信息",
-  "@rewardsTableTitle": {
-    "type": "text"
-  },
-  "rewardsTableUXTO": "UTXO 数量\nKMD",
-  "@rewardsTableUXTO": {
-    "type": "text"
-  },
-  "rewardsTimeDays": "{dd} 天",
-  "@rewardsTimeDays": {
-    "type": "text",
-    "placeholders": {
-      "dd": {}
-    }
-  },
-  "rewardsTimeHours": "{hh}小时 {minutes}分钟",
-  "@rewardsTimeHours": {
-    "type": "text",
-    "placeholders": {
-      "hh": {},
-      "minutes": {}
-    }
-  },
-  "rewardsTimeMin": "{mm}分钟",
-  "@rewardsTimeMin": {
-    "type": "text",
-    "placeholders": {
-      "mm": {}
-    }
-  },
-  "rewardsTitle": "奖励信息",
-  "@rewardsTitle": {
-    "type": "text"
-  },
-  "russianLanguage": "俄语",
-  "@russianLanguage": {
-    "type": "text"
-  },
-  "saveMerged": "保存合并",
-  "@saveMerged": {
-    "type": "text"
-  },
-  "scrollToContinue": "滚动到底部继续...",
-  "@scrollToContinue": {
-    "type": "text"
-  },
-  "searchFilterCoin": "搜索货币",
-  "@searchFilterCoin": {
-    "type": "text"
-  },
-  "searchFilterSubtitleAVX": "选择所有Avax代币",
-  "@searchFilterSubtitleAVX": {
-    "type": "text"
-  },
-  "searchFilterSubtitleBEP": "选择所有BEP代币",
-  "@searchFilterSubtitleBEP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleCosmos": "选择所有 Cosmos 网络",
-  "@searchFilterSubtitleCosmos": {
-    "type": "text"
-  },
-  "searchFilterSubtitleERC": "选择所有ERC代币",
-  "@searchFilterSubtitleERC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleETC": "选择所有ETC代币",
-  "@searchFilterSubtitleETC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleFTM": "选择所有Fantom代币",
-  "@searchFilterSubtitleFTM": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHCO": "选择所有HecoChain代币",
-  "@searchFilterSubtitleHCO": {
-    "type": "text"
-  },
-  "searchFilterSubtitleHRC": "选择所有Harmony代币",
-  "@searchFilterSubtitleHRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleIris": "选择所有虹膜网络",
-  "@searchFilterSubtitleIris": {
-    "type": "text"
-  },
-  "searchFilterSubtitleKRC": "选择所有Kucoin代币",
-  "@searchFilterSubtitleKRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleMVR": "选择所有Moonriver代币",
-  "@searchFilterSubtitleMVR": {
-    "type": "text"
-  },
-  "searchFilterSubtitlePLG": "选择所有Polygon代币",
-  "@searchFilterSubtitlePLG": {
-    "type": "text"
-  },
-  "searchFilterSubtitleQRC": "选择所有QRC代币",
-  "@searchFilterSubtitleQRC": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSBCH": "选择所有SmartBCH代币",
-  "@searchFilterSubtitleSBCH": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSLP": "选择所有 SLP 代币",
-  "@searchFilterSubtitleSLP": {
-    "type": "text"
-  },
-  "searchFilterSubtitleSmartChain": "选择所有智能链",
-  "@searchFilterSubtitleSmartChain": {
-    "type": "text"
-  },
-  "searchFilterSubtitleTestCoins": "选择所有测试资产",
-  "@searchFilterSubtitleTestCoins": {
-    "type": "text"
-  },
-  "searchFilterSubtitleUBQ": "选择所有Ubiq货币",
-  "@searchFilterSubtitleUBQ": {
-    "type": "text"
-  },
-  "searchFilterSubtitleutxo": "选择所有UTXO货币",
-  "@searchFilterSubtitleutxo": {
-    "type": "text"
-  },
-  "searchFilterSubtitleZHTLC": "选择所有ZHTLC币",
-  "@searchFilterSubtitleZHTLC": {
-    "type": "text"
-  },
-  "searchForTicker": "搜索货币代码",
-  "@searchForTicker": {
-    "type": "text"
-  },
-  "seconds": "秒",
-  "@seconds": {
-    "type": "text"
-  },
-  "security": "证券",
-  "@security": {
-    "type": "text"
-  },
-  "seedPhrase": "助记词",
-  "@seedPhrase": {
-    "type": "text"
-  },
-  "seedPhraseTitle": "您的新助記詞",
-  "@seedPhraseTitle": {
-    "type": "text"
-  },
-  "seeOrders": "点击查看{amount} 交易",
-  "@seeOrders": {
-    "type": "text",
-    "placeholders": {
-      "amount": {}
-    }
-  },
-  "seeTxHistory": "查看交易记录",
-  "@seeTxHistory": {
-    "type": "text"
-  },
-  "selectCoin": "选择货币",
-  "@selectCoin": {
-    "type": "text"
-  },
-  "selectCoinInfo": "选择您想要添加到投资组合的货币",
-  "@selectCoinInfo": {
-    "type": "text"
-  },
-  "selectCoinTitle": "激活货币：",
-  "@selectCoinTitle": {
-    "type": "text"
-  },
-  "selectCoinToBuy": "选择您想买入的货币",
-  "@selectCoinToBuy": {
-    "type": "text"
-  },
-  "selectCoinToSell": "选择您想卖出的货币",
-  "@selectCoinToSell": {
-    "type": "text"
-  },
-  "selectDate": "选择日期",
-  "@selectDate": {
-    "type": "text"
-  },
-  "selectedOrder": "选择订单",
-  "@selectedOrder": {
-    "type": "text"
-  },
-  "selectFileImport": "选择文件",
-  "@selectFileImport": {
-    "type": "text"
-  },
-  "selectLanguage": "选择语言",
-  "@selectLanguage": {
-    "type": "text"
-  },
-  "selectPaymentMethod": "选择您的支付方式",
-  "@selectPaymentMethod": {
-    "type": "text"
-  },
-  "sell": "卖出",
-  "@sell": {
-    "type": "text"
-  },
-  "sellTestCoinWarning": "警告，您正在卖出没有实际价值的测试币!",
-  "@sellTestCoinWarning": {
-    "type": "text"
-  },
-  "send": "发送",
-  "@send": {
-    "type": "text"
-  },
-  "settingDialogSpan1": "您确定要删除",
-  "@settingDialogSpan1": {
-    "type": "text"
-  },
-  "settingDialogSpan2": "钱包吗",
-  "@settingDialogSpan2": {
-    "type": "text"
-  },
-  "settingDialogSpan3": "如果是，请确认您已",
-  "@settingDialogSpan3": {
-    "type": "text"
-  },
-  "settingDialogSpan4": "记下助记词",
-  "@settingDialogSpan4": {
-    "type": "text"
-  },
-  "settingDialogSpan5": "以便在将来恢复您的钱包",
-  "@settingDialogSpan5": {
-    "type": "text"
-  },
-  "settingLanguageTitle": "语言",
-  "@settingLanguageTitle": {
-    "type": "text"
-  },
-  "settings": "设置",
-  "@settings": {
-    "type": "text"
-  },
-  "setUpPassword": "创建密码",
-  "@setUpPassword": {
-    "type": "text"
-  },
-  "share": "分享",
-  "@share": {
-    "type": "text"
-  },
-  "shareAddress": "我的{coinName} 地址:\n{address}",
-  "@shareAddress": {
-    "type": "text",
-    "placeholders": {
-      "coinName": {},
-      "address": {}
-    }
-  },
-  "shouldScanPastTransaction": "扫描过去的 {coin} 交易？",
-  "@shouldScanPastTransaction": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "showAddress": "显示地址",
-  "@showAddress": {
-    "type": "text"
-  },
-  "showDetails": "显示详细信息",
-  "@showDetails": {
-    "type": "text"
-  },
-  "showingOrders": "显示 {count} 个订单（共 {maxCount} 个）。",
-  "@showingOrders": {
-    "type": "text",
-    "placeholders": {
-      "count": {},
-      "maxCount": {}
-    }
-  },
-  "showMyOrders": "显示我的订单",
-  "@showMyOrders": {
-    "type": "text"
-  },
-  "signInWithPassword": "使用密码登录",
-  "@signInWithPassword": {
-    "type": "text"
-  },
-  "signInWithSeedPhrase": "忘记密码？用助记词恢复钱包",
-  "@signInWithSeedPhrase": {
-    "type": "text"
-  },
-  "simple": "简单",
-  "@simple": {
-    "type": "text"
-  },
-  "simpleTradeActivate": "激活",
-  "@simpleTradeActivate": {
-    "type": "text"
-  },
-  "simpleTradeBuyHint": "请输入要买入的 {coin} 数量",
-  "@simpleTradeBuyHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeBuyTitle": "买入",
-  "@simpleTradeBuyTitle": {
-    "type": "text"
-  },
-  "simpleTradeClose": "关闭",
-  "@simpleTradeClose": {
-    "type": "text"
-  },
-  "simpleTradeMaxActiveCoins": "货币最大活跃量为{maxCoins}。请停用一些。",
-  "@simpleTradeMaxActiveCoins": {
-    "type": "text",
-    "placeholders": {
-      "maxCoins": {}
-    }
-  },
-  "simpleTradeNotActive": "{coin}未激活！",
-  "@simpleTradeNotActive": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeRecieve": "接收",
-  "@simpleTradeRecieve": {
-    "type": "text"
-  },
-  "simpleTradeSellHint": "请输入要卖出的{coin}数量",
-  "@simpleTradeSellHint": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "simpleTradeSellTitle": "卖出",
-  "@simpleTradeSellTitle": {
-    "type": "text"
-  },
-  "simpleTradeSend": "发送",
-  "@simpleTradeSend": {
-    "type": "text"
-  },
-  "simpleTradeShowLess": "收起",
-  "@simpleTradeShowLess": {
-    "type": "text"
-  },
-  "simpleTradeShowMore": "显示更多",
-  "@simpleTradeShowMore": {
-    "type": "text"
-  },
-  "simpleTradeUnableActivate": "无法激活{coin}",
-  "@simpleTradeUnableActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "skip": "跳过",
-  "@skip": {
-    "type": "text"
-  },
-  "snackbarDismiss": "不予考虑",
-  "@snackbarDismiss": {
-    "type": "text"
-  },
-  "Sound": "声音",
-  "@Sound": {
-    "type": "text"
-  },
-  "soundCantPlayThatMsg": "请选择mp3或wav文件。我们将在{description}时播放它。",
-  "@soundCantPlayThatMsg": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundPlayedWhen": "当{description}播放",
-  "@soundPlayedWhen": {
-    "type": "text",
-    "placeholders": {
-      "description": {
-        "example": "a swap runs to completion"
-      }
-    }
-  },
-  "soundsDialogTitle": "声音",
-  "@soundsDialogTitle": {
-    "type": "text"
-  },
-  "soundsDoNotShowAgain": "已知晓，不再显示",
-  "@soundsDoNotShowAgain": {
-    "type": "text"
-  },
-  "soundSettingsLink": "声音",
-  "@soundSettingsLink": {
-    "type": "text"
-  },
-  "soundSettingsTitle": "声音设置",
-  "@soundSettingsTitle": {
-    "type": "text"
-  },
-  "soundsExplanation": "交换时，如果您有一个活跃的挂单交易，会收到声音提醒。\n原子交换协议要求参与者在线才能成功交易，声音通知可以帮助实现这一点。",
-  "@soundsExplanation": {
-    "type": "text"
-  },
-  "soundsNote": "请注意，您可以在应用程序设置中设置自定义声音。",
-  "@soundsNote": {
-    "type": "text"
-  },
-  "spanishLanguage": "西班牙语",
-  "@spanishLanguage": {
-    "type": "text"
-  },
-  "startDate": "开始日期",
-  "@startDate": {
-    "type": "text"
-  },
-  "startSwap": "开始交换",
-  "@startSwap": {
-    "type": "text"
-  },
-  "step": "步骤",
-  "@step": {
-    "type": "text"
-  },
-  "success": "成功",
-  "@success": {
-    "type": "text"
-  },
-  "support": "支持",
-  "@support": {
-    "type": "text"
-  },
-  "supportLinksDesc": "如果您有任何问题，或者认为您发现{appName} 应用程序存在技术问题，请联系我们获取我们团队的支持。",
-  "@supportLinksDesc": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "swap": "交换",
-  "@swap": {
-    "type": "text"
-  },
-  "swapCurrent": "现状",
-  "@swapCurrent": {
-    "type": "text"
-  },
-  "swapDetailTitle": "确认兑换细节",
-  "@swapDetailTitle": {
-    "type": "text"
-  },
-  "swapEstimated": "预估",
-  "@swapEstimated": {
-    "type": "text"
-  },
-  "swapFailed": "交换失败",
-  "@swapFailed": {
-    "type": "text"
-  },
-  "swapGasActivate": "请先激活 {coin} 并充值余额",
-  "@swapGasActivate": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmount": "{coin} 余额不足以支付交易费用。",
-  "@swapGasAmount": {
-    "type": "text",
-    "placeholders": {
-      "coin": {}
-    }
-  },
-  "swapGasAmountRequired": "{coin} 余额不足以支付交易费用。需要 {coin} {amount}",
-  "@swapGasAmountRequired": {
-    "type": "text",
-    "placeholders": {
-      "coin": {},
-      "amount": {}
-    }
-  },
-  "swapOngoing": "正在交换",
-  "@swapOngoing": {
-    "type": "text"
-  },
-  "swapProgress": "进度详情",
-  "@swapProgress": {
-    "type": "text"
-  },
-  "swapStarted": "已开始",
-  "@swapStarted": {
-    "type": "text"
-  },
-  "swapSucceful": "交换成功",
-  "@swapSucceful": {
-    "type": "text"
-  },
-  "swapTotal": "总共",
-  "@swapTotal": {
-    "type": "text"
-  },
-  "swapUUID": "UUID交换",
-  "@swapUUID": {
-    "type": "text"
-  },
-  "switchTheme": "切换主题",
-  "@switchTheme": {
-    "type": "text"
-  },
-  "syncFromDate": "从指定日期同步",
-  "@syncFromDate": {
-    "type": "text"
-  },
-  "syncFromSaplingActivation": "从树苗激活同步",
-  "@syncFromSaplingActivation": {
-    "type": "text"
-  },
-  "syncNewTransactions": "同步新交易",
-  "@syncNewTransactions": {
-    "type": "text"
-  },
-  "syncTransactionsQuestion": "您想要同步哪些{name}交易？",
-  "@syncTransactionsQuestion": {
-    "type": "text",
-    "placeholders": {
-      "name": {}
-    }
-  },
-  "tagAVX20": "AVX20",
-  "@tagAVX20": {
-    "type": "text"
-  },
-  "tagBEP20": "BEP20",
-  "@tagBEP20": {
-    "type": "text"
-  },
-  "tagERC20": "ERC20",
-  "@tagERC20": {
-    "type": "text"
-  },
-  "tagETC": "ETC",
-  "@tagETC": {
-    "type": "text"
-  },
-  "tagFTM20": "FTM20",
-  "@tagFTM20": {
-    "type": "text"
-  },
-  "tagHCO20": "HCO20",
-  "@tagHCO20": {
-    "type": "text"
-  },
-  "tagHRC20": "HRC20",
-  "@tagHRC20": {
-    "type": "text"
-  },
-  "tagKMD": "KMD",
-  "@tagKMD": {
-    "type": "text"
-  },
-  "tagKRC20": "KRC20",
-  "@tagKRC20": {
-    "type": "text"
-  },
-  "tagMVR20": "MVR20",
-  "@tagMVR20": {
-    "type": "text"
-  },
-  "tagPLG20": "PLG20",
-  "@tagPLG20": {
-    "type": "text"
-  },
-  "tagQRC20": "QRC20",
-  "@tagQRC20": {
-    "type": "text"
-  },
-  "tagSBCH": "SBCH",
-  "@tagSBCH": {
-    "type": "text"
-  },
-  "tagUBQ": "UBQ",
-  "@tagUBQ": {
-    "type": "text"
-  },
-  "tagZHTLC": "ZHTLC",
-  "@tagZHTLC": {
-    "type": "text"
-  },
-  "Taker": "吃单",
-  "@Taker": {
-    "type": "text"
-  },
-  "takerOrder": "吃单交易",
-  "@takerOrder": {
-    "type": "text"
-  },
-  "timeOut": "超时",
-  "@timeOut": {
-    "type": "text"
-  },
-  "titleCreatePassword": "创建密码",
-  "@titleCreatePassword": {
-    "type": "text"
-  },
-  "titleCurrentAsk": "选择订单",
-  "@titleCurrentAsk": {
-    "type": "text"
-  },
-  "to": "至",
-  "@to": {
-    "type": "text"
-  },
-  "toAddress": "接收地址",
-  "@toAddress": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan1": "您已",
-  "@tooManyAssetsEnabledSpan1": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan2": "启用资产。启用资产上限为",
-  "@tooManyAssetsEnabledSpan2": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledSpan3": "请在启用新资产前停用一些资产",
-  "@tooManyAssetsEnabledSpan3": {
-    "type": "text"
-  },
-  "tooManyAssetsEnabledTitle": "已启用的资产太多",
-  "@tooManyAssetsEnabledTitle": {
-    "type": "text"
-  },
-  "totalFees": "总费用",
-  "@totalFees": {
-    "type": "text"
-  },
-  "trade": "交易",
-  "@trade": {
-    "type": "text"
-  },
-  "tradeCompleted": "交换完成！",
-  "@tradeCompleted": {
-    "type": "text"
-  },
-  "tradeDetail": "交易详情",
-  "@tradeDetail": {
-    "type": "text"
-  },
-  "tradePreimageError": "无法计算交易费用",
-  "@tradePreimageError": {
-    "type": "text"
-  },
-  "tradingFee": "交易费用：",
-  "@tradingFee": {
-    "type": "text"
-  },
-  "tradingMode": "交易模式：",
-  "@tradingMode": {
-    "type": "text"
-  },
-  "transactionAddress": "交易地址",
-  "@transactionAddress": {
-    "type": "text"
-  },
-  "transactionHidden": "交易隐藏",
-  "@transactionHidden": {
-    "type": "text"
-  },
-  "transactionHiddenPhishing": "由于可能存在网络钓鱼尝试，该交易被隐藏。",
-  "@transactionHiddenPhishing": {
-    "type": "text"
-  },
-  "tryRestarting": "如果还是有一些货币未被激活，请尝试重启应用程序。",
-  "@tryRestarting": {
-    "type": "text"
-  },
-  "turkishLanguage": "土耳其语",
-  "@turkishLanguage": {
-    "type": "text"
-  },
-  "txBlock": "区块",
-  "@txBlock": {
-    "type": "text"
-  },
-  "txConfirmations": "确认",
-  "@txConfirmations": {
-    "type": "text"
-  },
-  "txConfirmed": "已确认",
-  "@txConfirmed": {
-    "type": "text"
-  },
-  "txFee": "费用",
-  "@txFee": {
-    "type": "text"
-  },
-  "txFeeTitle": "交易费用",
-  "@txFeeTitle": {
-    "type": "text"
-  },
-  "txHash": "交易ID",
-  "@txHash": {
-    "type": "text"
-  },
-  "txleft": "剩余交易: {left}",
-  "@txleft": {
-    "type": "text",
-    "placeholders": {
-      "left": {}
-    }
-  },
-  "txLimitExceeded": "请求过多。超出交易历史请求限制。请稍后重试",
-  "@txLimitExceeded": {
-    "type": "text"
-  },
-  "txNotConfirmed": "未确认",
-  "@txNotConfirmed": {
-    "type": "text"
-  },
-  "ukrainianLanguage": "乌克兰",
-  "@ukrainianLanguage": {
-    "type": "text"
-  },
-  "unlock": "解锁",
-  "@unlock": {
-    "type": "text"
-  },
-  "unlockFunds": "解锁基金",
-  "@unlockFunds": {
-    "type": "text"
-  },
-  "unlockSuccess": "成功解锁 {amnt} 基金 - 交易: {hash}",
-  "@unlockSuccess": {
-    "type": "text",
-    "placeholders": {
-      "amnt": {},
-      "hash": {}
-    }
-  },
-  "unspendable": "不可交易",
-  "@unspendable": {
-    "type": "text"
-  },
-  "updatesAvailable": "已有新版本",
-  "@updatesAvailable": {
-    "type": "text"
-  },
-  "updatesChecking": "正在检查更新",
-  "@updatesChecking": {
-    "type": "text"
-  },
-  "updatesCurrentVersion": "您正在使用版本{version}",
-  "@updatesCurrentVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifAvailable": "已有新版本。请更新。",
-  "@updatesNotifAvailable": {
-    "type": "text"
-  },
-  "updatesNotifAvailableVersion": "版本{version}可用。请更新。",
-  "@updatesNotifAvailableVersion": {
-    "type": "text",
-    "placeholders": {
-      "version": {}
-    }
-  },
-  "updatesNotifTitle": "可更新",
-  "@updatesNotifTitle": {
-    "type": "text"
-  },
-  "updatesSkip": "暂时跳过",
-  "@updatesSkip": {
-    "type": "text"
-  },
-  "updatesTitle": "更新{appName}",
-  "@updatesTitle": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "updatesUpdate": "已更新",
-  "@updatesUpdate": {
-    "type": "text"
-  },
-  "updatesUpToDate": "准备更新",
-  "@updatesUpToDate": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan1": "余额不足，无法扫描",
-  "@uriInsufficientBalanceSpan1": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceSpan2": "付款请求。",
-  "@uriInsufficientBalanceSpan2": {
-    "type": "text"
-  },
-  "uriInsufficientBalanceTitle": "余额不足",
-  "@uriInsufficientBalanceTitle": {
-    "type": "text"
-  },
-  "value": "价值",
-  "@value": {
-    "type": "text"
-  },
-  "version": "版本",
-  "@version": {
-    "type": "text"
-  },
-  "viewInExplorerButton": "资源管理器",
-  "@viewInExplorerButton": {
-    "type": "text"
-  },
-  "viewSeedAndKeys": "助记词和私钥",
-  "@viewSeedAndKeys": {
-    "type": "text"
-  },
-  "volumes": "交易量",
-  "@volumes": {
-    "type": "text"
-  },
-  "walletInUse": "钱包名称已被使用",
-  "@walletInUse": {
-    "type": "text"
-  },
-  "walletMaxChar": "钱包名称最多40个字符",
-  "@walletMaxChar": {
-    "type": "text"
-  },
-  "walletOnly": "仅钱包",
-  "@walletOnly": {
-    "type": "text"
-  },
-  "warning": "警告",
-  "@warning": {
-    "type": "text"
-  },
-  "warningOkBtn": "好的",
-  "@warningOkBtn": {
-    "type": "text"
-  },
-  "warningShareLogs": "警告-在特殊情况下，此登录数据包含敏感信息，可用于消费交换失败的货币！",
-  "@warningShareLogs": {
-    "type": "text"
-  },
-  "weFailedTo": "我们无法激活 {coinAbbr}",
-  "@weFailedTo": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "weFailedToActivate": "我们无法激活{coinAbbr}.\n请重启应用程序后重试",
-  "@weFailedToActivate": {
-    "type": "text",
-    "placeholders": {
-      "coinAbbr": {}
-    }
-  },
-  "welcomeInfo": "{appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。",
-  "@welcomeInfo": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "welcomeLetSetUp": "让我们开始吧",
-  "@welcomeLetSetUp": {
-    "type": "text"
-  },
-  "welcomeTitle": "欢迎",
-  "@welcomeTitle": {
-    "type": "text"
-  },
-  "welcomeWallet": "钱包",
-  "@welcomeWallet": {
-    "type": "text"
-  },
-  "willBeRedirected": "完成后，您将跳转至投资组合页面",
-  "@willBeRedirected": {
-    "type": "text"
-  },
-  "willTakeTime": "这将需要一段时间，并且应用程序必须保持在前台。\n在激活过程中终止应用程序可能会导致问题。",
-  "@willTakeTime": {
-    "type": "text"
-  },
-  "withdraw": "提取",
-  "@withdraw": {
-    "type": "text"
-  },
-  "withdrawCameraAccessText": "您之前禁止{appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描",
-  "@withdrawCameraAccessText": {
-    "type": "text",
-    "placeholders": {
-      "appName": {}
-    }
-  },
-  "withdrawCameraAccessTitle": "被拒绝使用",
-  "@withdrawCameraAccessTitle": {
-    "type": "text"
-  },
-  "withdrawConfirm": "确认提取",
-  "@withdrawConfirm": {
-    "type": "text"
-  },
-  "withdrawConfirmError": "出现错误。请稍后重试。",
-  "@withdrawConfirmError": {
-    "type": "text"
-  },
-  "withdrawValue": "提取 {amount} {coinName}",
-  "@withdrawValue": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coinName": {}
-    }
-  },
-  "wrongCoinSpan1": "您正在尝试扫描付款二维码",
-  "@wrongCoinSpan1": {
-    "type": "text"
-  },
-  "wrongCoinSpan2": "但您在",
-  "@wrongCoinSpan2": {
-    "type": "text"
-  },
-  "wrongCoinSpan3": "提取页面",
-  "@wrongCoinSpan3": {
-    "type": "text"
-  },
-  "wrongCoinTitle": "错误货币",
-  "@wrongCoinTitle": {
-    "type": "text"
-  },
-  "wrongPassword": "密码不匹配。请重试",
-  "@wrongPassword": {
-    "type": "text"
-  },
-  "yes": "对",
-  "@yes": {
-    "type": "text"
-  },
-  "youAreSending": "您正在发送：",
-  "@youAreSending": {
-    "type": "text"
-  },
-  "you have a fresh order that is trying to match with an existing order": "您有一个新订单正在尝试与现有订单匹配",
-  "@you have a fresh order that is trying to match with an existing order": {
-    "type": "text"
-  },
-  "you have an active swap in progress": "您有一个正在进行的活跃交换",
-  "@you have an active swap in progress": {
-    "type": "text"
-  },
-  "you have an order that new orders can match with": "你有一个新订单可以匹配的订单",
-  "@you have an order that new orders can match with": {
-    "type": "text"
-  },
-  "yourWallet": "您的钱包",
-  "@yourWallet": {
-    "type": "text"
-  },
-  "youWillReceiveClaim": "您将获得 {amount} {coin}",
-  "@youWillReceiveClaim": {
-    "type": "text",
-    "placeholders": {
-      "amount": {},
-      "coin": {}
-    }
-  },
-  "youWillReceived": "您将收到：",
-  "@youWillReceived": {
-    "type": "text"
-  }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -3621,6 +3621,16 @@
             "coinAbbr": {}
         }
     },
+    "failedToCancelActivation": "无法取消激活 {coinAbbr}",
+    "@failedToCancelActivation": {
+        "type": "text",
+        "placeholders_order": [
+            "coinAbbr"
+        ],
+        "placeholders": {
+            "coinAbbr": {}
+        }
+    },
     "isUnavailable": "{coinAbbr} 不可用:(",
     "@isUnavailable": {
         "type": "text",
@@ -5460,6 +5470,38 @@
         "placeholders": {
             "coin": {}
         }
+    },
+    "activationCancelled": "硬币激活已取消",
+    "@activationCancelled": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
+    },
+    "coinActivationSuccessfull": "成功激活{coin}",
+    "@coinActivationSuccessfull": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "coinActivationCancelled": "{coin}激活已取消",
+    "@coinActivationCancelled": {
+        "type": "text",
+        "placeholders_order": [
+            "coin"
+        ],
+        "placeholders": {
+            "coin": {}
+        }
+    },
+    "pleaseAcceptAllCoinActivationRequests": "请接受所有特殊硬币激活请求或取消选择硬币。",
+    "@pleaseAcceptAllCoinActivationRequests": {
+        "type": "text",
+        "placeholders_order": [],
+        "placeholders": {}
     },
     "cancelActivation": "取消激活",
     "@cancelActivation": {

--- a/lib/l10n/messages_all.dart
+++ b/lib/l10n/messages_all.dart
@@ -75,8 +75,10 @@ MessageLookupByLibrary _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String localeName) async {
   final availableLocale = Intl.verifiedLocale(
-      localeName, (locale) => _deferredLibraries[locale] != null,
-      onFailure: (_) => null);
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null,
+  );
   if (availableLocale == null) {
     return Future.value(false);
   }

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -76,246 +76,253 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "Was ist das ${index}.Wort in Ihrer Seed?";
 
-  static m22(protocolName) => "${protocolName}-Münzen sind aktiviert";
+  static m22(coin) => "Aktivierung von ${coin} abgebrochen";
 
-  static m23(protocolName) =>
+  static m23(coin) => "${coin} erfolgreich aktiviert";
+
+  static m24(protocolName) => "${protocolName}-Münzen sind aktiviert";
+
+  static m25(protocolName) =>
       "${protocolName}-Münzen wurden erfolgreich aktiviert";
 
-  static m24(protocolName) => "${protocolName}-Münzen sind nicht aktiviert";
+  static m26(protocolName) => "${protocolName}-Münzen sind nicht aktiviert";
 
-  static m25(name) => "Möchten Sie den Kontakt ${name} wirklich löschen?";
+  static m27(name) => "Möchten Sie den Kontakt ${name} wirklich löschen?";
 
-  static m26(iUnderstand) =>
+  static m28(iUnderstand) =>
       "Benutzerdefinierte Seed-Phrasen sind möglicherweise weniger sicher und leichter zu knacken als eine generierte BIP39-konforme Seed-Phrase oder ein privater Schlüssel (WIF). Um zu bestätigen, dass Sie das Risiko verstehen und wissen was Sie tun, geben Sie \"${iUnderstand}\" im Kasten unten an.\n";
 
-  static m27(coinName) => "Erhalten Sie die Transaktionsgebühr ${coinName}";
+  static m29(coinName) => "Erhalten Sie die Transaktionsgebühr ${coinName}";
 
-  static m28(coinName) => "Transaktionsgebühr für ${coinName} senden";
+  static m30(coinName) => "Transaktionsgebühr für ${coinName} senden";
 
-  static m29(abbr) => "Geben Sie die ${abbr}  Adresse ein";
+  static m31(abbr) => "Geben Sie die ${abbr}  Adresse ein";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "Sie können ${remains} weiterhin aktivieren, Ausgewählt: ${selected}";
 
-  static m31(gas) => "Nicht genug Gas - verwenden Sie mindestens ${gas} Gwei";
+  static m33(gas) => "Nicht genug Gas - verwenden Sie mindestens ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "Um abgeschlossen zu werden, ${appCompanyLong}muss jede virtuelle Währungstransaktion, die mit dem erstellt wurde, bestätigt und im Ledger für virtuelle Währungen aufgezeichnet werden, das dem jeweiligen virtuellen Währungsnetzwerk zugeordnet ist. ${appCompanyLong}Bei solchen Netzwerken handelt es sich um dezentrale Peer-to-Peer-Netzwerke, die von unabhängigen Dritten unterstützt werden, die sich nicht im Besitz, unter der Kontrolle oder unter der Kontrolle von ihnen befinden.\n${appCompanyLong}hat keine Kontrolle über virtuelle Währungsnetzwerke und kann und wird daher nicht sicherstellen, dass alle Transaktionsdetails, die Sie über unsere Dienste einreichen, im jeweiligen Netzwerk für virtuelle Währungen bestätigt werden. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionsdetails, die Sie über unsere Dienste übermitteln, durch das zur Bearbeitung der Transaktion verwendete virtuelle Währungsnetzwerk möglicherweise nicht abgeschlossen oder erheblich verzögert werden können. Wir garantieren nicht, dass das Wallet das Eigentum oder die Rechte an einer virtuellen Währung übertragen kann, und geben auch keine Garantie in Bezug auf den Titel.\nSobald Transaktionsdetails an ein virtuelles Währungsnetzwerk übermittelt wurden, können wir Ihnen nicht helfen, Ihre Transaktion oder Transaktionsdetails zu stornieren oder anderweitig zu ändern. ${appCompanyLong}hat keine Kontrolle über ein Netzwerk für virtuelle Währungen und ist nicht in der Lage, Stornierungs- oder Änderungsanfragen zu bearbeiten.\nIm Falle eines Forks ${appCompanyLong}kann es sein, dass wir Aktivitäten im Zusammenhang mit Ihrer virtuellen Währung nicht unterstützen können. Sie erklären sich damit einverstanden und verstehen, dass die Transaktionen im Falle einer Fork möglicherweise nicht, teilweise, falsch abgeschlossen oder erheblich verzögert werden. ${appCompanyLong}ist nicht verantwortlich für Verluste, die Ihnen ganz oder teilweise, direkt oder indirekt, durch einen Fork entstehen.\nIn keinem Fall ${appCompanyLong}haften ihre verbundenen Unternehmen und Dienstleister oder ihre jeweiligen leitenden Angestellten, Direktoren, Agenten, Mitarbeiter oder Vertreter für entgangene Gewinne oder besondere, zufällige, indirekte, immaterielle oder Folgeschäden, unabhängig davon, ob sie auf Vertrag, unerlaubter Handlung, Fahrlässigkeit, verschuldensunabhängiger Haftung oder auf andere Weise beruhen, die sich aus oder in Verbindung mit der autorisierten oder unbefugten Nutzung der Dienste oder dieser Vereinbarung ergeben, auch wenn ein bevollmächtigter Vertreter ${appCompanyLong}von darauf hingewiesen wurde, hat davon gewusst oder hätte von der Möglichkeit solcher Schäden bekannt. \nBeispielsweise (und ohne den Umfang des vorstehenden Satzes einzuschränken) dürfen Sie sich nicht für entgangene Gewinne, entgangene Geschäftschancen oder andere Arten von besonderen, zufälligen, indirekten, immateriellen oder Folgeschäden zurückfordern. In einigen Rechtsordnungen ist der Ausschluss oder die Beschränkung von Neben- oder Folgeschäden nicht zulässig, sodass die obige Beschränkung möglicherweise nicht für Sie gilt. \nWir sind Ihnen gegenüber nicht verantwortlich oder haftbar für Verluste und übernehmen keine Verantwortung für Schäden oder Ansprüche, die sich ganz oder teilweise, direkt oder indirekt ergeben aus: \n(a) Benutzerfehler wie vergessene Passwörter, falsch erstellte Transaktionen oder falsch eingegebene Adressen für virtuelle Währungen; \n(b) Serverausfall oder Datenverlust; \n(c) beschädigte oder anderweitig nicht funktionierende Wallets oder Wallet-Dateien; \n(d) unbefugter Zugriff auf Anwendungen; \n(e) alle nicht autorisierten Aktivitäten, einschließlich, aber nicht beschränkt auf den Einsatz von Hacking, Viren, Phishing, Brute-Forcing oder anderen Angriffsmethoden gegen die Dienste.\n\n";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "Anfrage an ${coin} faucet senden...";
+  static m48(coinAbbr) =>
+      "Aktivierung von ${coinAbbr} konnte nicht abgebrochen werden";
 
-  static m47(appCompanyShort) => "${appCompanyShort} Neuigkeiten";
+  static m49(coin) => "Anfrage an ${coin} faucet senden...";
 
-  static m48(value) => "Die Gebühren müssen bis zu ${value} betragen.";
+  static m50(appCompanyShort) => "${appCompanyShort} Neuigkeiten";
 
-  static m49(coin) => "${coin}-Gebühr";
+  static m51(value) => "Die Gebühren müssen bis zu ${value} betragen.";
 
-  static m50(coin) => "Bitte aktivieren Sie ${coin}.";
+  static m52(coin) => "${coin}-Gebühr";
 
-  static m51(value) => "Gwei muss bis zu ${value} sein";
+  static m53(coin) => "Bitte aktivieren Sie ${coin}.";
 
-  static m52(coinName) => "Eingehende ${coinName}-TXS-Schutzeinstellungen";
+  static m54(value) => "Gwei muss bis zu ${value} sein";
 
-  static m53(abbr) =>
+  static m55(coinName) => "Eingehende ${coinName}-TXS-Schutzeinstellungen";
+
+  static m56(abbr) =>
       "${abbr} Guthaben reicht nicht aus, um die Handelsgebühr zu bezahlen";
 
-  static m54(coin) => "Ungültige ${coin}-Adresse";
+  static m57(coin) => "Ungültige ${coin}-Adresse";
 
-  static m55(coinAbbr) => "${coinAbbr} ist nicht verfügbar :(";
+  static m58(coinAbbr) => "${coinAbbr} ist nicht verfügbar :(";
 
-  static m56(coinName) =>
+  static m59(coinName) =>
       "❗Vorsicht! Der Markt für ${coinName} hat ein 24-Stunden-Handelsvolumen von weniger als 10.000 US-Dollar!";
 
-  static m57(value) => "Das Limit muss bis zu ${value} betragen";
-
-  static m58(coinName, number) =>
-      "Die Mindestmenge für den Verkauf ist ${number} ${coinName}";
-
-  static m59(coinName, number) =>
-      "Die Mindestmenge für den Kauf ist ${number} ${coinName}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "Die Mindestmenge des Auftrags ist ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+  static m60(value) => "Das Limit muss bis zu ${value} betragen";
 
   static m61(coinName, number) =>
       "Die Mindestmenge für den Verkauf ist ${number} ${coinName}";
 
-  static m62(minValue, coin) => "Muss größer sein als ${minValue} ${coin}";
+  static m62(coinName, number) =>
+      "Die Mindestmenge für den Kauf ist ${number} ${coinName}";
 
-  static m63(appName) =>
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "Die Mindestmenge des Auftrags ist ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+
+  static m64(coinName, number) =>
+      "Die Mindestmenge für den Verkauf ist ${number} ${coinName}";
+
+  static m65(minValue, coin) => "Muss größer sein als ${minValue} ${coin}";
+
+  static m66(appName) =>
       "Bitte beachten Sie, dass Sie jetzt Mobilfunkdaten verwenden und die Teilnahme am P2P-Netzwerk von ${appName} Internetverkehr verbraucht. Es ist besser, ein WiFi-Netzwerk zu verwenden, wenn Ihr mobiler Datentarif kostspielig ist.";
 
-  static m64(coin) =>
+  static m67(coin) =>
       "Aktivieren Sie ${coin} und laden Sie zuerst Ihr Guthaben auf";
 
-  static m65(number) => "${number} Auftrag/Aufträge erstellen:";
+  static m68(number) => "${number} Auftrag/Aufträge erstellen:";
 
-  static m66(coin) => "${coin} Guthaben ist zu niedrig";
+  static m69(coin) => "${coin} Guthaben ist zu niedrig";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "Nicht genug ${coin} vorhanden, um die Gebühren zu zahlen. MIN Guthaben beträgt ${fee} ${coin}";
 
-  static m68(coinName) => "Bitte geben Sie die ${coinName} Menge ein.";
+  static m71(coinName) => "Bitte geben Sie die ${coinName} Menge ein.";
 
-  static m69(coin) => "Nicht genug ${coin} für die Transaktion!";
-
-  static m70(sell, buy) =>
-      "${sell}/${buy} swap wurde erfolgreich abgeschlossen";
-
-  static m71(sell, buy) => "${sell}/${buy} swap fehlgeschlagen";
-
-  static m72(sell, buy) => "${sell}/${buy} swap gestartet";
+  static m72(coin) => "Nicht genug ${coin} für die Transaktion!";
 
   static m73(sell, buy) =>
+      "${sell}/${buy} swap wurde erfolgreich abgeschlossen";
+
+  static m74(sell, buy) => "${sell}/${buy} swap fehlgeschlagen";
+
+  static m75(sell, buy) => "${sell}/${buy} swap gestartet";
+
+  static m76(sell, buy) =>
       "${sell}/${buy} swap ist abgelaufen(Zeitüberschreitung)";
 
-  static m74(coin) => "Du hast eine ${coin} Transaktion erhalten!";
+  static m77(coin) => "Du hast eine ${coin} Transaktion erhalten!";
 
-  static m75(assets) => "${assets} Assets";
+  static m78(assets) => "${assets} Assets";
 
-  static m76(coin) => "Alle ${coin} Aufträge werden storniert.";
+  static m79(coin) => "Alle ${coin} Aufträge werden storniert.";
 
-  static m77(delta) => "Sinnvoll: CEX +${delta}%";
+  static m80(delta) => "Sinnvoll: CEX +${delta}%";
 
-  static m78(delta) => "Teuer: CEX ${delta}%";
+  static m81(delta) => "Teuer: CEX ${delta}%";
 
-  static m79(fill) => "${fill}% ausgefüllt";
+  static m82(fill) => "${fill}% ausgefüllt";
 
-  static m80(coin) => "(${coin}) Menge";
+  static m83(coin) => "(${coin}) Menge";
 
-  static m81(coin) => "(${coin}) Preis";
+  static m84(coin) => "(${coin}) Preis";
 
-  static m82(coin) => "(${coin}) Gesamt";
+  static m85(coin) => "(${coin}) Gesamt";
 
-  static m83(abbr) =>
+  static m86(abbr) =>
       "${abbr} ist nicht aktiviert. Bitte aktivieren und erneut versuchen.";
 
-  static m84(appName) => "Auf welchen Geräten kann ich ${appName} verwenden?";
-
-  static m85(appName) =>
-      "Wie unterscheidet sich der Handel auf ${appName} vom Handel auf anderen DEXs?";
-
-  static m86(appName) => "Wie werden die Gebühren für ${appName} berechnet?";
-
-  static m87(appName) => "Wer steckt hinter ${appName}?";
+  static m87(appName) => "Auf welchen Geräten kann ich ${appName} verwenden?";
 
   static m88(appName) =>
+      "Wie unterscheidet sich der Handel auf ${appName} vom Handel auf anderen DEXs?";
+
+  static m89(appName) => "Wie werden die Gebühren für ${appName} berechnet?";
+
+  static m90(appName) => "Wer steckt hinter ${appName}?";
+
+  static m91(appName) =>
       "Ist es möglich, meine eigene White-Label-Börse auf ${appName} zu entwickeln?";
 
-  static m89(amount) => "Erfolgreich! ${amount} KMD erhalten";
+  static m92(amount) => "Erfolgreich! ${amount} KMD erhalten";
 
-  static m90(dd) => "${dd} Tag(e)";
+  static m93(dd) => "${dd} Tag(e)";
 
-  static m91(hh, minutes) => "${hh}h ${minutes}m";
+  static m94(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m92(mm) => "${mm}min";
+  static m95(mm) => "${mm}min";
 
-  static m93(amount) => "Klicken Sie hier, um ${amount} Aufträge zu sehen";
+  static m96(amount) => "Klicken Sie hier, um ${amount} Aufträge zu sehen";
 
-  static m94(coinName, address) => "Meine ${coinName} Adresse:\n${address}";
+  static m97(coinName, address) => "Meine ${coinName} Adresse:\n${address}";
 
-  static m95(coin) => "Nach vergangenen ${coin}-Transaktionen suchen?";
+  static m98(coin) => "Nach vergangenen ${coin}-Transaktionen suchen?";
 
-  static m96(count, maxCount) =>
+  static m99(count, maxCount) =>
       "Es werden ${count} von ${maxCount} Bestellungen angezeigt.";
 
-  static m97(coin) =>
+  static m100(coin) =>
       "Bitte geben Sie die ${coin} Menge an, die Sie kaufen möchten";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "Maximum an aktivierbaren Coins ist ${maxCoins}. Bitte deaktivieren Sie welche.";
 
-  static m99(coin) => "${coin} ist nicht aktiviert!";
+  static m102(coin) => "${coin} ist nicht aktiviert!";
 
-  static m100(coin) =>
+  static m103(coin) =>
       "Bitte geben Sie die ${coin} Menge an, die Sie verkaufen möchten";
 
-  static m101(coin) => "${coin} kann nicht aktiviert werden";
+  static m104(coin) => "${coin} kann nicht aktiviert werden";
 
-  static m102(description) =>
+  static m105(description) =>
       "Wählen Sie bitte eine mp3- oder wav-Datei aus. Wir spielen es, wenn ${description}.";
 
-  static m103(description) => "Abgespielt, wenn ${description}";
+  static m106(description) => "Abgespielt, wenn ${description}";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "Wenn Sie Fragen haben oder glauben, dass Sie ein technisches Problem mit der ${appName} App gefunden haben, können Sie dies melden und Unterstützung von unserem Team erhalten.";
 
-  static m105(coin) =>
+  static m108(coin) =>
       "Bitte aktivieren Sie zuerst ${coin} und laden Sie Ihr Guthaben auf";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "Das ${coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "Das ${coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen. ${coin} ${amount} sind erforderlich.";
 
-  static m108(name) =>
+  static m111(name) =>
       "Welche ${name}-Transaktionen möchten Sie synchronisieren?";
 
-  static m109(left) => "Verbleibende Transaktionen: ${left}";
+  static m112(left) => "Verbleibende Transaktionen: ${left}";
 
-  static m110(amnt, hash) =>
+  static m113(amnt, hash) =>
       "${amnt} Geldmittel wurden erfolgreich freigeschaltet - TX: ${hash}";
 
-  static m111(version) => "Sie nutzen Version ${version}";
+  static m114(version) => "Sie nutzen Version ${version}";
 
-  static m112(version) => "Version ${version} verfügbar. Bitte updaten.";
+  static m115(version) => "Version ${version} verfügbar. Bitte updaten.";
 
-  static m113(appName) => "${appName} Update";
+  static m116(appName) => "${appName} Update";
 
-  static m114(coinAbbr) => "Wir konnten ${coinAbbr} nicht aktivieren";
+  static m117(coinAbbr) => "Wir konnten ${coinAbbr} nicht aktivieren";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "Wir konnten ${coinAbbr} nicht aktivieren.\nBitte starten Sie die App neu, um es erneut zu versuchen.";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} ist eine Multi-Coin-Wallet der nächsten Generation mit nativer DEX-Funktionalität der dritten Generation und mehr.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "Sie haben ${appName} zuvor den Zugriff auf die Kamera verweigert.\nBitte ändern Sie die Kamerazugriffsrechte manuell in den Telefoneinstellungen, um mit dem QR-Code-Scan fortzufahren.";
 
-  static m118(amount, coinName) => "${amount} ${coinName} ABHEBEN";
+  static m121(amount, coinName) => "${amount} ${coinName} ABHEBEN";
 
-  static m119(amount, coin) => "Sie erhalten ${amount} ${coin}";
+  static m122(amount, coin) => "Sie erhalten ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -344,6 +351,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled":
+            MessageLookupByLibrary.simpleMessage("Münzaktivierung abgebrochen"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("Coin aktivieren"),
         "addingCoinSuccess": m4,
@@ -491,6 +500,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Code:"),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Löschen"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("keine aktivierten Coins"),
@@ -498,9 +509,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Coin auswählen"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "Sie haben die maximale Anzahl an Assets ausgewählt"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("Demnächst..."),
         "commingsoon":
             MessageLookupByLibrary.simpleMessage("TX Details folgen in Kürze!"),
@@ -532,7 +543,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactDelete":
             MessageLookupByLibrary.simpleMessage("Kontakt löschen"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Löschen"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Verwerfen"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Bearbeiten"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Beenden"),
@@ -562,7 +573,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Individuelle Gebühr"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "Individuelle Gebühr nur nutzen, wenn Sie wissen was darunter zu verstehen ist!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW Sicherheit"),
         "date": MessageLookupByLibrary.simpleMessage("Datum"),
         "decryptingWallet":
@@ -578,8 +589,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteWallet": MessageLookupByLibrary.simpleMessage("Wallet löschen"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Wallet wird gelöscht..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "Handelsgebühr senden Transaktionsgebühr"),
@@ -605,7 +616,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "duration": MessageLookupByLibrary.simpleMessage("Dauer"),
         "editContact":
             MessageLookupByLibrary.simpleMessage("Kontakt bearbeiten"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "Verschlüsselungskennwort darf nicht leer sein"),
         "emptyImportPass": MessageLookupByLibrary.simpleMessage(
@@ -614,7 +625,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Kontakt-Name darf nicht leer sein"),
         "emptyWallet": MessageLookupByLibrary.simpleMessage(
             "Wallet-Name darf nicht leer sein"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "Bitte aktivieren Sie Benachrichtigungen, um Updates zum Aktivierungsfortschritt zu erhalten."),
@@ -651,7 +662,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ungültige Adresse"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Segwit-Adressen werden (noch) nicht unterstützt"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain": MessageLookupByLibrary.simpleMessage(
             "Fehler, bitte versuchen Sie es erneut"),
         "errorTryLater": MessageLookupByLibrary.simpleMessage(
@@ -662,32 +673,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Bitte Daten eintippen"),
         "estimateValue":
             MessageLookupByLibrary.simpleMessage("Geschätzter Gesamtwert"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -737,12 +748,13 @@ class MessageLookup extends MessageLookupByLibrary {
             "Die Elemente wurden erfolgreich exportiert:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Swaps"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Exportieren"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Gefälschter Guthaben:"),
         "faqTitle":
             MessageLookupByLibrary.simpleMessage("Häufig gestellte Fragen"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Fehler"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("FAUCET"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Erfolg"),
         "faucetTimedOut": MessageLookupByLibrary.simpleMessage(
@@ -750,7 +762,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("Neuigkeiten"),
         "feedNotFound":
             MessageLookupByLibrary.simpleMessage("Hier gibt es nichts"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("Mehr lesen..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("Feed"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("Newsfeed"),
@@ -764,7 +776,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Newsfeed aktualisiert"),
         "feedback":
             MessageLookupByLibrary.simpleMessage("Protokolldatei teilen"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("Alle"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Filter"),
         "filtersClearAll":
@@ -788,9 +800,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("Von"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "Wir synchronisieren zukünftige Transaktionen, die nach der Aktivierung in Verbindung mit Ihrem öffentlichen Schlüssel durchgeführt werden. Dies ist die schnellste Option und beansprucht am wenigsten Speicherplatz."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Gas-Limit"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("Gas-Preis"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "Der allgemeine PIN-Schutz ist nicht aktiv.\nDer Tarnungsmodus ist nicht verfügbar.\nBitte aktivieren Sie den PIN-Schutz."),
@@ -800,7 +812,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Die Transaktion wird ausgeführt. Bitte warten Sie"),
         "goToPorfolio":
             MessageLookupByLibrary.simpleMessage("Zum Portfolio gehen"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Hilfe"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("Hilfe und Support"),
         "hideBalance":
@@ -854,7 +866,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
             "Fehler beim Dekodieren der json-Datei"),
         "importTitle": MessageLookupByLibrary.simpleMessage("Importieren"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Verwenden Sie ein sicheres Kennwort und speichern Sie es nicht auf demselben Gerät"),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -863,7 +875,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Der Swap kann bis zu 60 Minuten dauern. Schließen Sie diese Anwendung NICHT!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "Aus Sicherheitsgründen müssen Sie ein Kennwort für die Verschlüsselung ihres Wallets angeben."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "Die Mindestmenge, die für diesen Auftrag erforderlich ist, beträgt"),
         "insufficientTitle":
@@ -872,12 +884,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Aktualisieren"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Internetverbindung wiederhergestellt"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap": MessageLookupByLibrary.simpleMessage(
             "Swap kann nicht durchgeführt werden"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Details"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japanisch"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Koreanisch"),
         "language": MessageLookupByLibrary.simpleMessage("Sprache"),
@@ -885,8 +897,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Letzte Transaktionen"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Rechtliches"),
         "less": MessageLookupByLibrary.simpleMessage("Weniger"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Wird geladen..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
             "Auftragsbuch wird geladen..."),
@@ -962,11 +974,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder":
             MessageLookupByLibrary.simpleMessage("Min Auftragsvolumen:"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Muss niedriger als die Verkaufsmenge sein"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -976,10 +988,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Warnung: Durch das Minimieren der App auf iOS wird der Aktivierungsprozess abgebrochen."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Mehr Info"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Mehr"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Menge"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Coin"),
@@ -988,7 +1000,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Abbrechen"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Bestätigen"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Erstellen"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Auftrag"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Aufträge"),
@@ -1004,8 +1016,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ungültige Menge"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Ungültige Verkaufsmenge"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Max Verkaufsmenge beträgt"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
@@ -1039,7 +1051,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Keine Elemente ausgewählt"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Keine übereinstimmenden Aufträge gefunden"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Klicken Sie hier, um einen Auftrag zu erstellen"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1057,7 +1069,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput": MessageLookupByLibrary.simpleMessage(
             "Der Wert muss numerisch sein"),
         "none": MessageLookupByLibrary.simpleMessage("Keiner"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Nicht genügend Guthaben für Gebühren - handeln Sie einen kleinere Menge"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1066,24 +1078,24 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Notiz hinzufügen"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("Notiz"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("Nichts gefunden"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Swap abgeschlossen"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Swap fehlgeschlagen"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Neuer swap gestartet"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Swap-Status geändert"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle": MessageLookupByLibrary.simpleMessage(
             "Swap ist abgelaufen(Zeitüberschreitung)"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Eingehende Transaktion"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Offizielle Pressemitteilung"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -1095,15 +1107,15 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Fehlermeldung öffnen"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Weniger"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Mehr"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Auftrag erstellt"),
         "orderCreatedInfo": MessageLookupByLibrary.simpleMessage(
             "Auftrag erfolgreich erstellt"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Adresse"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Abbrechen"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("für"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Identisch mit CEX"),
@@ -1116,7 +1128,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Durch einmaliges antippen öffnen Sie die Details, durch langes antippen wählen Sie einen Auftrag"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Ausgegeben"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Details"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched":
             MessageLookupByLibrary.simpleMessage("Auftrag gematched!"),
         "orderMatching":
@@ -1127,9 +1139,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("Aufträge"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Aktiv"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Verlauf"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Überschreiben"),
         "ownOrder": MessageLookupByLibrary.simpleMessage(
             "Dies ist Ihr eigener Auftrag!"),
@@ -1156,9 +1168,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Abbrechen"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Zahlung angefordert"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder":
             MessageLookupByLibrary.simpleMessage("Auftrag platzieren"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Bitte akzeptieren Sie alle speziellen Münzaktivierungsanfragen oder heben Sie die Auswahl der Münzen auf."),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
             "Bitte fügen Sie einen Coin hinzu"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1185,19 +1200,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR-Code-Scanner"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Speichern Sie meine privaten Schlüssel?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Wie lange dauert ein Atomic Swap?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Muss ich für die Dauer des Swaps online sein?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Bieten Sie einen Support für die Nutzer an?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Gibt es länderspezifische Einschränkungen?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Es ist eine neue Ära! Wir haben unseren Namen offiziell von „AtomicDEX“ in „Komodo Wallet“ geändert."),
         "receive": MessageLookupByLibrary.simpleMessage("ERHALTEN"),
@@ -1239,7 +1254,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Lesen Sie mehr über KMD-Belohnungen für aktive Nutzer"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Empfangen"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Belohnungen,\nKMD"),
@@ -1250,9 +1265,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Informationen zu den Belohnungen:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO Menge,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage(
             "Informationen zu den Belohnungen"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Russisch"),
@@ -1305,7 +1320,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ticker suchen"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage(
             "Transaktionsverlauf anzeigen"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Seed-Phrase"),
@@ -1350,13 +1365,13 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Sprachen"),
         "settings": MessageLookupByLibrary.simpleMessage("Einstellungen"),
         "share": MessageLookupByLibrary.simpleMessage("Teilen"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("Adresse anzeigen"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Details anzeigen"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("MEINE AUFTRÄGE ANZEIGEN"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Mit Kennwort anmelden"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
@@ -1364,13 +1379,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Einfach"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Aktivieren"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Kaufen"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Schließen"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Erhalten"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle":
             MessageLookupByLibrary.simpleMessage("Verkaufen"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Senden"),
@@ -1378,11 +1393,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Weniger anzeigen"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Mehr anzeigen"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Überspringen"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Ablehnen"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Sound"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Sound-Einstellungen"),
@@ -1400,7 +1415,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Schritt"),
         "success": MessageLookupByLibrary.simpleMessage("Erfolgreich!"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("swap"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Aktuell"),
         "swapDetailTitle":
@@ -1408,9 +1423,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Schätzung"),
         "swapFailed":
             MessageLookupByLibrary.simpleMessage("Swap fehlgeschlagen"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Swap läuft"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Fortschrittdetails"),
@@ -1426,7 +1441,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Synchronisierung durch Setzlingsaktivierung"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
             "Synchronisieren Sie neue Transaktionen"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1487,26 +1502,26 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Zu viele Anfragen.\nDas Limit für Anfragen zur Transaktionshistorie wurde überschritten.\nBitte versuchen Sie es später noch einmal."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("UNBESTÄTIGT"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrainisch"),
         "unlock": MessageLookupByLibrary.simpleMessage("Freischalten"),
         "unlockFunds":
             MessageLookupByLibrary.simpleMessage("Geldmittel freischalten"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("Nicht verwendbar"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Neue Version verfügbar"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Nach Updates suchen..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Neue Version verfügbar. Bitte updaten."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Update verfügbar"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Vorerst überspringen"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage(
             "Bereits auf dem neuesten Stand"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Update"),
@@ -1532,9 +1547,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Achtung - in besonderen Fällen enthalten diese Protokolldaten sensible Informationen, die dazu verwendet werden können, Coins aus fehlgeschlagenen Swaps auszugeben!"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("AUF GEHT\'S!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("WILLKOMMEN"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("Wallet"),
@@ -1543,14 +1558,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Dies dauert eine Weile und die App muss im Vordergrund bleiben.\nDas Beenden der App während der Aktivierung kann zu Problemen führen."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Auszahlung"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Zugriff verweigert"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Auszahlung bestätigen"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Sie versuchen, einen QR-Code für eine Zahlung zu scannen"),
         "wrongCoinSpan2":
@@ -1571,7 +1586,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Sie haben einen Auftrag, dem neue Aufträge zugeordnet werden können"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Sie senden:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("Sie erhalten:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("Ihr Wallet")

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -158,157 +158,164 @@ class MessageLookup extends MessageLookupByLibrary {
   static m53(abbr) =>
       "${abbr} Guthaben reicht nicht aus, um die Handelsgebühr zu bezahlen";
 
-  static m54(coinAbbr) => "${coinAbbr} ist nicht verfügbar :(";
+  static m54(coin) => "Ungültige ${coin}-Adresse";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} ist nicht verfügbar :(";
+
+  static m56(coinName) =>
       "❗Vorsicht! Der Markt für ${coinName} hat ein 24-Stunden-Handelsvolumen von weniger als 10.000 US-Dollar!";
 
-  static m56(value) => "Das Limit muss bis zu ${value} betragen";
-
-  static m57(coinName, number) =>
-      "Die Mindestmenge für den Verkauf ist ${number} ${coinName}";
+  static m57(value) => "Das Limit muss bis zu ${value} betragen";
 
   static m58(coinName, number) =>
-      "Die Mindestmenge für den Kauf ist ${number} ${coinName}";
-
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "Die Mindestmenge des Auftrags ist ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
-
-  static m60(coinName, number) =>
       "Die Mindestmenge für den Verkauf ist ${number} ${coinName}";
 
-  static m61(minValue, coin) => "Muss größer sein als ${minValue} ${coin}";
+  static m59(coinName, number) =>
+      "Die Mindestmenge für den Kauf ist ${number} ${coinName}";
 
-  static m62(appName) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "Die Mindestmenge des Auftrags ist ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+
+  static m61(coinName, number) =>
+      "Die Mindestmenge für den Verkauf ist ${number} ${coinName}";
+
+  static m62(minValue, coin) => "Muss größer sein als ${minValue} ${coin}";
+
+  static m63(appName) =>
       "Bitte beachten Sie, dass Sie jetzt Mobilfunkdaten verwenden und die Teilnahme am P2P-Netzwerk von ${appName} Internetverkehr verbraucht. Es ist besser, ein WiFi-Netzwerk zu verwenden, wenn Ihr mobiler Datentarif kostspielig ist.";
 
-  static m63(coin) =>
+  static m64(coin) =>
       "Aktivieren Sie ${coin} und laden Sie zuerst Ihr Guthaben auf";
 
-  static m64(number) => "${number} Auftrag/Aufträge erstellen:";
+  static m65(number) => "${number} Auftrag/Aufträge erstellen:";
 
-  static m65(coin) => "${coin} Guthaben ist zu niedrig";
+  static m66(coin) => "${coin} Guthaben ist zu niedrig";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "Nicht genug ${coin} vorhanden, um die Gebühren zu zahlen. MIN Guthaben beträgt ${fee} ${coin}";
 
-  static m67(coinName) => "Bitte geben Sie die ${coinName} Menge ein.";
+  static m68(coinName) => "Bitte geben Sie die ${coinName} Menge ein.";
 
-  static m68(coin) => "Nicht genug ${coin} für die Transaktion!";
+  static m69(coin) => "Nicht genug ${coin} für die Transaktion!";
 
-  static m69(sell, buy) =>
+  static m70(sell, buy) =>
       "${sell}/${buy} swap wurde erfolgreich abgeschlossen";
 
-  static m70(sell, buy) => "${sell}/${buy} swap fehlgeschlagen";
+  static m71(sell, buy) => "${sell}/${buy} swap fehlgeschlagen";
 
-  static m71(sell, buy) => "${sell}/${buy} swap gestartet";
+  static m72(sell, buy) => "${sell}/${buy} swap gestartet";
 
-  static m72(sell, buy) =>
+  static m73(sell, buy) =>
       "${sell}/${buy} swap ist abgelaufen(Zeitüberschreitung)";
 
-  static m73(coin) => "Du hast eine ${coin} Transaktion erhalten!";
+  static m74(coin) => "Du hast eine ${coin} Transaktion erhalten!";
 
-  static m74(assets) => "${assets} Assets";
+  static m75(assets) => "${assets} Assets";
 
-  static m75(coin) => "Alle ${coin} Aufträge werden storniert.";
+  static m76(coin) => "Alle ${coin} Aufträge werden storniert.";
 
-  static m76(delta) => "Sinnvoll: CEX +${delta}%";
+  static m77(delta) => "Sinnvoll: CEX +${delta}%";
 
-  static m77(delta) => "Teuer: CEX ${delta}%";
+  static m78(delta) => "Teuer: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% ausgefüllt";
+  static m79(fill) => "${fill}% ausgefüllt";
 
-  static m79(coin) => "(${coin}) Menge";
+  static m80(coin) => "(${coin}) Menge";
 
-  static m80(coin) => "(${coin}) Preis";
+  static m81(coin) => "(${coin}) Preis";
 
-  static m81(coin) => "(${coin}) Gesamt";
+  static m82(coin) => "(${coin}) Gesamt";
 
-  static m82(abbr) =>
+  static m83(abbr) =>
       "${abbr} ist nicht aktiviert. Bitte aktivieren und erneut versuchen.";
 
-  static m83(appName) => "Auf welchen Geräten kann ich ${appName} verwenden?";
+  static m84(appName) => "Auf welchen Geräten kann ich ${appName} verwenden?";
 
-  static m84(appName) =>
+  static m85(appName) =>
       "Wie unterscheidet sich der Handel auf ${appName} vom Handel auf anderen DEXs?";
 
-  static m85(appName) => "Wie werden die Gebühren für ${appName} berechnet?";
+  static m86(appName) => "Wie werden die Gebühren für ${appName} berechnet?";
 
-  static m86(appName) => "Wer steckt hinter ${appName}?";
+  static m87(appName) => "Wer steckt hinter ${appName}?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "Ist es möglich, meine eigene White-Label-Börse auf ${appName} zu entwickeln?";
 
-  static m88(amount) => "Erfolgreich! ${amount} KMD erhalten";
+  static m89(amount) => "Erfolgreich! ${amount} KMD erhalten";
 
-  static m89(dd) => "${dd} Tag(e)";
+  static m90(dd) => "${dd} Tag(e)";
 
-  static m90(hh, minutes) => "${hh}h ${minutes}m";
+  static m91(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m91(mm) => "${mm}min";
+  static m92(mm) => "${mm}min";
 
-  static m92(amount) => "Klicken Sie hier, um ${amount} Aufträge zu sehen";
+  static m93(amount) => "Klicken Sie hier, um ${amount} Aufträge zu sehen";
 
-  static m93(coinName, address) => "Meine ${coinName} Adresse:\n${address}";
+  static m94(coinName, address) => "Meine ${coinName} Adresse:\n${address}";
 
-  static m94(count, maxCount) =>
+  static m95(coin) => "Nach vergangenen ${coin}-Transaktionen suchen?";
+
+  static m96(count, maxCount) =>
       "Es werden ${count} von ${maxCount} Bestellungen angezeigt.";
 
-  static m95(coin) =>
+  static m97(coin) =>
       "Bitte geben Sie die ${coin} Menge an, die Sie kaufen möchten";
 
-  static m96(maxCoins) =>
+  static m98(maxCoins) =>
       "Maximum an aktivierbaren Coins ist ${maxCoins}. Bitte deaktivieren Sie welche.";
 
-  static m97(coin) => "${coin} ist nicht aktiviert!";
+  static m99(coin) => "${coin} ist nicht aktiviert!";
 
-  static m98(coin) =>
+  static m100(coin) =>
       "Bitte geben Sie die ${coin} Menge an, die Sie verkaufen möchten";
 
-  static m99(coin) => "${coin} kann nicht aktiviert werden";
+  static m101(coin) => "${coin} kann nicht aktiviert werden";
 
-  static m100(description) =>
+  static m102(description) =>
       "Wählen Sie bitte eine mp3- oder wav-Datei aus. Wir spielen es, wenn ${description}.";
 
-  static m101(description) => "Abgespielt, wenn ${description}";
+  static m103(description) => "Abgespielt, wenn ${description}";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "Wenn Sie Fragen haben oder glauben, dass Sie ein technisches Problem mit der ${appName} App gefunden haben, können Sie dies melden und Unterstützung von unserem Team erhalten.";
 
-  static m103(coin) =>
+  static m105(coin) =>
       "Bitte aktivieren Sie zuerst ${coin} und laden Sie Ihr Guthaben auf";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "Das ${coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "Das ${coin} Guthaben reicht nicht aus, um die Transaktionsgebühren zu bezahlen. ${coin} ${amount} sind erforderlich.";
 
-  static m106(left) => "Verbleibende Transaktionen: ${left}";
+  static m108(name) =>
+      "Welche ${name}-Transaktionen möchten Sie synchronisieren?";
 
-  static m107(amnt, hash) =>
+  static m109(left) => "Verbleibende Transaktionen: ${left}";
+
+  static m110(amnt, hash) =>
       "${amnt} Geldmittel wurden erfolgreich freigeschaltet - TX: ${hash}";
 
-  static m108(version) => "Sie nutzen Version ${version}";
+  static m111(version) => "Sie nutzen Version ${version}";
 
-  static m109(version) => "Version ${version} verfügbar. Bitte updaten.";
+  static m112(version) => "Version ${version} verfügbar. Bitte updaten.";
 
-  static m110(appName) => "${appName} Update";
+  static m113(appName) => "${appName} Update";
 
-  static m111(coinAbbr) => "Wir konnten ${coinAbbr} nicht aktivieren";
+  static m114(coinAbbr) => "Wir konnten ${coinAbbr} nicht aktivieren";
 
-  static m112(coinAbbr) =>
+  static m115(coinAbbr) =>
       "Wir konnten ${coinAbbr} nicht aktivieren.\nBitte starten Sie die App neu, um es erneut zu versuchen.";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "${appName} ist eine Multi-Coin-Wallet der nächsten Generation mit nativer DEX-Funktionalität der dritten Generation und mehr.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "Sie haben ${appName} zuvor den Zugriff auf die Kamera verweigert.\nBitte ändern Sie die Kamerazugriffsrechte manuell in den Telefoneinstellungen, um mit dem QR-Code-Scan fortzufahren.";
 
-  static m115(amount, coinName) => "${amount} ${coinName} ABHEBEN";
+  static m118(amount, coinName) => "${amount} ${coinName} ABHEBEN";
 
-  static m116(amount, coin) => "Sie erhalten ${amount} ${coin}";
+  static m119(amount, coin) => "Sie erhalten ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -355,6 +362,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("Empfängeradresse"),
         "advanced": MessageLookupByLibrary.simpleMessage("Fortgeschritten"),
         "all": MessageLookupByLibrary.simpleMessage("Alle"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "In Ihrem Wallet werden alle vergangenen Transaktionen angezeigt. Dies wird viel Speicherplatz und Zeit in Anspruch nehmen, da alle Blöcke heruntergeladen und gescannt werden."),
         "allowCustomSeed": MessageLookupByLibrary.simpleMessage(
             "Benutzerdefinierten Seed erlauben"),
         "alreadyExists":
@@ -428,6 +437,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup":
             MessageLookupByLibrary.simpleMessage("Tarnungs-PIN Einrichtung"),
         "cancel": MessageLookupByLibrary.simpleMessage("stornieren"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Aktivierung abbrechen"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("stornieren"),
         "cancelOrder":
             MessageLookupByLibrary.simpleMessage("Auftrag stornieren"),
@@ -476,6 +489,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closePreview":
             MessageLookupByLibrary.simpleMessage("Vorschau schließen"),
         "code": MessageLookupByLibrary.simpleMessage("Code:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Sind Sie sicher, dass Sie die Aktivierung abbrechen möchten?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Löschen"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("keine aktivierten Coins"),
@@ -771,6 +786,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("QR-Code gefunden"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("Französisch"),
         "from": MessageLookupByLibrary.simpleMessage("Von"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "Wir synchronisieren zukünftige Transaktionen, die nach der Aktivierung in Verbindung mit Ihrem öffentlichen Schlüssel durchgeführt werden. Dies ist die schnellste Option und beansprucht am wenigsten Speicherplatz."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Gas-Limit"),
         "gasNotActive": m50,
@@ -855,11 +872,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Aktualisieren"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Internetverbindung wiederhergestellt"),
+        "invalidCoinAddress": m54,
         "invalidSwap": MessageLookupByLibrary.simpleMessage(
             "Swap kann nicht durchgeführt werden"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Details"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japanisch"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Koreanisch"),
         "language": MessageLookupByLibrary.simpleMessage("Sprache"),
@@ -867,8 +885,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Letzte Transaktionen"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Rechtliches"),
         "less": MessageLookupByLibrary.simpleMessage("Weniger"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Wird geladen..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
             "Auftragsbuch wird geladen..."),
@@ -944,11 +962,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder":
             MessageLookupByLibrary.simpleMessage("Min Auftragsvolumen:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Muss niedriger als die Verkaufsmenge sein"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -958,10 +976,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Warnung: Durch das Minimieren der App auf iOS wird der Aktivierungsprozess abgebrochen."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Mehr Info"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Mehr"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Menge"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Coin"),
@@ -970,7 +988,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Abbrechen"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Bestätigen"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Erstellen"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Auftrag"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Aufträge"),
@@ -986,8 +1004,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ungültige Menge"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Ungültige Verkaufsmenge"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Max Verkaufsmenge beträgt"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
@@ -1021,7 +1039,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Keine Elemente ausgewählt"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Keine übereinstimmenden Aufträge gefunden"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Klicken Sie hier, um einen Auftrag zu erstellen"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1039,7 +1057,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput": MessageLookupByLibrary.simpleMessage(
             "Der Wert muss numerisch sein"),
         "none": MessageLookupByLibrary.simpleMessage("Keiner"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Nicht genügend Guthaben für Gebühren - handeln Sie einen kleinere Menge"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1048,24 +1066,24 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Notiz hinzufügen"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("Notiz"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("Nichts gefunden"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Swap abgeschlossen"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Swap fehlgeschlagen"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Neuer swap gestartet"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Swap-Status geändert"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle": MessageLookupByLibrary.simpleMessage(
             "Swap ist abgelaufen(Zeitüberschreitung)"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Eingehende Transaktion"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Offizielle Pressemitteilung"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -1077,15 +1095,15 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Fehlermeldung öffnen"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Weniger"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Mehr"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Auftrag erstellt"),
         "orderCreatedInfo": MessageLookupByLibrary.simpleMessage(
             "Auftrag erfolgreich erstellt"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Adresse"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Abbrechen"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("für"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Identisch mit CEX"),
@@ -1098,7 +1116,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Durch einmaliges antippen öffnen Sie die Details, durch langes antippen wählen Sie einen Auftrag"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Ausgegeben"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Details"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched":
             MessageLookupByLibrary.simpleMessage("Auftrag gematched!"),
         "orderMatching":
@@ -1109,9 +1127,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("Aufträge"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Aktiv"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Verlauf"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Überschreiben"),
         "ownOrder": MessageLookupByLibrary.simpleMessage(
             "Dies ist Ihr eigener Auftrag!"),
@@ -1122,6 +1140,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Bezahlt mit"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "Das Kennwort muss mindestens 12 Zeichen enthalten, davon ein Kleinbuchstabe, ein Großbuchstabe und ein Sonderzeichen."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "In Ihrem Wallet werden Ihre vergangenen Transaktionen angezeigt, die nach dem angegebenen Datum getätigt wurden."),
         "paymentUriDetailsAccept":
             MessageLookupByLibrary.simpleMessage("Bezahlen"),
         "paymentUriDetailsAcceptQuestion": MessageLookupByLibrary.simpleMessage(
@@ -1136,7 +1156,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Abbrechen"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Zahlung angefordert"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder":
             MessageLookupByLibrary.simpleMessage("Auftrag platzieren"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
@@ -1165,19 +1185,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR-Code-Scanner"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Speichern Sie meine privaten Schlüssel?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Wie lange dauert ein Atomic Swap?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Muss ich für die Dauer des Swaps online sein?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Bieten Sie einen Support für die Nutzer an?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Gibt es länderspezifische Einschränkungen?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Es ist eine neue Ära! Wir haben unseren Namen offiziell von „AtomicDEX“ in „Komodo Wallet“ geändert."),
         "receive": MessageLookupByLibrary.simpleMessage("ERHALTEN"),
@@ -1219,7 +1239,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Lesen Sie mehr über KMD-Belohnungen für aktive Nutzer"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Empfangen"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Belohnungen,\nKMD"),
@@ -1230,9 +1250,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Informationen zu den Belohnungen:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO Menge,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage(
             "Informationen zu den Belohnungen"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Russisch"),
@@ -1285,7 +1305,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ticker suchen"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage(
             "Transaktionsverlauf anzeigen"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Seed-Phrase"),
@@ -1300,6 +1320,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Wählen Sie den zu kaufenden Coin aus"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "Wählen Sie den zu verkaufenden Coin"),
+        "selectDate":
+            MessageLookupByLibrary.simpleMessage("Wählen Sie ein Datum aus"),
         "selectFileImport":
             MessageLookupByLibrary.simpleMessage("Datei auswählen"),
         "selectLanguage":
@@ -1328,12 +1350,13 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Sprachen"),
         "settings": MessageLookupByLibrary.simpleMessage("Einstellungen"),
         "share": MessageLookupByLibrary.simpleMessage("Teilen"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("Adresse anzeigen"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Details anzeigen"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("MEINE AUFTRÄGE ANZEIGEN"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Mit Kennwort anmelden"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
@@ -1341,13 +1364,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Einfach"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Aktivieren"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Kaufen"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Schließen"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Erhalten"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle":
             MessageLookupByLibrary.simpleMessage("Verkaufen"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Senden"),
@@ -1355,11 +1378,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Weniger anzeigen"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Mehr anzeigen"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Überspringen"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Ablehnen"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Sound"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Sound-Einstellungen"),
@@ -1371,12 +1394,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Beachten Sie, dass Sie Ihre eigenen Sounds in den Anwendungseinstellungen festlegen können."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("Spanisch"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Startdatum"),
         "startSwap":
             MessageLookupByLibrary.simpleMessage("Starten Sie den Tausch"),
         "step": MessageLookupByLibrary.simpleMessage("Schritt"),
         "success": MessageLookupByLibrary.simpleMessage("Erfolgreich!"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("swap"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Aktuell"),
         "swapDetailTitle":
@@ -1384,9 +1408,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Schätzung"),
         "swapFailed":
             MessageLookupByLibrary.simpleMessage("Swap fehlgeschlagen"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Swap läuft"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Fortschrittdetails"),
@@ -1396,6 +1420,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Gesamt"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("Swap UUID"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Thema ändern"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Ab dem angegebenen Datum synchronisieren"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Synchronisierung durch Setzlingsaktivierung"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Synchronisieren Sie neue Transaktionen"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1456,26 +1487,26 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Zu viele Anfragen.\nDas Limit für Anfragen zur Transaktionshistorie wurde überschritten.\nBitte versuchen Sie es später noch einmal."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("UNBESTÄTIGT"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrainisch"),
         "unlock": MessageLookupByLibrary.simpleMessage("Freischalten"),
         "unlockFunds":
             MessageLookupByLibrary.simpleMessage("Geldmittel freischalten"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("Nicht verwendbar"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Neue Version verfügbar"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Nach Updates suchen..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Neue Version verfügbar. Bitte updaten."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Update verfügbar"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Vorerst überspringen"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage(
             "Bereits auf dem neuesten Stand"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Update"),
@@ -1501,9 +1532,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Achtung - in besonderen Fällen enthalten diese Protokolldaten sensible Informationen, die dazu verwendet werden können, Coins aus fehlgeschlagenen Swaps auszugeben!"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("AUF GEHT\'S!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("WILLKOMMEN"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("Wallet"),
@@ -1512,14 +1543,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Dies dauert eine Weile und die App muss im Vordergrund bleiben.\nDas Beenden der App während der Aktivierung kann zu Problemen führen."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Auszahlung"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Zugriff verweigert"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Auszahlung bestätigen"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Sie versuchen, einen QR-Code für eine Zahlung zu scannen"),
         "wrongCoinSpan2":
@@ -1540,7 +1571,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Sie haben einen Auftrag, dem neue Aufträge zugeordnet werden können"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Sie senden:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("Sie erhalten:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("Ihr Wallet")

--- a/lib/l10n/messages_es.dart
+++ b/lib/l10n/messages_es.dart
@@ -31,43 +31,31 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m5(title) => "Solo mostrar contactos con direcciones ${title}";
 
-  static m6(abbr) =>
-      "No puede enviar fondos a la dirección ${abbr} porque ${abbr} no está activado. Por favor, vaya a la cartera.";
+  static m6(abbr) => "No puede enviar fondos a la dirección ${abbr} porque ${abbr} no está activado. Por favor, vaya a la cartera.";
 
-  static m7(appName) =>
-      "¡No! ${appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.";
+  static m7(appName) => "¡No! ${appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.";
 
-  static m8(appName) =>
-      "${appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.";
+  static m8(appName) => "${appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.";
 
-  static m9(appName) =>
-      "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n${appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.";
+  static m9(appName) => "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n${appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.";
 
-  static m10(appName) =>
-      "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a ${appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.";
+  static m10(appName) => "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a ${appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.";
 
-  static m11(appName) =>
-      "Hay dos categorías de tarifas a tener en cuenta al intercambiar en ${appName}.\n\n1. ${appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.";
+  static m11(appName) => "Hay dos categorías de tarifas a tener en cuenta al intercambiar en ${appName}.\n\n1. ${appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.";
 
-  static m12(name, link, appName, appCompanyShort) =>
-      "¡Sí! ${appName} ofrece soporte a través de <a href=\"${link}\">${appCompanyShort} ${name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!";
+  static m12(name, link, appName, appCompanyShort) => "¡Sí! ${appName} ofrece soporte a través de <a href=\"${link}\">${appCompanyShort} ${name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!";
 
-  static m13(appName) =>
-      "¡No! ${appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.";
+  static m13(appName) => "¡No! ${appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.";
 
-  static m14(appName, appCompanyShort) =>
-      "${appName} está desarrollado por el equipo de ${appCompanyShort}. ${appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.";
+  static m14(appName, appCompanyShort) => "${appName} está desarrollado por el equipo de ${appCompanyShort}. ${appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.";
 
-  static m15(appName) =>
-      "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de ${appName} siempre está lista para ayudar!";
+  static m15(appName) => "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de ${appName} siempre está lista para ayudar!";
 
   static m16(coinName1, coinName2) => "basado en ${coinName1}/${coinName2}";
 
-  static m17(batteryLevelCritical) =>
-      "La carga de su batería es crítica (${batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.";
+  static m17(batteryLevelCritical) => "La carga de su batería es crítica (${batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.";
 
-  static m18(batteryLevelLow) =>
-      "La carga de la batería es inferior al ${batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.";
+  static m18(batteryLevelLow) => "La carga de la batería es inferior al ${batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.";
 
   static m19(seconde) => "Ordermatch en curso, ¡espere ${seconde} segundos!";
 
@@ -83,8 +71,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m25(name) => "¿Está seguro de que desea eliminar el contacto ${name}?";
 
-  static m26(iUnderstand) =>
-      "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"${iUnderstand}\" en el cuadro a continuación.";
+  static m26(iUnderstand) => "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"${iUnderstand}\" en el cuadro a continuación.";
 
   static m27(coinName) => "recibir tarifa de transacción de ${coinName}";
 
@@ -94,47 +81,33 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m31(gas) => "No hay suficiente gas: usa al menos ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
-      "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
+  static m32(appName, appCompanyLong) => "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
-      "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
+  static m33(appCompanyLong) => "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
-      "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
+  static m34(appCompanyShort, appCompanyLong) => "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
-      "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
+  static m35(appCompanyLong) => "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
-      "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
+  static m36(appCompanyLong) => "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
-      "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
+  static m37(appCompanyLong) => "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
-      "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
+  static m38(appCompanyShort, appCompanyLong) => "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
-      "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
+  static m39(appCompanyLong) => "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
-      "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
+  static m40(appCompanyLong) => "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
-      "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
+  static m41(appName, appCompanyLong) => "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
-      "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
+  static m42(appName, appCompanyLong) => "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
-      "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
+  static m43(appName) => "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
-      "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
+  static m44(appName, appCompanyLong) => "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
-      "End-User License Agreement (EULA) of ${appName} mobile:";
+  static m45(appName) => "End-User License Agreement (EULA) of ${appName} mobile:";
 
   static m46(coin) => "Enviando solicitud a la llave ${coin}...";
 
@@ -146,1380 +119,961 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m50(coin) => "Activa ${coin}.";
 
-  static m52(coinName) =>
-      "Configuración de protección de txs entrantes de ${coinName}";
+  static m52(coinName) => "Configuración de protección de txs entrantes de ${coinName}";
 
-  static m53(abbr) =>
-      " El saldo de ${abbr} no es suficiente para pagar la tarifa de negociación";
+  static m53(abbr) => " El saldo de ${abbr} no es suficiente para pagar la tarifa de negociación";
 
-  static m54(coinAbbr) => "${coinAbbr} no está disponible :(";
+  static m55(coinAbbr) => "${coinAbbr} no está disponible :(";
 
-  static m55(coinName) =>
-      "❗¡Precaución! ¡El mercado de ${coinName} tiene un volumen de negociación de menos de \$ 10k las 24 horas!";
+  static m56(coinName) => "❗¡Precaución! ¡El mercado de ${coinName} tiene un volumen de negociación de menos de \$ 10k las 24 horas!";
 
-  static m57(coinName, number) =>
-      "La cantidad mínima para vender es ${number} ${coinName}";
+  static m58(coinName, number) => "La cantidad mínima para vender es ${number} ${coinName}";
 
-  static m58(coinName, number) =>
-      "La cantidad mínima para comprar es ${number}${coinName}";
+  static m59(coinName, number) => "La cantidad mínima para comprar es ${number}${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "El monto mínimo del pedido es ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) => "El monto mínimo del pedido es ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
 
-  static m60(coinName, number) =>
-      "La cantidad mínima para vender es ${number}${coinName}";
+  static m61(coinName, number) => "La cantidad mínima para vender es ${number}${coinName}";
 
-  static m61(minValue, coin) => "Debe ser mayor que ${minValue} ${coin}";
+  static m62(minValue, coin) => "Debe ser mayor que ${minValue} ${coin}";
 
-  static m62(appName) =>
-      "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de ${appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.";
+  static m63(appName) => "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de ${appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.";
 
-  static m63(coin) => "Active ${coin} y añada saldo primero";
+  static m64(coin) => "Active ${coin} y añada saldo primero";
 
-  static m64(number) => "Crear ${number} pedido(s):";
+  static m65(number) => "Crear ${number} pedido(s):";
 
-  static m65(coin) => " El saldo de${coin} es demasiado bajo";
+  static m66(coin) => " El saldo de${coin} es demasiado bajo";
 
-  static m66(coin, fee) =>
-      "No hay suficientes ${coin} para pagar las tarifas. El saldo MÍN es ${fee} ${coin}";
+  static m67(coin, fee) => "No hay suficientes ${coin} para pagar las tarifas. El saldo MÍN es ${fee} ${coin}";
 
-  static m67(coinName) => "Ingrese la cantidad de ${coinName}.";
+  static m68(coinName) => "Ingrese la cantidad de ${coinName}.";
 
-  static m68(coin) => "¡No hay suficiente ${coin} para la transacción!";
+  static m69(coin) => "¡No hay suficiente ${coin} para la transacción!";
 
-  static m69(sell, buy) =>
-      " El intercambio de${sell}/${buy} se completó con éxito";
+  static m70(sell, buy) => " El intercambio de${sell}/${buy} se completó con éxito";
 
-  static m70(sell, buy) => "${sell}/${buy} intercambio fallido";
+  static m71(sell, buy) => "${sell}/${buy} intercambio fallido";
 
-  static m71(sell, buy) => "${sell}/${buy} intercambio iniciado";
+  static m72(sell, buy) => "${sell}/${buy} intercambio iniciado";
 
-  static m72(sell, buy) => "${sell}/${buy} intercambio se agotó";
+  static m73(sell, buy) => "${sell}/${buy} intercambio se agotó";
 
-  static m73(coin) => "¡Ha recibido una transacción de ${coin}!";
+  static m74(coin) => "¡Ha recibido una transacción de ${coin}!";
 
-  static m74(assets) => "${assets} activos";
+  static m75(assets) => "${assets} activos";
 
-  static m75(coin) => "Todos los pedidos de ${coin} serán cancelados.";
+  static m76(coin) => "Todos los pedidos de ${coin} serán cancelados.";
 
-  static m76(delta) => "Expediente: CEX +${delta}%";
+  static m77(delta) => "Expediente: CEX +${delta}%";
 
-  static m77(delta) => "Caro: CEX ${delta}%";
+  static m78(delta) => "Caro: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% llenado";
+  static m79(fill) => "${fill}% llenado";
 
-  static m79(coin) => "Cantidad (${coin})";
+  static m80(coin) => "Cantidad (${coin})";
 
-  static m80(coin) => "Precio (${coin})";
+  static m81(coin) => "Precio (${coin})";
 
-  static m81(coin) => "Total (${coin})";
+  static m82(coin) => "Total (${coin})";
 
-  static m82(abbr) => "${abbr} no está activo. Activa e inténtalo de nuevo..";
+  static m83(abbr) => "${abbr} no está activo. Activa e inténtalo de nuevo..";
 
-  static m83(appName) => "¿En qué dispositivos puedo usar ${appName}?";
+  static m84(appName) => "¿En qué dispositivos puedo usar ${appName}?";
 
-  static m84(appName) =>
-      "¿En qué se diferencia el comercio en ${appName} del comercio en otros DEX?";
+  static m85(appName) => "¿En qué se diferencia el comercio en ${appName} del comercio en otros DEX?";
 
-  static m85(appName) => "¿Cómo se calculan las tarifas de ${appName}?";
+  static m86(appName) => "¿Cómo se calculan las tarifas de ${appName}?";
 
-  static m86(appName) => "¿Quién está detrás de ${appName}?";
+  static m87(appName) => "¿Quién está detrás de ${appName}?";
 
-  static m87(appName) =>
-      "¿Es posible desarrollar mi propio intercambio con ${appName}?";
+  static m88(appName) => "¿Es posible desarrollar mi propio intercambio con ${appName}?";
 
-  static m88(amount) => "¡Éxito! ${amount} KMD recibido.";
+  static m89(amount) => "¡Éxito! ${amount} KMD recibido.";
 
-  static m89(dd) => "${dd} dias(s)";
+  static m90(dd) => "${dd} dias(s)";
 
-  static m90(hh, minutes) => "${hh}h ${minutes}m";
+  static m91(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m91(mm) => "${mm}min";
+  static m92(mm) => "${mm}min";
 
-  static m92(amount) => "Haga clic para ver ${amount} pedidos";
+  static m93(amount) => "Haga clic para ver ${amount} pedidos";
 
-  static m93(coinName, address) => "Mi ${coinName} dirección:\n${address}";
+  static m94(coinName, address) => "Mi ${coinName} dirección:\n${address}";
 
-  static m94(count, maxCount) => "Mostrando ${count} de ${maxCount} pedidos.";
+  static m96(count, maxCount) => "Mostrando ${count} de ${maxCount} pedidos.";
 
-  static m95(coin) => "Ingrese la cantidad de ${coin} para comprar";
+  static m97(coin) => "Ingrese la cantidad de ${coin} para comprar";
 
-  static m96(maxCoins) =>
-      "El número máximo de monedas activas es ${maxCoins}. Por favor, desactive algunos.";
+  static m98(maxCoins) => "El número máximo de monedas activas es ${maxCoins}. Por favor, desactive algunos.";
 
-  static m97(coin) => "${coin} no está activo!";
+  static m99(coin) => "${coin} no está activo!";
 
-  static m98(coin) => "Ingrese la cantidad de ${coin} para vender";
+  static m100(coin) => "Ingrese la cantidad de ${coin} para vender";
 
-  static m99(coin) => "No se puede activar ${coin}";
+  static m101(coin) => "No se puede activar ${coin}";
 
-  static m100(description) =>
-      "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando ${description}.";
+  static m102(description) => "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando ${description}.";
 
-  static m101(description) => "Jugado cuando ${description}";
+  static m103(description) => "Jugado cuando ${description}";
 
-  static m102(appName) =>
-      "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación ${appName}, puede informar y obtener asistencia de nuestro equipo.";
+  static m104(appName) => "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación ${appName}, puede informar y obtener asistencia de nuestro equipo.";
 
-  static m103(coin) => "Activa ${coin} y recarga el saldo primero";
+  static m105(coin) => "Activa ${coin} y recarga el saldo primero";
 
-  static m104(coin) =>
-      "El saldo de ${coin} no es suficiente para pagar las tarifas de transacción.";
+  static m106(coin) => "El saldo de ${coin} no es suficiente para pagar las tarifas de transacción.";
 
-  static m105(coin, amount) =>
-      " El saldo de${coin} no es suficiente para pagar las tarifas de transacción. ${coin} ${amount} obligatorio.";
+  static m107(coin, amount) => " El saldo de${coin} no es suficiente para pagar las tarifas de transacción. ${coin} ${amount} obligatorio.";
 
-  static m106(left) => "Transacciones restantes: ${left}";
+  static m109(left) => "Transacciones restantes: ${left}";
 
-  static m107(amnt, hash) =>
-      "Desbloqueó con éxito ${amnt} fondos - TX: ${hash}";
+  static m110(amnt, hash) => "Desbloqueó con éxito ${amnt} fondos - TX: ${hash}";
 
-  static m108(version) => "Estás usando la versión ${version}";
+  static m111(version) => "Estás usando la versión ${version}";
 
-  static m109(version) => "Versión ${version} disponible. Por favor actualice.";
+  static m112(version) => "Versión ${version} disponible. Por favor actualice.";
 
-  static m110(appName) => "${appName} actualizar";
+  static m113(appName) => "${appName} actualizar";
 
-  static m111(coinAbbr) => "No pudimos activar ${coinAbbr}";
+  static m114(coinAbbr) => "No pudimos activar ${coinAbbr}";
 
-  static m112(coinAbbr) =>
-      "No pudimos activar ${coinAbbr}.\nReinicie la aplicación para volver a intentarlo.";
+  static m115(coinAbbr) => "No pudimos activar ${coinAbbr}.\nReinicie la aplicación para volver a intentarlo.";
 
-  static m113(appName) =>
-      "${appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.";
+  static m116(appName) => "${appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.";
 
-  static m114(appName) =>
-      "Previamente le has negado a ${appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.";
+  static m117(appName) => "Previamente le has negado a ${appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.";
 
-  static m115(amount, coinName) => "RETIRAR ${amount} ${coinName}";
+  static m118(amount, coinName) => "RETIRAR ${amount} ${coinName}";
 
-  static m116(amount, coin) => "Recibirás ${amount} ${coin}";
+  static m119(amount, coin) => "Recibirás ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
-        "Active": MessageLookupByLibrary.simpleMessage("Activo"),
-        "Applause": MessageLookupByLibrary.simpleMessage("Aplausos"),
-        "Can\'t play that":
-            MessageLookupByLibrary.simpleMessage("no puedo escuchar eso"),
-        "Failed": MessageLookupByLibrary.simpleMessage("Fallido"),
-        "Maker": MessageLookupByLibrary.simpleMessage("Vendedor"),
-        "Optional": MessageLookupByLibrary.simpleMessage("Opcional"),
-        "Play at full volume":
-            MessageLookupByLibrary.simpleMessage("Juega a todo volumen"),
-        "Sound": MessageLookupByLibrary.simpleMessage("Sonido"),
-        "Taker": MessageLookupByLibrary.simpleMessage("Comprador"),
-        "a swap fails":
-            MessageLookupByLibrary.simpleMessage("un intercambio falla"),
-        "a swap runs to completion": MessageLookupByLibrary.simpleMessage(
-            "un intercambio se ejecuta hasta su finalización"),
-        "accepteula": MessageLookupByLibrary.simpleMessage("Aceptar EULA"),
-        "accepttac": MessageLookupByLibrary.simpleMessage(
-            "Aceptar TERMINOS y CONDICIONES"),
-        "activateAccessBiometric": MessageLookupByLibrary.simpleMessage(
-            "Activar protección biométrica"),
-        "activateAccessPin": MessageLookupByLibrary.simpleMessage(
-            "Activar la protección con PIN"),
-        "activateCoins": m0,
-        "activating": m1,
-        "activation": m2,
-        "activationInProgress": m3,
-        "addCoin": MessageLookupByLibrary.simpleMessage("Activar moneda"),
-        "addingCoinSuccess": m4,
-        "addressAdd": MessageLookupByLibrary.simpleMessage("Añadir Direccion"),
-        "addressBook": MessageLookupByLibrary.simpleMessage("Directorio"),
-        "addressBookEmpty": MessageLookupByLibrary.simpleMessage(
-            "La libreta de direcciones está vacía"),
-        "addressBookFilter": m5,
-        "addressBookTitle": MessageLookupByLibrary.simpleMessage("Directorio"),
-        "addressCoinInactive": m6,
-        "addressNotFound":
-            MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
-        "addressSelectCoin":
-            MessageLookupByLibrary.simpleMessage("Seleccionar Moneda"),
-        "addressSend": MessageLookupByLibrary.simpleMessage(
-            "Dirección de los destinatarios"),
-        "advanced": MessageLookupByLibrary.simpleMessage("Avanzado"),
-        "all": MessageLookupByLibrary.simpleMessage("TODOS"),
-        "allowCustomSeed": MessageLookupByLibrary.simpleMessage(
-            "Permitir semilla personalizada"),
-        "alreadyExists": MessageLookupByLibrary.simpleMessage("Ya existe"),
-        "amount": MessageLookupByLibrary.simpleMessage("Cantidad"),
-        "amountToSell":
-            MessageLookupByLibrary.simpleMessage("Cantidad a Vender"),
-        "answer_1": m7,
-        "answer_10": m8,
-        "answer_2": m9,
-        "answer_3": m10,
-        "answer_4": MessageLookupByLibrary.simpleMessage(
-            "Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico."),
-        "answer_5": m11,
-        "answer_6": m12,
-        "answer_7": m13,
-        "answer_8": m14,
-        "answer_9": m15,
-        "areYouSure": MessageLookupByLibrary.simpleMessage("ESTAS SEGURO?"),
-        "authenticate": MessageLookupByLibrary.simpleMessage("autenticar"),
-        "automaticRedirected": MessageLookupByLibrary.simpleMessage(
-            "Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación."),
-        "availableVolume":
-            MessageLookupByLibrary.simpleMessage("volumen máximo"),
-        "back": MessageLookupByLibrary.simpleMessage("back"),
-        "backupTitle": MessageLookupByLibrary.simpleMessage("Respaldo"),
-        "basedOnCoinRatio": m16,
-        "batteryCriticalError": m17,
-        "batteryLowWarning": m18,
-        "batterySavingWarning": MessageLookupByLibrary.simpleMessage(
-            "Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio."),
-        "bestAvailableRate":
-            MessageLookupByLibrary.simpleMessage("Tipo de cambio"),
-        "builtKomodo":
-            MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
-        "builtOnKmd":
-            MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
-        "buy": MessageLookupByLibrary.simpleMessage("Comprar"),
-        "buyOrderType": MessageLookupByLibrary.simpleMessage(
-            "Convertir a Vendedor si no coincide"),
-        "buySuccessWaiting": MessageLookupByLibrary.simpleMessage(
-            "Intercambio emitido, por favor espere!"),
-        "buySuccessWaitingError": m19,
-        "buyTestCoinWarning": MessageLookupByLibrary.simpleMessage(
-            "¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!"),
-        "camoPinBioProtectionConflict": MessageLookupByLibrary.simpleMessage(
-            "El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo."),
-        "camoPinBioProtectionConflictTitle":
-            MessageLookupByLibrary.simpleMessage(
-                "Conflicto entre PIN de camuflaje y bioprotección."),
-        "camoPinChange":
-            MessageLookupByLibrary.simpleMessage("Cambiar PIN de camuflaje"),
-        "camoPinCreate":
-            MessageLookupByLibrary.simpleMessage("Crear PIN de camuflaje"),
-        "camoPinDesc": MessageLookupByLibrary.simpleMessage(
-            "Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración"),
-        "camoPinInvalid":
-            MessageLookupByLibrary.simpleMessage("PIN de camuflaje no válido"),
-        "camoPinLink": MessageLookupByLibrary.simpleMessage("Camuflajear PIN"),
-        "camoPinNotFound": MessageLookupByLibrary.simpleMessage(
-            "PIN de camuflaje no encontrado"),
-        "camoPinOff": MessageLookupByLibrary.simpleMessage("Desactivado"),
-        "camoPinOn": MessageLookupByLibrary.simpleMessage("Activado"),
-        "camoPinSaved":
-            MessageLookupByLibrary.simpleMessage("PIN de camuflaje guardado"),
-        "camoPinTitle":
-            MessageLookupByLibrary.simpleMessage("Camuflajear el PIN"),
-        "camoSetupSubtitle": MessageLookupByLibrary.simpleMessage(
-            "Ingrese el nuevo PIN de camuflaje"),
-        "camoSetupTitle": MessageLookupByLibrary.simpleMessage(
-            "Configuración de PIN de camuflaje"),
-        "camouflageSetup": MessageLookupByLibrary.simpleMessage(
-            "Configuración de PIN de camuflaje"),
-        "cancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "cancelButton": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "cancelOrder": MessageLookupByLibrary.simpleMessage("Cancelar orden"),
-        "candleChartError": MessageLookupByLibrary.simpleMessage(
-            "Algo salió mal. Vuelve a intentarlo más tarde."),
-        "cantDeleteDefaultCoinOk": MessageLookupByLibrary.simpleMessage("Ok"),
-        "cantDeleteDefaultCoinSpan": MessageLookupByLibrary.simpleMessage(
-            "es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar."),
-        "cantDeleteDefaultCoinTitle":
-            MessageLookupByLibrary.simpleMessage("No se puede deshabilitar"),
-        "cex": MessageLookupByLibrary.simpleMessage("CEX"),
-        "cexChangeRate":
-            MessageLookupByLibrary.simpleMessage("Tasa de Cambio CEX"),
-        "cexData": MessageLookupByLibrary.simpleMessage("data de CEX"),
-        "cexDataDesc": MessageLookupByLibrary.simpleMessage(
-            "Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>)."),
-        "cexRate": MessageLookupByLibrary.simpleMessage("Tasa CEX"),
-        "changePin": MessageLookupByLibrary.simpleMessage("Cambiar código PIN"),
-        "checkForUpdates":
-            MessageLookupByLibrary.simpleMessage("Buscar actualizaciones"),
-        "checkOut": MessageLookupByLibrary.simpleMessage("Verificar"),
-        "checkSeedPhrase":
-            MessageLookupByLibrary.simpleMessage("Comprobar la frase inicial"),
-        "checkSeedPhraseButton1":
-            MessageLookupByLibrary.simpleMessage("SEGUIR"),
-        "checkSeedPhraseButton2":
-            MessageLookupByLibrary.simpleMessage("VOLVER Y VERIFICAR DE NUEVO"),
-        "checkSeedPhraseHint": m20,
-        "checkSeedPhraseInfo": MessageLookupByLibrary.simpleMessage(
-            "Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee."),
-        "checkSeedPhraseSubtile": m21,
-        "checkSeedPhraseTitle": MessageLookupByLibrary.simpleMessage(
-            "VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA"),
-        "chineseLanguage": MessageLookupByLibrary.simpleMessage("Chino"),
-        "claim": MessageLookupByLibrary.simpleMessage("afirmar"),
-        "claimTitle": MessageLookupByLibrary.simpleMessage(
-            "¿Reclamar su recompensa KMD?"),
-        "clickToSee": MessageLookupByLibrary.simpleMessage("Clic para ver"),
-        "clipboard":
-            MessageLookupByLibrary.simpleMessage("Copiado al portapapeles"),
-        "clipboardCopy":
-            MessageLookupByLibrary.simpleMessage("Copiar al portapapeles"),
-        "close": MessageLookupByLibrary.simpleMessage("Cerrar"),
-        "closeMessage":
-            MessageLookupByLibrary.simpleMessage("Cerrar mensaje de error"),
-        "closePreview": MessageLookupByLibrary.simpleMessage("Cerrar prevista"),
-        "code": MessageLookupByLibrary.simpleMessage("Código:"),
-        "coinSelectClear": MessageLookupByLibrary.simpleMessage("Remover"),
-        "coinSelectNotFound":
-            MessageLookupByLibrary.simpleMessage("No hay monedas activas"),
-        "coinSelectTitle":
-            MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
-        "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
-            "Ha seleccionado el número máximo de activos"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
-        "comingSoon": MessageLookupByLibrary.simpleMessage("Próximamente..."),
-        "commingsoon": MessageLookupByLibrary.simpleMessage(
-            "Detalles de TX próximamente!"),
-        "commingsoonGeneral":
-            MessageLookupByLibrary.simpleMessage("¡Detalles muy pronto!"),
-        "commissionFee":
-            MessageLookupByLibrary.simpleMessage("cuota de comisión"),
-        "comparedTo24hrCex": MessageLookupByLibrary.simpleMessage(
-            "en comparación con el promedio Precio CEX 24h"),
-        "comparedToCex":
-            MessageLookupByLibrary.simpleMessage("comparable a CEX"),
-        "configureWallet": MessageLookupByLibrary.simpleMessage(
-            "Configurando su billetera, por favor espere..."),
-        "confirm": MessageLookupByLibrary.simpleMessage("Confirmar"),
-        "confirmCamouflageSetup":
-            MessageLookupByLibrary.simpleMessage("Confirmar PIN de camuflaje"),
-        "confirmCancel": MessageLookupByLibrary.simpleMessage(
-            "¿Está seguro de que desea cancelar el pedido?"),
-        "confirmPassword":
-            MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
-        "confirmPin":
-            MessageLookupByLibrary.simpleMessage("Confirmar código PIN"),
-        "confirmSeed":
-            MessageLookupByLibrary.simpleMessage("Confirmar frase semilla"),
-        "confirmeula": MessageLookupByLibrary.simpleMessage(
-            "Al hacer clic en los botones a continuación, confirma haber leído el \'EULA\' y los \'Términos y condiciones\' y acepta estos"),
-        "connecting": MessageLookupByLibrary.simpleMessage("Conectando..."),
-        "contactCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "contactDelete":
-            MessageLookupByLibrary.simpleMessage("Borrar Contacto"),
-        "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Borrar"),
-        "contactDeleteWarning": m25,
-        "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Descartar"),
-        "contactEdit": MessageLookupByLibrary.simpleMessage("Editar"),
-        "contactExit": MessageLookupByLibrary.simpleMessage("Salir"),
-        "contactExitWarning":
-            MessageLookupByLibrary.simpleMessage("Descartar tus cambios?"),
-        "contactNotFound":
-            MessageLookupByLibrary.simpleMessage("No se encontraron contactos"),
-        "contactSave": MessageLookupByLibrary.simpleMessage("Guardar"),
-        "contactTitle":
-            MessageLookupByLibrary.simpleMessage("Detalles de contacto"),
-        "contactTitleName": MessageLookupByLibrary.simpleMessage("Nombre"),
-        "contract": MessageLookupByLibrary.simpleMessage("Contrato"),
-        "convert": MessageLookupByLibrary.simpleMessage("Convertir"),
-        "couldNotLaunchUrl":
-            MessageLookupByLibrary.simpleMessage("No se pudo iniciar la URL"),
-        "couldntImportError":
-            MessageLookupByLibrary.simpleMessage("No se pudo importar:"),
-        "create": MessageLookupByLibrary.simpleMessage("intercambiar"),
-        "createAWallet":
-            MessageLookupByLibrary.simpleMessage("CREAR UNA CARTERA"),
-        "createContact": MessageLookupByLibrary.simpleMessage("Crear Contacto"),
-        "createPin": MessageLookupByLibrary.simpleMessage("Crear numero PIN"),
-        "currency": MessageLookupByLibrary.simpleMessage("Moneda"),
-        "currencyDialogTitle": MessageLookupByLibrary.simpleMessage("Moneda"),
-        "currentValue": MessageLookupByLibrary.simpleMessage("Valor actual:"),
-        "customFee": MessageLookupByLibrary.simpleMessage(
-            "Costo de Transacción Personalizado"),
-        "customFeeWarning": MessageLookupByLibrary.simpleMessage(
-            "¡Solo use tarifas personalizadas si sabe lo que está haciendo!"),
-        "customSeedWarning": m26,
-        "dPow":
-            MessageLookupByLibrary.simpleMessage("Seguridad de Komodo dPoW"),
-        "date": MessageLookupByLibrary.simpleMessage("Fecha"),
-        "decryptingWallet":
-            MessageLookupByLibrary.simpleMessage("Billetera de descifrado"),
-        "delete": MessageLookupByLibrary.simpleMessage("Borrar"),
-        "deleteConfirm":
-            MessageLookupByLibrary.simpleMessage("Confirmar desactivación"),
-        "deleteSpan1":
-            MessageLookupByLibrary.simpleMessage("¿Quieres eliminar"),
-        "deleteSpan2": MessageLookupByLibrary.simpleMessage(
-            "de tu cartera? Todos los pedidos no emparejados serán cancelados."),
-        "deleteSpan3":
-            MessageLookupByLibrary.simpleMessage(" también se desactivará"),
-        "deleteWallet":
-            MessageLookupByLibrary.simpleMessage("Eliminar Billetera"),
-        "deletingWallet":
-            MessageLookupByLibrary.simpleMessage("Eliminando billetera..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
-        "detailedFeesSendTradingFeeTransactionFee":
-            MessageLookupByLibrary.simpleMessage(
-                "enviar tarifa comercial tarifa de transacción"),
-        "detailedFeesTradingFee":
-            MessageLookupByLibrary.simpleMessage("tarifa comercial"),
-        "details": MessageLookupByLibrary.simpleMessage("detalles"),
-        "deutscheLanguage": MessageLookupByLibrary.simpleMessage("Alemán"),
-        "developerTitle": MessageLookupByLibrary.simpleMessage("Desarrollador"),
-        "dex": MessageLookupByLibrary.simpleMessage("DEX"),
-        "dexIsNotAvailable": MessageLookupByLibrary.simpleMessage(
-            "DEX no está disponible para esta moneda"),
-        "disableScreenshots": MessageLookupByLibrary.simpleMessage(
-            "Desactivar capturas de pantalla/vista previa"),
-        "disclaimerAndTos": MessageLookupByLibrary.simpleMessage(
-            "Descargo de responsabilidad y condiciones de servicio"),
-        "doNotCloseTheAppTapForMoreInfo": MessageLookupByLibrary.simpleMessage(
-            "No cierres la aplicación. Toca para obtener más información..."),
-        "done": MessageLookupByLibrary.simpleMessage("Hecho"),
-        "dontAskAgain":
-            MessageLookupByLibrary.simpleMessage("No vuelvas a preguntar"),
-        "dontWantPassword":
-            MessageLookupByLibrary.simpleMessage("no quiero una contraseña"),
-        "duration": MessageLookupByLibrary.simpleMessage("Duración"),
-        "editContact": MessageLookupByLibrary.simpleMessage("Editar contacto"),
-        "emptyCoin": m29,
-        "emptyExportPass": MessageLookupByLibrary.simpleMessage(
-            "La contraseña de cifrado no puede estar vacía"),
-        "emptyImportPass": MessageLookupByLibrary.simpleMessage(
-            "La contraseña no puede estar vacía"),
-        "emptyName": MessageLookupByLibrary.simpleMessage(
-            "El nombre del contacto no puede estar vacío"),
-        "emptyWallet": MessageLookupByLibrary.simpleMessage(
-            "El nombre de la billetera no debe estar vacío"),
-        "enableNotificationsForActivationProgress":
-            MessageLookupByLibrary.simpleMessage(
-                "Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación."),
-        "enableTestCoins":
-            MessageLookupByLibrary.simpleMessage("Habilitar monedas de prueba"),
-        "enablingTooManyAssetsSpan1":
-            MessageLookupByLibrary.simpleMessage("Tu tienes"),
-        "enablingTooManyAssetsSpan2": MessageLookupByLibrary.simpleMessage(
-            "activos habilitados y tratando de habilitar"),
-        "enablingTooManyAssetsSpan3": MessageLookupByLibrary.simpleMessage(
-            "más. El límite máximo de activos habilitados es"),
-        "enablingTooManyAssetsSpan4": MessageLookupByLibrary.simpleMessage(
-            ". Desactive algunos antes de agregar otros nuevos."),
-        "enablingTooManyAssetsTitle": MessageLookupByLibrary.simpleMessage(
-            "Intentando habilitar demasiados activos"),
-        "encryptingWallet":
-            MessageLookupByLibrary.simpleMessage("Billetera cifrada"),
-        "englishLanguage": MessageLookupByLibrary.simpleMessage("Inglés"),
-        "enterNewPinCode":
-            MessageLookupByLibrary.simpleMessage("Ingrese su nuevo PIN"),
-        "enterOldPinCode":
-            MessageLookupByLibrary.simpleMessage("Ingrese su antiguo PIN"),
-        "enterPinCode":
-            MessageLookupByLibrary.simpleMessage("Ingresa tu numero PIN"),
-        "enterSeedPhrase": MessageLookupByLibrary.simpleMessage(
-            "Ingrese su Semilla de 12 palabras"),
-        "enterSellAmount": MessageLookupByLibrary.simpleMessage(
-            "Primero debe ingresar el monto de la venta"),
-        "enterpassword": MessageLookupByLibrary.simpleMessage(
-            "Por favor ingrese su contraseña para continuar."),
-        "errorAmountBalance": MessageLookupByLibrary.simpleMessage(
-            "No hay suficiente equilibrio"),
-        "errorNotAValidAddress":
-            MessageLookupByLibrary.simpleMessage("No es una dirección válida"),
-        "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
-            "Las direcciones de Segwit no son compatibles (todavía)"),
-        "errorNotEnoughGas": m31,
-        "errorTryAgain":
-            MessageLookupByLibrary.simpleMessage("Error, inténtalo de nuevo"),
-        "errorTryLater":
-            MessageLookupByLibrary.simpleMessage("Error, intente más tarde"),
-        "errorValueEmpty": MessageLookupByLibrary.simpleMessage(
-            "El valor es demasiado alto o bajo"),
-        "errorValueNotEmpty":
-            MessageLookupByLibrary.simpleMessage("Por favor ingrese datos"),
-        "estimateValue":
-            MessageLookupByLibrary.simpleMessage("Valor total estimado"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
-        "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
-            "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
-        "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
-            "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
-        "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
-            "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
-        "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
-            "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
-        "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
-            "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
-        "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
-            "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
-        "eulaTitle10":
-            MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
-        "eulaTitle11": MessageLookupByLibrary.simpleMessage(
-            "INTELLECTUAL PROPERTY RIGHTS"),
-        "eulaTitle12": MessageLookupByLibrary.simpleMessage("DISCLAIMER"),
-        "eulaTitle13": MessageLookupByLibrary.simpleMessage(
-            "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY"),
-        "eulaTitle14":
-            MessageLookupByLibrary.simpleMessage("GENERAL RISK FACTORS"),
-        "eulaTitle15": MessageLookupByLibrary.simpleMessage("INDEMNIFICATION"),
-        "eulaTitle16": MessageLookupByLibrary.simpleMessage(
-            "RISK DISCLOSURES RELATING TO THE WALLET"),
-        "eulaTitle17": MessageLookupByLibrary.simpleMessage(
-            "NO INVESTMENT ADVICE OR BROKERAGE"),
-        "eulaTitle18": MessageLookupByLibrary.simpleMessage("TERMINATION"),
-        "eulaTitle19":
-            MessageLookupByLibrary.simpleMessage("THIRD PARTY RIGHTS"),
-        "eulaTitle2": MessageLookupByLibrary.simpleMessage(
-            "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)"),
-        "eulaTitle20":
-            MessageLookupByLibrary.simpleMessage("OUR LEGAL OBLIGATIONS"),
-        "eulaTitle3": MessageLookupByLibrary.simpleMessage(
-            "TERMS AND CONDITIONS OF USE AND DISCLAIMER"),
-        "eulaTitle4": MessageLookupByLibrary.simpleMessage("GENERAL USE"),
-        "eulaTitle5": MessageLookupByLibrary.simpleMessage("MODIFICATIONS"),
-        "eulaTitle6":
-            MessageLookupByLibrary.simpleMessage("LIMITATIONS ON USE"),
-        "eulaTitle7":
-            MessageLookupByLibrary.simpleMessage("ACCOUNTS AND MEMBERSHIP"),
-        "eulaTitle8": MessageLookupByLibrary.simpleMessage("BACKUPS"),
-        "eulaTitle9": MessageLookupByLibrary.simpleMessage("GENERAL WARNING"),
-        "exampleHintSeed": MessageLookupByLibrary.simpleMessage(
-            "Ejemplo: build case level ..."),
-        "exchangeExpedient": MessageLookupByLibrary.simpleMessage("Expediente"),
-        "exchangeExpensive": MessageLookupByLibrary.simpleMessage("Caro"),
-        "exchangeIdentical":
-            MessageLookupByLibrary.simpleMessage("Identico a CEX"),
-        "exchangeRate": MessageLookupByLibrary.simpleMessage("Tipo de cambio:"),
-        "exchangeTitle": MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
-        "exportButton": MessageLookupByLibrary.simpleMessage("Exportar"),
-        "exportContactsTitle":
-            MessageLookupByLibrary.simpleMessage("Contactos"),
-        "exportDesc": MessageLookupByLibrary.simpleMessage(
-            "Seleccione elementos para exportar a un archivo cifrado."),
-        "exportLink": MessageLookupByLibrary.simpleMessage("Exportar"),
-        "exportNotesTitle": MessageLookupByLibrary.simpleMessage("Notas"),
-        "exportSuccessTitle": MessageLookupByLibrary.simpleMessage(
-            "Los elementos se han exportado correctamente:"),
-        "exportSwapsTitle":
-            MessageLookupByLibrary.simpleMessage("Intercambios"),
-        "exportTitle": MessageLookupByLibrary.simpleMessage("Exportar"),
-        "fakeBalanceAmt":
-            MessageLookupByLibrary.simpleMessage("Cantidad de saldo falso:"),
-        "faqTitle":
-            MessageLookupByLibrary.simpleMessage("Preguntas frecuentes"),
-        "faucetError": MessageLookupByLibrary.simpleMessage("Error"),
-        "faucetInProgress": m46,
-        "faucetName": MessageLookupByLibrary.simpleMessage("GRIFO"),
-        "faucetSuccess": MessageLookupByLibrary.simpleMessage("Éxito"),
-        "faucetTimedOut":
-            MessageLookupByLibrary.simpleMessage("Tiempo de espera agotado"),
-        "feedNewsTab": MessageLookupByLibrary.simpleMessage("Noticias"),
-        "feedNotFound": MessageLookupByLibrary.simpleMessage("Nada aquí"),
-        "feedNotifTitle": m47,
-        "feedReadMore": MessageLookupByLibrary.simpleMessage("Leer más..."),
-        "feedTab": MessageLookupByLibrary.simpleMessage("Informacion"),
-        "feedTitle": MessageLookupByLibrary.simpleMessage("Noticias"),
-        "feedUnableToProceed": MessageLookupByLibrary.simpleMessage(
-            "No se puede continuar con la actualización de noticias"),
-        "feedUnableToUpdate": MessageLookupByLibrary.simpleMessage(
-            "No se puede obtener la actualización de noticias"),
-        "feedUpToDate":
-            MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
-        "feedUpdated": MessageLookupByLibrary.simpleMessage(
-            "Fuente de noticias actualizada"),
-        "feedback": MessageLookupByLibrary.simpleMessage(
-            "Compartir archivo de registro"),
-        "feesError": m48,
-        "filtersAll": MessageLookupByLibrary.simpleMessage("Todo"),
-        "filtersButton": MessageLookupByLibrary.simpleMessage("Filtro"),
-        "filtersClearAll":
-            MessageLookupByLibrary.simpleMessage("Borrar todos los filtros"),
-        "filtersFailed": MessageLookupByLibrary.simpleMessage("Fallido"),
-        "filtersFrom":
-            MessageLookupByLibrary.simpleMessage("Partir de la fecha"),
-        "filtersMaker": MessageLookupByLibrary.simpleMessage("Vendedor"),
-        "filtersReceive":
-            MessageLookupByLibrary.simpleMessage("Recibir moneda"),
-        "filtersSell": MessageLookupByLibrary.simpleMessage("Vender moneda"),
-        "filtersStatus": MessageLookupByLibrary.simpleMessage("Estado"),
-        "filtersSuccessful": MessageLookupByLibrary.simpleMessage("Exitoso"),
-        "filtersTaker": MessageLookupByLibrary.simpleMessage("Comprador"),
-        "filtersTo": MessageLookupByLibrary.simpleMessage("Hasta la fecha"),
-        "filtersType":
-            MessageLookupByLibrary.simpleMessage("Comprador/Vendedor"),
-        "fingerprint": MessageLookupByLibrary.simpleMessage("Huella dactilar"),
-        "finishingUp": MessageLookupByLibrary.simpleMessage(
-            "Terminando, por favor espera."),
-        "foundQrCode":
-            MessageLookupByLibrary.simpleMessage("Código QR encontrado"),
-        "frenchLanguage": MessageLookupByLibrary.simpleMessage("Francés"),
-        "from": MessageLookupByLibrary.simpleMessage("Desde"),
-        "gasFee": m49,
-        "gasLimit": MessageLookupByLibrary.simpleMessage("Limite de Gas"),
-        "gasNotActive": m50,
-        "gasPrice": MessageLookupByLibrary.simpleMessage("Precio de Gas"),
-        "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
-            "La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN."),
-        "getBackupPhrase": MessageLookupByLibrary.simpleMessage(
-            "Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!"),
-        "gettingTxWait": MessageLookupByLibrary.simpleMessage(
-            "Obteniendo transacción, por favor espere"),
-        "goToPorfolio":
-            MessageLookupByLibrary.simpleMessage("Ir al portafolio"),
-        "helpLink": MessageLookupByLibrary.simpleMessage("Ayuda"),
-        "helpTitle": MessageLookupByLibrary.simpleMessage("Ayuda y apoyo"),
-        "hideBalance": MessageLookupByLibrary.simpleMessage("Ocultar saldos"),
-        "hintConfirmPassword":
-            MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
-        "hintCreatePassword":
-            MessageLookupByLibrary.simpleMessage("Crear contraseña"),
-        "hintCurrentPassword":
-            MessageLookupByLibrary.simpleMessage("Contraseña actual"),
-        "hintEnterPassword":
-            MessageLookupByLibrary.simpleMessage("Ingresa tu contraseña"),
-        "hintEnterSeedPhrase":
-            MessageLookupByLibrary.simpleMessage("Ingrese su frase inicial"),
-        "hintNameYourWallet":
-            MessageLookupByLibrary.simpleMessage("Nombra tu billetera"),
-        "hintPassword": MessageLookupByLibrary.simpleMessage("Clave"),
-        "history": MessageLookupByLibrary.simpleMessage("historia"),
-        "hours": MessageLookupByLibrary.simpleMessage("h"),
-        "hungarianLanguage": MessageLookupByLibrary.simpleMessage("Húngaro"),
-        "iUnderstand": MessageLookupByLibrary.simpleMessage("Entiendo"),
-        "importButton": MessageLookupByLibrary.simpleMessage("Importar"),
-        "importDecryptError": MessageLookupByLibrary.simpleMessage(
-            "Contraseña no válida o datos dañados"),
-        "importDesc":
-            MessageLookupByLibrary.simpleMessage("Elementos a importar:"),
-        "importFileNotFound":
-            MessageLookupByLibrary.simpleMessage("Archivo no encontrado"),
-        "importInvalidSwapData": MessageLookupByLibrary.simpleMessage(
-            "Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido."),
-        "importLink": MessageLookupByLibrary.simpleMessage("Importar"),
-        "importLoadDesc": MessageLookupByLibrary.simpleMessage(
-            "Seleccione el archivo cifrado para importar."),
-        "importLoadSwapDesc": MessageLookupByLibrary.simpleMessage(
-            "Seleccione el archivo de intercambio de texto sin formato para importar."),
-        "importLoading": MessageLookupByLibrary.simpleMessage("Abriendo..."),
-        "importPassCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "importPassOk": MessageLookupByLibrary.simpleMessage("Ok"),
-        "importPassword": MessageLookupByLibrary.simpleMessage("Clave"),
-        "importSingleSwapLink":
-            MessageLookupByLibrary.simpleMessage("Importar un Intercambio"),
-        "importSingleSwapTitle":
-            MessageLookupByLibrary.simpleMessage("Importar Intercambio"),
-        "importSomeItemsSkippedWarning": MessageLookupByLibrary.simpleMessage(
-            "Se han saltado algunos elementos"),
-        "importSuccessTitle": MessageLookupByLibrary.simpleMessage(
-            "Los elementos se han importado correctamente:"),
-        "importSwapFailed": MessageLookupByLibrary.simpleMessage(
-            "No se pudo importar el intercambio"),
-        "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
-            "Error al decodificar el archivo json"),
-        "importTitle": MessageLookupByLibrary.simpleMessage("Importar"),
-        "incomingTransactionsProtectionSettings": m52,
-        "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
-            "Utilice una contraseña segura y no la almacene en el mismo dispositivo"),
-        "infoTrade1": MessageLookupByLibrary.simpleMessage(
-            "¡La solicitud de intercambio no se puede deshacer y es un evento final!"),
-        "infoTrade2": MessageLookupByLibrary.simpleMessage(
-            "El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!"),
-        "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
-            "Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad."),
-        "insufficientBalanceToPay": m53,
-        "insufficientText": MessageLookupByLibrary.simpleMessage(
-            "El volumen mínimo requerido por este pedido es"),
-        "insufficientTitle":
-            MessageLookupByLibrary.simpleMessage("Volumen insuficiente"),
-        "internetRefreshButton":
-            MessageLookupByLibrary.simpleMessage("Actualizar"),
-        "internetRestored": MessageLookupByLibrary.simpleMessage(
-            "Conexión a Internet restaurada"),
-        "invalidSwap": MessageLookupByLibrary.simpleMessage(
-            "No se puede continuar con el intercambio"),
-        "invalidSwapDetailsLink":
-            MessageLookupByLibrary.simpleMessage("Detalles"),
-        "isUnavailable": m54,
-        "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japonés"),
-        "koreanLanguage": MessageLookupByLibrary.simpleMessage("Coreano"),
-        "language": MessageLookupByLibrary.simpleMessage("Idioma"),
-        "latestTxs":
-            MessageLookupByLibrary.simpleMessage("Últimas transacciones"),
-        "legalTitle": MessageLookupByLibrary.simpleMessage("Legal"),
-        "less": MessageLookupByLibrary.simpleMessage("menos"),
-        "lessThanCaution": m55,
-        "loading": MessageLookupByLibrary.simpleMessage("Cargando..."),
-        "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
-            "Cargando libro de ordenes..."),
-        "lockScreen":
-            MessageLookupByLibrary.simpleMessage("La pantalla está bloqueada"),
-        "lockScreenAuth":
-            MessageLookupByLibrary.simpleMessage("¡Por favor, autentícate!"),
-        "login": MessageLookupByLibrary.simpleMessage("acceso"),
-        "logout": MessageLookupByLibrary.simpleMessage("Cerrar sesión"),
-        "logoutOnExit":
-            MessageLookupByLibrary.simpleMessage("Cerrar sesión al salir"),
-        "logoutWarning": MessageLookupByLibrary.simpleMessage(
-            "¿Estás seguro de que quieres cerrar sesión ahora?"),
-        "logoutsettings": MessageLookupByLibrary.simpleMessage(
-            "Configuración de cierre de sesión"),
-        "longMinutes": MessageLookupByLibrary.simpleMessage("Minutos"),
-        "makeAorder": MessageLookupByLibrary.simpleMessage("hacer un pedido"),
-        "makerDetailsCancel":
-            MessageLookupByLibrary.simpleMessage("Cancelar orden"),
-        "makerDetailsCreated":
-            MessageLookupByLibrary.simpleMessage("Createdo en"),
-        "makerDetailsFor": MessageLookupByLibrary.simpleMessage("Recibir"),
-        "makerDetailsId": MessageLookupByLibrary.simpleMessage("ID de Orden"),
-        "makerDetailsNoSwaps": MessageLookupByLibrary.simpleMessage(
-            "Este pedido no inició intercambios"),
-        "makerDetailsPrice": MessageLookupByLibrary.simpleMessage("Precio"),
-        "makerDetailsSell": MessageLookupByLibrary.simpleMessage("Vender"),
-        "makerDetailsSwaps": MessageLookupByLibrary.simpleMessage(
-            "Intercambios iniciados por este pedido"),
-        "makerDetailsTitle": MessageLookupByLibrary.simpleMessage(
-            "Detalles del pedido del fabricante"),
-        "makerOrder": MessageLookupByLibrary.simpleMessage("Orden de Vendedor"),
-        "marketplace": MessageLookupByLibrary.simpleMessage("Mercado"),
-        "marketsChart": MessageLookupByLibrary.simpleMessage("Gráfico"),
-        "marketsDepth": MessageLookupByLibrary.simpleMessage("Profundidad"),
-        "marketsNoAsks": MessageLookupByLibrary.simpleMessage(
-            "No se encontraron solicitudes"),
-        "marketsNoBids":
-            MessageLookupByLibrary.simpleMessage("No se encontraron ofertas"),
-        "marketsOrderDetails":
-            MessageLookupByLibrary.simpleMessage("Detalles del Pedido"),
-        "marketsOrderbook":
-            MessageLookupByLibrary.simpleMessage("LIBRO DE ORDENES"),
-        "marketsPrice": MessageLookupByLibrary.simpleMessage("PRECIO"),
-        "marketsSelectCoins": MessageLookupByLibrary.simpleMessage(
-            "Por favor seleccione monedas"),
-        "marketsTab": MessageLookupByLibrary.simpleMessage("Mercados"),
-        "marketsTitle": MessageLookupByLibrary.simpleMessage("MERCADOS"),
-        "matchExportPass": MessageLookupByLibrary.simpleMessage(
-            "Las contraseñas deben coincidir"),
-        "matchingCamoChange": MessageLookupByLibrary.simpleMessage("Cambiar"),
-        "matchingCamoPinError": MessageLookupByLibrary.simpleMessage(
-            "Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje."),
-        "matchingCamoTitle":
-            MessageLookupByLibrary.simpleMessage("PIN Invalido"),
-        "max": MessageLookupByLibrary.simpleMessage("MAXIMO"),
-        "maxOrder":
-            MessageLookupByLibrary.simpleMessage("Volumen máximo de pedidos:"),
-        "media": MessageLookupByLibrary.simpleMessage("Noticias"),
-        "mediaBrowse": MessageLookupByLibrary.simpleMessage("NAVEGAR"),
-        "mediaBrowseFeed": MessageLookupByLibrary.simpleMessage("NAVEGAR RSS"),
-        "mediaBy": MessageLookupByLibrary.simpleMessage("By"),
-        "mediaNotSavedDescription": MessageLookupByLibrary.simpleMessage(
-            "NO TIENES ARTÍCULOS GUARDADOS"),
-        "mediaSaved": MessageLookupByLibrary.simpleMessage("GUARDADO"),
-        "memo": MessageLookupByLibrary.simpleMessage("Memorándum"),
-        "merge": MessageLookupByLibrary.simpleMessage("Unir"),
-        "mergedValue": MessageLookupByLibrary.simpleMessage("Valor combinado:"),
-        "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
-        "min": MessageLookupByLibrary.simpleMessage("Min"),
-        "minOrder":
-            MessageLookupByLibrary.simpleMessage("Volumen mínimo de pedido:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
-        "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
-            "Debe ser menor que el monto de venta"),
-        "minVolumeTitle":
-            MessageLookupByLibrary.simpleMessage("Volumen mínimo requerido"),
-        "minVolumeToggle": MessageLookupByLibrary.simpleMessage(
-            "Usar volumen mínimo personalizado"),
-        "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
-            "Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación."),
-        "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m62,
-        "moreInfo": MessageLookupByLibrary.simpleMessage("Más información"),
-        "moreTab": MessageLookupByLibrary.simpleMessage("Mas"),
-        "multiActivateGas": m63,
-        "multiBaseAmtPlaceholder":
-            MessageLookupByLibrary.simpleMessage("Cantidad"),
-        "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Moneda"),
-        "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("Vender"),
-        "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "multiConfirmConfirm":
-            MessageLookupByLibrary.simpleMessage("Confirmar"),
-        "multiConfirmTitle": m64,
-        "multiCreate": MessageLookupByLibrary.simpleMessage("Crear"),
-        "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Orden"),
-        "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Ordenes"),
-        "multiEthFee": MessageLookupByLibrary.simpleMessage("costo"),
-        "multiFiatCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "multiFiatDesc": MessageLookupByLibrary.simpleMessage(
-            "Ingrese la cantidad de dinero para recibir:"),
-        "multiFiatFill": MessageLookupByLibrary.simpleMessage("Autollenarl"),
-        "multiFixErrors": MessageLookupByLibrary.simpleMessage(
-            "Corrija todos los errores antes de continuar"),
-        "multiInvalidAmt":
-            MessageLookupByLibrary.simpleMessage("Monto invalido"),
-        "multiInvalidSellAmt":
-            MessageLookupByLibrary.simpleMessage("Cantidad de venta no válido"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
-        "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage(
-            "La cantidad máxima de venta es"),
-        "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
-            "La cantidad mínima recibida es"),
-        "multiMinSellAmt": MessageLookupByLibrary.simpleMessage(
-            "La cantidad mínima de venta es"),
-        "multiReceiveTitle": MessageLookupByLibrary.simpleMessage("Recibir:"),
-        "multiSellTitle": MessageLookupByLibrary.simpleMessage("Vender:"),
-        "multiTab": MessageLookupByLibrary.simpleMessage("Multi"),
-        "multiTableAmt": MessageLookupByLibrary.simpleMessage("Recibir Cntd."),
-        "multiTablePrice": MessageLookupByLibrary.simpleMessage("Precio/CEX"),
-        "networkFee": MessageLookupByLibrary.simpleMessage("Tarifa de red"),
-        "newAccount": MessageLookupByLibrary.simpleMessage("nueva cuenta"),
-        "newAccountUpper": MessageLookupByLibrary.simpleMessage("Nueva Cuenta"),
-        "newValue": MessageLookupByLibrary.simpleMessage("Nuevo valor:"),
-        "newsFeed": MessageLookupByLibrary.simpleMessage("Noticias"),
-        "next": MessageLookupByLibrary.simpleMessage("próximo"),
-        "no": MessageLookupByLibrary.simpleMessage("No"),
-        "noArticles": MessageLookupByLibrary.simpleMessage(
-            "No hay noticias. Vuelva a consultar más tarde."),
-        "noCoinFound": MessageLookupByLibrary.simpleMessage(
-            "No se encontró ninguna moneda"),
-        "noFunds": MessageLookupByLibrary.simpleMessage("Sin Fondos"),
-        "noFundsDetected": MessageLookupByLibrary.simpleMessage(
-            "No hay fondos disponibles, por favor deposite."),
-        "noInternet":
-            MessageLookupByLibrary.simpleMessage("Sin conexión a Internet"),
-        "noItemsToExport": MessageLookupByLibrary.simpleMessage(
-            "No hay artículos seleccionados"),
-        "noItemsToImport": MessageLookupByLibrary.simpleMessage(
-            "No hay artículos seleccionados"),
-        "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
-            "No se encontraron pedidos coincidentes"),
-        "noOrder": m67,
-        "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
-            "Haga clic para crear un pedido"),
-        "noOrders": MessageLookupByLibrary.simpleMessage(
-            "No hay pedidos, por favor vaya al comercio."),
-        "noRewardYet": MessageLookupByLibrary.simpleMessage(
-            "No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora."),
-        "noRewards": MessageLookupByLibrary.simpleMessage(
-            "No hay recompensas reclamables"),
-        "noSuchCoin": MessageLookupByLibrary.simpleMessage("No hay tal moneda"),
-        "noSwaps": MessageLookupByLibrary.simpleMessage("No historia."),
-        "noTxs": MessageLookupByLibrary.simpleMessage("Sin transacciones"),
-        "nonNumericInput":
-            MessageLookupByLibrary.simpleMessage("El valor debe ser numérico."),
-        "none": MessageLookupByLibrary.simpleMessage("Ninguno"),
-        "notEnoughGas": m68,
-        "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
-            "No hay suficiente saldo para las tarifas: opere con una cantidad menor"),
-        "noteOnOrder": MessageLookupByLibrary.simpleMessage(
-            "Nota: el pedido emparejado no se puede cancelar de nuevo"),
-        "notePlaceholder": MessageLookupByLibrary.simpleMessage("Añadir Nota"),
-        "noteTitle": MessageLookupByLibrary.simpleMessage("Nota"),
-        "nothingFound": MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
-        "notifSwapCompletedText": m69,
-        "notifSwapCompletedTitle":
-            MessageLookupByLibrary.simpleMessage("Intercambio completado"),
-        "notifSwapFailedText": m70,
-        "notifSwapFailedTitle":
-            MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
-        "notifSwapStartedText": m71,
-        "notifSwapStartedTitle":
-            MessageLookupByLibrary.simpleMessage("Nuevo intercambio iniciado"),
-        "notifSwapStatusTitle":
-            MessageLookupByLibrary.simpleMessage("Cambio de estado cambiado"),
-        "notifSwapTimeoutText": m72,
-        "notifSwapTimeoutTitle": MessageLookupByLibrary.simpleMessage(
-            "Se agotó el tiempo de intercambio"),
-        "notifTxText": m73,
-        "notifTxTitle":
-            MessageLookupByLibrary.simpleMessage("Transaccion entrante"),
-        "numberAssets": m74,
-        "officialPressRelease": MessageLookupByLibrary.simpleMessage(
-            "comunicado de prensa oficial"),
-        "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
-        "oldLogsDelete": MessageLookupByLibrary.simpleMessage("Borrar"),
-        "oldLogsTitle":
-            MessageLookupByLibrary.simpleMessage("Registros antiguos"),
-        "oldLogsUsed": MessageLookupByLibrary.simpleMessage("Espacio usado"),
-        "openMessage":
-            MessageLookupByLibrary.simpleMessage("Abrir mensaje de error"),
-        "orderBookLess": MessageLookupByLibrary.simpleMessage("Menos"),
-        "orderBookMore": MessageLookupByLibrary.simpleMessage("Más"),
-        "orderCancel": m75,
-        "orderCreated": MessageLookupByLibrary.simpleMessage("Pedido creado"),
-        "orderCreatedInfo":
-            MessageLookupByLibrary.simpleMessage("Pedido creado con éxito"),
-        "orderDetailsAddress":
-            MessageLookupByLibrary.simpleMessage("Direccion"),
-        "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
-        "orderDetailsFor": MessageLookupByLibrary.simpleMessage("for"),
-        "orderDetailsIdentical":
-            MessageLookupByLibrary.simpleMessage("Idéntico a CEX"),
-        "orderDetailsMin": MessageLookupByLibrary.simpleMessage("min."),
-        "orderDetailsPrice": MessageLookupByLibrary.simpleMessage("Precio"),
-        "orderDetailsReceive": MessageLookupByLibrary.simpleMessage("Recibir"),
-        "orderDetailsSelect":
-            MessageLookupByLibrary.simpleMessage("Seleccione"),
-        "orderDetailsSells": MessageLookupByLibrary.simpleMessage("Ventas"),
-        "orderDetailsSettings": MessageLookupByLibrary.simpleMessage(
-            "Abra detalles con un solo toque y seleccione Ordenar con un toque largo"),
-        "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Gastar"),
-        "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Detalles"),
-        "orderFilled": m78,
-        "orderMatched":
-            MessageLookupByLibrary.simpleMessage("Orden Triangulada"),
-        "orderMatching":
-            MessageLookupByLibrary.simpleMessage("Triangulación de órdenes"),
-        "orderTypePartial": MessageLookupByLibrary.simpleMessage("Orden"),
-        "orderTypeUnknown":
-            MessageLookupByLibrary.simpleMessage("Orden desconocida"),
-        "orders": MessageLookupByLibrary.simpleMessage("ordenes"),
-        "ordersActive": MessageLookupByLibrary.simpleMessage("Activo"),
-        "ordersHistory": MessageLookupByLibrary.simpleMessage("Historial"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
-        "overwrite": MessageLookupByLibrary.simpleMessage("Sobrescribir"),
-        "ownOrder":
-            MessageLookupByLibrary.simpleMessage("Esta es tu propia orden!"),
-        "paidFromBalance":
-            MessageLookupByLibrary.simpleMessage("Pagado del saldo:"),
-        "paidFromVolume": MessageLookupByLibrary.simpleMessage(
-            "Pagado del volumen recibido:"),
-        "paidWith": MessageLookupByLibrary.simpleMessage("Pagado con"),
-        "passwordRequirement": MessageLookupByLibrary.simpleMessage(
-            "La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial."),
-        "paymentUriDetailsAccept":
-            MessageLookupByLibrary.simpleMessage("Pagar"),
-        "paymentUriDetailsAcceptQuestion":
-            MessageLookupByLibrary.simpleMessage("¿Acepta esta transacción?"),
-        "paymentUriDetailsAddressSpan":
-            MessageLookupByLibrary.simpleMessage("A Direccion"),
-        "paymentUriDetailsAmountSpan":
-            MessageLookupByLibrary.simpleMessage("Monto:"),
-        "paymentUriDetailsCoinSpan":
-            MessageLookupByLibrary.simpleMessage("Moneda:"),
-        "paymentUriDetailsDeny":
-            MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "paymentUriDetailsTitle":
-            MessageLookupByLibrary.simpleMessage("Pago solicitado"),
-        "paymentUriInactiveCoin": m82,
-        "placeOrder": MessageLookupByLibrary.simpleMessage("Haga su pedido"),
-        "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
-            "Por favor agregue una moneda"),
-        "pleaseRestart": MessageLookupByLibrary.simpleMessage(
-            "Reinicie la aplicación para volver a intentarlo o presione el botón a continuación."),
-        "portfolio": MessageLookupByLibrary.simpleMessage("Portfolio"),
-        "poweredOnKmd":
-            MessageLookupByLibrary.simpleMessage("Desarrollado por Komodo"),
-        "price": MessageLookupByLibrary.simpleMessage("price"),
-        "privateKey": MessageLookupByLibrary.simpleMessage("Llave Privada"),
-        "privateKeys": MessageLookupByLibrary.simpleMessage("Llaves Privadas"),
-        "protectionCtrlConfirmations":
-            MessageLookupByLibrary.simpleMessage("Confirmaciones"),
-        "protectionCtrlCustom": MessageLookupByLibrary.simpleMessage(
-            "Usar configuraciones de protección personalizadas"),
-        "protectionCtrlOff":
-            MessageLookupByLibrary.simpleMessage("DESACTIVADO"),
-        "protectionCtrlOn": MessageLookupByLibrary.simpleMessage("ACTIVADO"),
-        "protectionCtrlWarning": MessageLookupByLibrary.simpleMessage(
-            "Advertencia, este intercambio atómico no está protegido por dPoW."),
-        "pubkey": MessageLookupByLibrary.simpleMessage("Llave Publica"),
-        "qrCodeScanner":
-            MessageLookupByLibrary.simpleMessage("Escáner de código QR"),
-        "question_1": MessageLookupByLibrary.simpleMessage(
-            "¿Guardás mis llaves privadas?"),
-        "question_10": m83,
-        "question_2": m84,
-        "question_3": MessageLookupByLibrary.simpleMessage(
-            "¿Cuánto tiempo toma cada intercambio atómico?"),
-        "question_4": MessageLookupByLibrary.simpleMessage(
-            "¿Necesito estar en línea durante la duración del intercambio?"),
-        "question_5": m85,
-        "question_6": MessageLookupByLibrary.simpleMessage(
-            "¿Ofrecen soporte al usuario?"),
-        "question_7": MessageLookupByLibrary.simpleMessage(
-            "¿Tiene restricciones de país?"),
-        "question_8": m86,
-        "question_9": m87,
-        "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
-            "¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de \'AtomicDEX\' a \'Komodo Wallet\'"),
-        "receive": MessageLookupByLibrary.simpleMessage("RECIBIR"),
-        "receiveLower": MessageLookupByLibrary.simpleMessage("Recibir"),
-        "recommendSeedMessage": MessageLookupByLibrary.simpleMessage(
-            "Recomendamos almacenarlo fuera de línea."),
-        "remove": MessageLookupByLibrary.simpleMessage("Desactivar"),
-        "requestedTrade":
-            MessageLookupByLibrary.simpleMessage("Comercio solicitado"),
-        "reset": MessageLookupByLibrary.simpleMessage("RESETEAR"),
-        "resetTitle":
-            MessageLookupByLibrary.simpleMessage("Restablecer formulario"),
-        "restoreWallet": MessageLookupByLibrary.simpleMessage("RESTAURAR"),
-        "retryActivating": MessageLookupByLibrary.simpleMessage(
-            "Volviendo a intentar activar todas las monedas..."),
-        "retryAll": MessageLookupByLibrary.simpleMessage(
-            "Vuelva a intentar activar todo"),
-        "rewardsButton":
-            MessageLookupByLibrary.simpleMessage("Reclama tus recompensas"),
-        "rewardsCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
-        "rewardsError": MessageLookupByLibrary.simpleMessage(
-            "Algo salió mal. Por favor, inténtelo de nuevo más tarde."),
-        "rewardsInProgressLong": MessageLookupByLibrary.simpleMessage(
-            "La transacción está en curso"),
-        "rewardsInProgressShort":
-            MessageLookupByLibrary.simpleMessage("procesando"),
-        "rewardsLowAmountLong": MessageLookupByLibrary.simpleMessage(
-            "Cantidad de UTXO inferior a 10 KMD"),
-        "rewardsLowAmountShort":
-            MessageLookupByLibrary.simpleMessage("<10 KMD"),
-        "rewardsOneHourLong":
-            MessageLookupByLibrary.simpleMessage("Aún no ha pasado una hora"),
-        "rewardsOneHourShort": MessageLookupByLibrary.simpleMessage("<1 hora"),
-        "rewardsPopupOk": MessageLookupByLibrary.simpleMessage("Ok"),
-        "rewardsPopupTitle":
-            MessageLookupByLibrary.simpleMessage("Estado de recompensas:"),
-        "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
-            "Obtenga más información sobre las recompensas para usuarios activos de KMD"),
-        "rewardsReceive": MessageLookupByLibrary.simpleMessage("Recibir"),
-        "rewardsSuccess": m88,
-        "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
-        "rewardsTableRewards":
-            MessageLookupByLibrary.simpleMessage("Recompensas,\nKMD"),
-        "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("Estado"),
-        "rewardsTableTime":
-            MessageLookupByLibrary.simpleMessage("Tiempo\nrestante"),
-        "rewardsTableTitle":
-            MessageLookupByLibrary.simpleMessage("Información de recompensas:"),
-        "rewardsTableUXTO":
-            MessageLookupByLibrary.simpleMessage("UTXO\ncantidad,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
-        "rewardsTitle":
-            MessageLookupByLibrary.simpleMessage("Información de recompensas"),
-        "russianLanguage": MessageLookupByLibrary.simpleMessage("Ruso"),
-        "saveMerged": MessageLookupByLibrary.simpleMessage("Guardar combinado"),
-        "scrollToContinue": MessageLookupByLibrary.simpleMessage(
-            "Desplácese hacia abajo para continuar..."),
-        "searchFilterCoin":
-            MessageLookupByLibrary.simpleMessage("Buscar una moneda"),
-        "searchFilterSubtitleAVX": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens de Avax"),
-        "searchFilterSubtitleBEP": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens BEP"),
-        "searchFilterSubtitleCosmos": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todo Cosmos Network"),
-        "searchFilterSubtitleERC": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens ERC"),
-        "searchFilterSubtitleETC": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens ETC"),
-        "searchFilterSubtitleFTM": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todas las fichas de Fantom"),
-        "searchFilterSubtitleHCO": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens de HecoChain"),
-        "searchFilterSubtitleHRC": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todas las fichas de armonía"),
-        "searchFilterSubtitleIris": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todo Iris Network"),
-        "searchFilterSubtitleKRC": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens de Kucoin"),
-        "searchFilterSubtitleMVR": MessageLookupByLibrary.simpleMessage(
-            "Seleccione todas las fichas de Moonriver"),
-        "searchFilterSubtitlePLG": MessageLookupByLibrary.simpleMessage(
-            "Seleccione todas las fichas de polígono"),
-        "searchFilterSubtitleQRC": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens QRC"),
-        "searchFilterSubtitleSBCH": MessageLookupByLibrary.simpleMessage(
-            "Seleccione todos los tokens SmartBCH"),
-        "searchFilterSubtitleSLP": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los tokens SLP"),
-        "searchFilterSubtitleSmartChain": MessageLookupByLibrary.simpleMessage(
-            "Seleccione todos los SmartChains"),
-        "searchFilterSubtitleTestCoins": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todos los activos de prueba"),
-        "searchFilterSubtitleUBQ": MessageLookupByLibrary.simpleMessage(
-            "Seleccionar todas las monedas Ubiq"),
-        "searchFilterSubtitleZHTLC": MessageLookupByLibrary.simpleMessage(
-            "Seleccione todas las monedas ZHTLC"),
-        "searchFilterSubtitleutxo": MessageLookupByLibrary.simpleMessage(
-            "Seleccione todas las monedas UTXO"),
-        "searchForTicker":
-            MessageLookupByLibrary.simpleMessage("Buscar teletipo"),
-        "seconds": MessageLookupByLibrary.simpleMessage("s"),
-        "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
-        "seeOrders": m92,
-        "seeTxHistory": MessageLookupByLibrary.simpleMessage(
-            "Ver historial de transacciones"),
-        "seedPhrase": MessageLookupByLibrary.simpleMessage("Frase Semilla"),
-        "seedPhraseTitle":
-            MessageLookupByLibrary.simpleMessage("Tu nueva frase semilla"),
-        "selectCoin":
-            MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
-        "selectCoinInfo": MessageLookupByLibrary.simpleMessage(
-            "Seleccione las monedas que desea agregar a su cartera."),
-        "selectCoinTitle":
-            MessageLookupByLibrary.simpleMessage("Activar monedas:"),
-        "selectCoinToBuy": MessageLookupByLibrary.simpleMessage(
-            "Seleccione la moneda que desea COMPRAR"),
-        "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
-            "Seleccione la moneda que desea VENDER"),
-        "selectFileImport":
-            MessageLookupByLibrary.simpleMessage("Seleccione Archivo"),
-        "selectLanguage":
-            MessageLookupByLibrary.simpleMessage("Seleccione el idioma"),
-        "selectPaymentMethod":
-            MessageLookupByLibrary.simpleMessage("Selecciona tu forma de pago"),
-        "selectedOrder":
-            MessageLookupByLibrary.simpleMessage("Orden seleccionado:"),
-        "sell": MessageLookupByLibrary.simpleMessage("Vender"),
-        "sellTestCoinWarning": MessageLookupByLibrary.simpleMessage(
-            "¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!"),
-        "send": MessageLookupByLibrary.simpleMessage("ENVIAR"),
-        "setUpPassword":
-            MessageLookupByLibrary.simpleMessage("CONFIGURAR UNA CONTRASEÑA"),
-        "settingDialogSpan1": MessageLookupByLibrary.simpleMessage(
-            "Estás seguro de que quieres eliminar"),
-        "settingDialogSpan2":
-            MessageLookupByLibrary.simpleMessage("billetera?"),
-        "settingDialogSpan3":
-            MessageLookupByLibrary.simpleMessage("Si es así, asegúrese de"),
-        "settingDialogSpan4":
-            MessageLookupByLibrary.simpleMessage("guardar su frase inicial."),
-        "settingDialogSpan5": MessageLookupByLibrary.simpleMessage(
-            "Para restaurar su billetera en el futuro."),
-        "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Idiomas"),
-        "settings": MessageLookupByLibrary.simpleMessage("Ajustes"),
-        "share": MessageLookupByLibrary.simpleMessage("Compartir"),
-        "shareAddress": m93,
-        "showAddress":
-            MessageLookupByLibrary.simpleMessage("Mostrar dirección"),
-        "showDetails": MessageLookupByLibrary.simpleMessage("Mostrar detalles"),
-        "showMyOrders":
-            MessageLookupByLibrary.simpleMessage("Mostrar mis pedidos"),
-        "showingOrders": m94,
-        "signInWithPassword": MessageLookupByLibrary.simpleMessage(
-            "Iniciar sesión con contraseña"),
-        "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
-            "¿Olvidó la contraseña? Restaurar billetera desde semilla"),
-        "simple": MessageLookupByLibrary.simpleMessage("Sencillo"),
-        "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("Activar"),
-        "simpleTradeBuyHint": m95,
-        "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Comprar"),
-        "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Cerrar"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
-        "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Recibir"),
-        "simpleTradeSellHint": m98,
-        "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Vender"),
-        "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Enviar"),
-        "simpleTradeShowLess":
-            MessageLookupByLibrary.simpleMessage("Muestra menos"),
-        "simpleTradeShowMore":
-            MessageLookupByLibrary.simpleMessage("Mostrar mas"),
-        "simpleTradeUnableActivate": m99,
-        "skip": MessageLookupByLibrary.simpleMessage("Omitir"),
-        "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Descartar"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
-        "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Sonido"),
-        "soundSettingsTitle":
-            MessageLookupByLibrary.simpleMessage("Ajustes de sonido"),
-        "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("Sonidos"),
-        "soundsDoNotShowAgain": MessageLookupByLibrary.simpleMessage(
-            "Entendido, no lo muestres más."),
-        "soundsExplanation": MessageLookupByLibrary.simpleMessage(
-            "Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo."),
-        "soundsNote": MessageLookupByLibrary.simpleMessage(
-            "Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación."),
-        "spanishLanguage": MessageLookupByLibrary.simpleMessage("Español"),
-        "startSwap":
-            MessageLookupByLibrary.simpleMessage("Iniciar intercambio"),
-        "step": MessageLookupByLibrary.simpleMessage("Paso"),
-        "success": MessageLookupByLibrary.simpleMessage("¡Éxito!"),
-        "support": MessageLookupByLibrary.simpleMessage("Apoyo"),
-        "supportLinksDesc": m102,
-        "swap": MessageLookupByLibrary.simpleMessage("intercambio"),
-        "swapCurrent": MessageLookupByLibrary.simpleMessage("Actual"),
-        "swapDetailTitle": MessageLookupByLibrary.simpleMessage(
-            "CONFIRMAR DETALLES DE CAMBIO"),
-        "swapEstimated": MessageLookupByLibrary.simpleMessage("Estimado"),
-        "swapFailed":
-            MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
-        "swapOngoing":
-            MessageLookupByLibrary.simpleMessage("Intercambio en curso"),
-        "swapProgress":
-            MessageLookupByLibrary.simpleMessage("Detalles del Progreso"),
-        "swapStarted": MessageLookupByLibrary.simpleMessage("Iniciado"),
-        "swapSucceful":
-            MessageLookupByLibrary.simpleMessage("Intercambio exitoso"),
-        "swapTotal": MessageLookupByLibrary.simpleMessage("Total"),
-        "swapUUID": MessageLookupByLibrary.simpleMessage("Intercambiar UUID"),
-        "switchTheme": MessageLookupByLibrary.simpleMessage("Cambiar Tema"),
-        "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
-        "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
-        "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
-        "tagETC": MessageLookupByLibrary.simpleMessage("ETC"),
-        "tagFTM20": MessageLookupByLibrary.simpleMessage("FTM20"),
-        "tagHCO20": MessageLookupByLibrary.simpleMessage("HCO20"),
-        "tagHRC20": MessageLookupByLibrary.simpleMessage("HRC20"),
-        "tagKMD": MessageLookupByLibrary.simpleMessage("KMD"),
-        "tagKRC20": MessageLookupByLibrary.simpleMessage("KRC20"),
-        "tagMVR20": MessageLookupByLibrary.simpleMessage("MVR20"),
-        "tagPLG20": MessageLookupByLibrary.simpleMessage("PLG20"),
-        "tagQRC20": MessageLookupByLibrary.simpleMessage("QRC20"),
-        "tagSBCH": MessageLookupByLibrary.simpleMessage("SBCH"),
-        "tagUBQ": MessageLookupByLibrary.simpleMessage("UBQ"),
-        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ZHTLC"),
-        "takerOrder":
-            MessageLookupByLibrary.simpleMessage("Orden de Comprador"),
-        "timeOut": MessageLookupByLibrary.simpleMessage("Se acabó el tiempo"),
-        "titleCreatePassword":
-            MessageLookupByLibrary.simpleMessage("CREA UNA CONTRASEÑA"),
-        "titleCurrentAsk":
-            MessageLookupByLibrary.simpleMessage("Pedido seleccionado"),
-        "to": MessageLookupByLibrary.simpleMessage("Para"),
-        "toAddress": MessageLookupByLibrary.simpleMessage("Hacia:"),
-        "tooManyAssetsEnabledSpan1":
-            MessageLookupByLibrary.simpleMessage("Tu tienes"),
-        "tooManyAssetsEnabledSpan2": MessageLookupByLibrary.simpleMessage(
-            "activos habilitados. El límite máximo de activos habilitados es"),
-        "tooManyAssetsEnabledSpan3": MessageLookupByLibrary.simpleMessage(
-            ". Desactive algunos antes de agregar otros nuevos."),
-        "tooManyAssetsEnabledTitle": MessageLookupByLibrary.simpleMessage(
-            "Demasiados recursos habilitados"),
-        "totalFees": MessageLookupByLibrary.simpleMessage("Tarifas totales:"),
-        "trade": MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
-        "tradeCompleted":
-            MessageLookupByLibrary.simpleMessage("¡CAMBIO COMPLETADO!"),
-        "tradeDetail":
-            MessageLookupByLibrary.simpleMessage("DETALLES INTERCAMBIO"),
-        "tradePreimageError": MessageLookupByLibrary.simpleMessage(
-            "Error al calcular las tarifas comerciales"),
-        "tradingFee":
-            MessageLookupByLibrary.simpleMessage("tarifa de negociación:"),
-        "tradingMode":
-            MessageLookupByLibrary.simpleMessage("Modo de comercio:"),
-        "transactionAddress":
-            MessageLookupByLibrary.simpleMessage("Dirección de transacción"),
-        "transactionHidden":
-            MessageLookupByLibrary.simpleMessage("Transacción oculta"),
-        "transactionHiddenPhishing": MessageLookupByLibrary.simpleMessage(
-            "Esta transacción fue ocultada debido a un posible intento de phishing."),
-        "tryRestarting": MessageLookupByLibrary.simpleMessage(
-            "Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación."),
-        "turkishLanguage": MessageLookupByLibrary.simpleMessage("Turco"),
-        "txBlock": MessageLookupByLibrary.simpleMessage("Bloque"),
-        "txConfirmations":
-            MessageLookupByLibrary.simpleMessage("Confirmaciones"),
-        "txConfirmed": MessageLookupByLibrary.simpleMessage("CONFIRMADO"),
-        "txFee": MessageLookupByLibrary.simpleMessage("Tarifa"),
-        "txFeeTitle":
-            MessageLookupByLibrary.simpleMessage("tarifa de transacción:"),
-        "txHash": MessageLookupByLibrary.simpleMessage("ID de transacción"),
-        "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
-            "Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde."),
-        "txNotConfirmed": MessageLookupByLibrary.simpleMessage("INCONFIRMADO"),
-        "txleft": m106,
-        "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ucranio"),
-        "unlock": MessageLookupByLibrary.simpleMessage("desbloquear"),
-        "unlockFunds":
-            MessageLookupByLibrary.simpleMessage("Desbloquear fondos"),
-        "unlockSuccess": m107,
-        "unspendable": MessageLookupByLibrary.simpleMessage("ingastable"),
-        "updatesAvailable":
-            MessageLookupByLibrary.simpleMessage("Nueva versión disponible"),
-        "updatesChecking": MessageLookupByLibrary.simpleMessage(
-            "Comprobando actualizaciones..."),
-        "updatesCurrentVersion": m108,
-        "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
-            "Nueva versión disponible. Por favor actualice."),
-        "updatesNotifAvailableVersion": m109,
-        "updatesNotifTitle":
-            MessageLookupByLibrary.simpleMessage("Actualización disponible"),
-        "updatesSkip": MessageLookupByLibrary.simpleMessage("Saltar por ahora"),
-        "updatesTitle": m110,
-        "updatesUpToDate":
-            MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
-        "updatesUpdate": MessageLookupByLibrary.simpleMessage("Actualizar"),
-        "uriInsufficientBalanceSpan1": MessageLookupByLibrary.simpleMessage(
-            "No hay suficiente saldo para escaneado"),
-        "uriInsufficientBalanceSpan2":
-            MessageLookupByLibrary.simpleMessage("solicitud de pago."),
-        "uriInsufficientBalanceTitle":
-            MessageLookupByLibrary.simpleMessage("Saldo insuficiente"),
-        "value": MessageLookupByLibrary.simpleMessage("Valor:"),
-        "version": MessageLookupByLibrary.simpleMessage("version"),
-        "viewInExplorerButton":
-            MessageLookupByLibrary.simpleMessage("Explorador"),
-        "viewSeedAndKeys":
-            MessageLookupByLibrary.simpleMessage("Semilla y Claves Privadas"),
-        "volumes": MessageLookupByLibrary.simpleMessage("Volumenes"),
-        "walletInUse": MessageLookupByLibrary.simpleMessage(
-            "El nombre de la billetera ya está en uso"),
-        "walletMaxChar": MessageLookupByLibrary.simpleMessage(
-            "El nombre de la billetera debe tener un máximo de 40 caracteres"),
-        "walletOnly": MessageLookupByLibrary.simpleMessage("Solo billetera"),
-        "warning": MessageLookupByLibrary.simpleMessage("¡Advertencia!"),
-        "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
-        "warningShareLogs": MessageLookupByLibrary.simpleMessage(
-            "Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos."),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
-        "welcomeLetSetUp":
-            MessageLookupByLibrary.simpleMessage("¡VAMOS A PREPARARNOS!"),
-        "welcomeTitle": MessageLookupByLibrary.simpleMessage("BIENVENIDO"),
-        "welcomeWallet": MessageLookupByLibrary.simpleMessage("wallet"),
-        "willBeRedirected": MessageLookupByLibrary.simpleMessage(
-            "Se le redirigirá a la página del portafolio al finalizar."),
-        "willTakeTime": MessageLookupByLibrary.simpleMessage(
-            "Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas."),
-        "withdraw": MessageLookupByLibrary.simpleMessage("Retirar"),
-        "withdrawCameraAccessText": m114,
-        "withdrawCameraAccessTitle":
-            MessageLookupByLibrary.simpleMessage("Acceso Denegado"),
-        "withdrawConfirm":
-            MessageLookupByLibrary.simpleMessage("Confirmar Retiro"),
-        "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
-            "Algo salió mal. Vuelva a intentarlo más tarde."),
-        "withdrawValue": m115,
-        "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
-            "Está intentando escanear un código QR de pago para"),
-        "wrongCoinSpan2":
-            MessageLookupByLibrary.simpleMessage("pero tu estas en la"),
-        "wrongCoinSpan3":
-            MessageLookupByLibrary.simpleMessage("pantalla de retirar"),
-        "wrongCoinTitle":
-            MessageLookupByLibrary.simpleMessage("Moneda equivocada"),
-        "wrongPassword": MessageLookupByLibrary.simpleMessage(
-            "Las contraseñas no coinciden. Inténtalo de nuevo."),
-        "yes": MessageLookupByLibrary.simpleMessage("Sí"),
-        "you have a fresh order that is trying to match with an existing order":
-            MessageLookupByLibrary.simpleMessage(
-                "tiene un pedido nuevo que está tratando de coincidir con un pedido existente"),
-        "you have an active swap in progress":
-            MessageLookupByLibrary.simpleMessage(
-                "tienes un intercambio activo en curso"),
-        "you have an order that new orders can match with":
-            MessageLookupByLibrary.simpleMessage(
-                "tiene un pedido con el que pueden coincidir nuevos pedidos"),
-        "youAreSending":
-            MessageLookupByLibrary.simpleMessage("Usted está enviando:"),
-        "youWillReceiveClaim": m116,
-        "youWillReceived":
-            MessageLookupByLibrary.simpleMessage("Usted recibirá:"),
-        "yourWallet": MessageLookupByLibrary.simpleMessage("Su billetera")
-      };
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function> {
+    "Active" : MessageLookupByLibrary.simpleMessage("Activo"),
+    "Applause" : MessageLookupByLibrary.simpleMessage("Aplausos"),
+    "Can\'t play that" : MessageLookupByLibrary.simpleMessage("no puedo escuchar eso"),
+    "Failed" : MessageLookupByLibrary.simpleMessage("Fallido"),
+    "Maker" : MessageLookupByLibrary.simpleMessage("Vendedor"),
+    "Optional" : MessageLookupByLibrary.simpleMessage("Opcional"),
+    "Play at full volume" : MessageLookupByLibrary.simpleMessage("Juega a todo volumen"),
+    "Sound" : MessageLookupByLibrary.simpleMessage("Sonido"),
+    "Taker" : MessageLookupByLibrary.simpleMessage("Comprador"),
+    "a swap fails" : MessageLookupByLibrary.simpleMessage("un intercambio falla"),
+    "a swap runs to completion" : MessageLookupByLibrary.simpleMessage("un intercambio se ejecuta hasta su finalización"),
+    "accepteula" : MessageLookupByLibrary.simpleMessage("Aceptar EULA"),
+    "accepttac" : MessageLookupByLibrary.simpleMessage("Aceptar TERMINOS y CONDICIONES"),
+    "activateAccessBiometric" : MessageLookupByLibrary.simpleMessage("Activar protección biométrica"),
+    "activateAccessPin" : MessageLookupByLibrary.simpleMessage("Activar la protección con PIN"),
+    "activateCoins" : m0,
+    "activating" : m1,
+    "activation" : m2,
+    "activationInProgress" : m3,
+    "addCoin" : MessageLookupByLibrary.simpleMessage("Activar moneda"),
+    "addingCoinSuccess" : m4,
+    "addressAdd" : MessageLookupByLibrary.simpleMessage("Añadir Direccion"),
+    "addressBook" : MessageLookupByLibrary.simpleMessage("Directorio"),
+    "addressBookEmpty" : MessageLookupByLibrary.simpleMessage("La libreta de direcciones está vacía"),
+    "addressBookFilter" : m5,
+    "addressBookTitle" : MessageLookupByLibrary.simpleMessage("Directorio"),
+    "addressCoinInactive" : m6,
+    "addressNotFound" : MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
+    "addressSelectCoin" : MessageLookupByLibrary.simpleMessage("Seleccionar Moneda"),
+    "addressSend" : MessageLookupByLibrary.simpleMessage("Dirección de los destinatarios"),
+    "advanced" : MessageLookupByLibrary.simpleMessage("Avanzado"),
+    "all" : MessageLookupByLibrary.simpleMessage("TODOS"),
+    "allPastTransactions" : MessageLookupByLibrary.simpleMessage("Su billetera mostrará cualquier transacción pasada. Esto requerirá mucho almacenamiento y tiempo, ya que todos los bloques se descargarán y escanearán."),
+    "allowCustomSeed" : MessageLookupByLibrary.simpleMessage("Permitir semilla personalizada"),
+    "alreadyExists" : MessageLookupByLibrary.simpleMessage("Ya existe"),
+    "amount" : MessageLookupByLibrary.simpleMessage("Cantidad"),
+    "amountToSell" : MessageLookupByLibrary.simpleMessage("Cantidad a Vender"),
+    "answer_1" : m7,
+    "answer_10" : m8,
+    "answer_2" : m9,
+    "answer_3" : m10,
+    "answer_4" : MessageLookupByLibrary.simpleMessage("Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico."),
+    "answer_5" : m11,
+    "answer_6" : m12,
+    "answer_7" : m13,
+    "answer_8" : m14,
+    "answer_9" : m15,
+    "areYouSure" : MessageLookupByLibrary.simpleMessage("ESTAS SEGURO?"),
+    "authenticate" : MessageLookupByLibrary.simpleMessage("autenticar"),
+    "automaticRedirected" : MessageLookupByLibrary.simpleMessage("Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación."),
+    "availableVolume" : MessageLookupByLibrary.simpleMessage("volumen máximo"),
+    "back" : MessageLookupByLibrary.simpleMessage("back"),
+    "backupTitle" : MessageLookupByLibrary.simpleMessage("Respaldo"),
+    "basedOnCoinRatio" : m16,
+    "batteryCriticalError" : m17,
+    "batteryLowWarning" : m18,
+    "batterySavingWarning" : MessageLookupByLibrary.simpleMessage("Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio."),
+    "bestAvailableRate" : MessageLookupByLibrary.simpleMessage("Tipo de cambio"),
+    "builtKomodo" : MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
+    "builtOnKmd" : MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
+    "buy" : MessageLookupByLibrary.simpleMessage("Comprar"),
+    "buyOrderType" : MessageLookupByLibrary.simpleMessage("Convertir a Vendedor si no coincide"),
+    "buySuccessWaiting" : MessageLookupByLibrary.simpleMessage("Intercambio emitido, por favor espere!"),
+    "buySuccessWaitingError" : m19,
+    "buyTestCoinWarning" : MessageLookupByLibrary.simpleMessage("¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!"),
+    "camoPinBioProtectionConflict" : MessageLookupByLibrary.simpleMessage("El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo."),
+    "camoPinBioProtectionConflictTitle" : MessageLookupByLibrary.simpleMessage("Conflicto entre PIN de camuflaje y bioprotección."),
+    "camoPinChange" : MessageLookupByLibrary.simpleMessage("Cambiar PIN de camuflaje"),
+    "camoPinCreate" : MessageLookupByLibrary.simpleMessage("Crear PIN de camuflaje"),
+    "camoPinDesc" : MessageLookupByLibrary.simpleMessage("Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración"),
+    "camoPinInvalid" : MessageLookupByLibrary.simpleMessage("PIN de camuflaje no válido"),
+    "camoPinLink" : MessageLookupByLibrary.simpleMessage("Camuflajear PIN"),
+    "camoPinNotFound" : MessageLookupByLibrary.simpleMessage("PIN de camuflaje no encontrado"),
+    "camoPinOff" : MessageLookupByLibrary.simpleMessage("Desactivado"),
+    "camoPinOn" : MessageLookupByLibrary.simpleMessage("Activado"),
+    "camoPinSaved" : MessageLookupByLibrary.simpleMessage("PIN de camuflaje guardado"),
+    "camoPinTitle" : MessageLookupByLibrary.simpleMessage("Camuflajear el PIN"),
+    "camoSetupSubtitle" : MessageLookupByLibrary.simpleMessage("Ingrese el nuevo PIN de camuflaje"),
+    "camoSetupTitle" : MessageLookupByLibrary.simpleMessage("Configuración de PIN de camuflaje"),
+    "camouflageSetup" : MessageLookupByLibrary.simpleMessage("Configuración de PIN de camuflaje"),
+    "cancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "cancelActivation" : MessageLookupByLibrary.simpleMessage("Cancelar activación"),
+    "cancelActivationQuestion" : MessageLookupByLibrary.simpleMessage("¿Estás seguro de que deseas cancelar la activación?"),
+    "cancelButton" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "cancelOrder" : MessageLookupByLibrary.simpleMessage("Cancelar orden"),
+    "candleChartError" : MessageLookupByLibrary.simpleMessage("Algo salió mal. Vuelve a intentarlo más tarde."),
+    "cantDeleteDefaultCoinOk" : MessageLookupByLibrary.simpleMessage("Ok"),
+    "cantDeleteDefaultCoinSpan" : MessageLookupByLibrary.simpleMessage("es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar."),
+    "cantDeleteDefaultCoinTitle" : MessageLookupByLibrary.simpleMessage("No se puede deshabilitar"),
+    "cex" : MessageLookupByLibrary.simpleMessage("CEX"),
+    "cexChangeRate" : MessageLookupByLibrary.simpleMessage("Tasa de Cambio CEX"),
+    "cexData" : MessageLookupByLibrary.simpleMessage("data de CEX"),
+    "cexDataDesc" : MessageLookupByLibrary.simpleMessage("Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>)."),
+    "cexRate" : MessageLookupByLibrary.simpleMessage("Tasa CEX"),
+    "changePin" : MessageLookupByLibrary.simpleMessage("Cambiar código PIN"),
+    "checkForUpdates" : MessageLookupByLibrary.simpleMessage("Buscar actualizaciones"),
+    "checkOut" : MessageLookupByLibrary.simpleMessage("Verificar"),
+    "checkSeedPhrase" : MessageLookupByLibrary.simpleMessage("Comprobar la frase inicial"),
+    "checkSeedPhraseButton1" : MessageLookupByLibrary.simpleMessage("SEGUIR"),
+    "checkSeedPhraseButton2" : MessageLookupByLibrary.simpleMessage("VOLVER Y VERIFICAR DE NUEVO"),
+    "checkSeedPhraseHint" : m20,
+    "checkSeedPhraseInfo" : MessageLookupByLibrary.simpleMessage("Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee."),
+    "checkSeedPhraseSubtile" : m21,
+    "checkSeedPhraseTitle" : MessageLookupByLibrary.simpleMessage("VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA"),
+    "chineseLanguage" : MessageLookupByLibrary.simpleMessage("Chino"),
+    "claim" : MessageLookupByLibrary.simpleMessage("afirmar"),
+    "claimTitle" : MessageLookupByLibrary.simpleMessage("¿Reclamar su recompensa KMD?"),
+    "clickToSee" : MessageLookupByLibrary.simpleMessage("Clic para ver"),
+    "clipboard" : MessageLookupByLibrary.simpleMessage("Copiado al portapapeles"),
+    "clipboardCopy" : MessageLookupByLibrary.simpleMessage("Copiar al portapapeles"),
+    "close" : MessageLookupByLibrary.simpleMessage("Cerrar"),
+    "closeMessage" : MessageLookupByLibrary.simpleMessage("Cerrar mensaje de error"),
+    "closePreview" : MessageLookupByLibrary.simpleMessage("Cerrar prevista"),
+    "code" : MessageLookupByLibrary.simpleMessage("Código:"),
+    "cofirmCancelActivation" : MessageLookupByLibrary.simpleMessage("¿Estás seguro de que deseas cancelar la activación?"),
+    "coinSelectClear" : MessageLookupByLibrary.simpleMessage("Remover"),
+    "coinSelectNotFound" : MessageLookupByLibrary.simpleMessage("No hay monedas activas"),
+    "coinSelectTitle" : MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
+    "coinsActivatedLimitReached" : MessageLookupByLibrary.simpleMessage("Ha seleccionado el número máximo de activos"),
+    "coinsAreActivated" : m22,
+    "coinsAreActivatedSuccessfully" : m23,
+    "coinsAreNotActivated" : m24,
+    "comingSoon" : MessageLookupByLibrary.simpleMessage("Próximamente..."),
+    "commingsoon" : MessageLookupByLibrary.simpleMessage("Detalles de TX próximamente!"),
+    "commingsoonGeneral" : MessageLookupByLibrary.simpleMessage("¡Detalles muy pronto!"),
+    "commissionFee" : MessageLookupByLibrary.simpleMessage("cuota de comisión"),
+    "comparedTo24hrCex" : MessageLookupByLibrary.simpleMessage("en comparación con el promedio Precio CEX 24h"),
+    "comparedToCex" : MessageLookupByLibrary.simpleMessage("comparable a CEX"),
+    "configureWallet" : MessageLookupByLibrary.simpleMessage("Configurando su billetera, por favor espere..."),
+    "confirm" : MessageLookupByLibrary.simpleMessage("Confirmar"),
+    "confirmCamouflageSetup" : MessageLookupByLibrary.simpleMessage("Confirmar PIN de camuflaje"),
+    "confirmCancel" : MessageLookupByLibrary.simpleMessage("¿Está seguro de que desea cancelar el pedido?"),
+    "confirmPassword" : MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
+    "confirmPin" : MessageLookupByLibrary.simpleMessage("Confirmar código PIN"),
+    "confirmSeed" : MessageLookupByLibrary.simpleMessage("Confirmar frase semilla"),
+    "confirmeula" : MessageLookupByLibrary.simpleMessage("Al hacer clic en los botones a continuación, confirma haber leído el \'EULA\' y los \'Términos y condiciones\' y acepta estos"),
+    "connecting" : MessageLookupByLibrary.simpleMessage("Conectando..."),
+    "contactCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "contactDelete" : MessageLookupByLibrary.simpleMessage("Borrar Contacto"),
+    "contactDeleteBtn" : MessageLookupByLibrary.simpleMessage("Borrar"),
+    "contactDeleteWarning" : m25,
+    "contactDiscardBtn" : MessageLookupByLibrary.simpleMessage("Descartar"),
+    "contactEdit" : MessageLookupByLibrary.simpleMessage("Editar"),
+    "contactExit" : MessageLookupByLibrary.simpleMessage("Salir"),
+    "contactExitWarning" : MessageLookupByLibrary.simpleMessage("Descartar tus cambios?"),
+    "contactNotFound" : MessageLookupByLibrary.simpleMessage("No se encontraron contactos"),
+    "contactSave" : MessageLookupByLibrary.simpleMessage("Guardar"),
+    "contactTitle" : MessageLookupByLibrary.simpleMessage("Detalles de contacto"),
+    "contactTitleName" : MessageLookupByLibrary.simpleMessage("Nombre"),
+    "contract" : MessageLookupByLibrary.simpleMessage("Contrato"),
+    "convert" : MessageLookupByLibrary.simpleMessage("Convertir"),
+    "couldNotLaunchUrl" : MessageLookupByLibrary.simpleMessage("No se pudo iniciar la URL"),
+    "couldntImportError" : MessageLookupByLibrary.simpleMessage("No se pudo importar:"),
+    "create" : MessageLookupByLibrary.simpleMessage("intercambiar"),
+    "createAWallet" : MessageLookupByLibrary.simpleMessage("CREAR UNA CARTERA"),
+    "createContact" : MessageLookupByLibrary.simpleMessage("Crear Contacto"),
+    "createPin" : MessageLookupByLibrary.simpleMessage("Crear numero PIN"),
+    "currency" : MessageLookupByLibrary.simpleMessage("Moneda"),
+    "currencyDialogTitle" : MessageLookupByLibrary.simpleMessage("Moneda"),
+    "currentValue" : MessageLookupByLibrary.simpleMessage("Valor actual:"),
+    "customFee" : MessageLookupByLibrary.simpleMessage("Costo de Transacción Personalizado"),
+    "customFeeWarning" : MessageLookupByLibrary.simpleMessage("¡Solo use tarifas personalizadas si sabe lo que está haciendo!"),
+    "customSeedWarning" : m26,
+    "dPow" : MessageLookupByLibrary.simpleMessage("Seguridad de Komodo dPoW"),
+    "date" : MessageLookupByLibrary.simpleMessage("Fecha"),
+    "decryptingWallet" : MessageLookupByLibrary.simpleMessage("Billetera de descifrado"),
+    "delete" : MessageLookupByLibrary.simpleMessage("Borrar"),
+    "deleteConfirm" : MessageLookupByLibrary.simpleMessage("Confirmar desactivación"),
+    "deleteSpan1" : MessageLookupByLibrary.simpleMessage("¿Quieres eliminar"),
+    "deleteSpan2" : MessageLookupByLibrary.simpleMessage("de tu cartera? Todos los pedidos no emparejados serán cancelados."),
+    "deleteSpan3" : MessageLookupByLibrary.simpleMessage(" también se desactivará"),
+    "deleteWallet" : MessageLookupByLibrary.simpleMessage("Eliminar Billetera"),
+    "deletingWallet" : MessageLookupByLibrary.simpleMessage("Eliminando billetera..."),
+    "detailedFeesReceiveCoinTransactionFee" : m27,
+    "detailedFeesSendCoinTransactionFee" : m28,
+    "detailedFeesSendTradingFeeTransactionFee" : MessageLookupByLibrary.simpleMessage("enviar tarifa comercial tarifa de transacción"),
+    "detailedFeesTradingFee" : MessageLookupByLibrary.simpleMessage("tarifa comercial"),
+    "details" : MessageLookupByLibrary.simpleMessage("detalles"),
+    "deutscheLanguage" : MessageLookupByLibrary.simpleMessage("Alemán"),
+    "developerTitle" : MessageLookupByLibrary.simpleMessage("Desarrollador"),
+    "dex" : MessageLookupByLibrary.simpleMessage("DEX"),
+    "dexIsNotAvailable" : MessageLookupByLibrary.simpleMessage("DEX no está disponible para esta moneda"),
+    "disableScreenshots" : MessageLookupByLibrary.simpleMessage("Desactivar capturas de pantalla/vista previa"),
+    "disclaimerAndTos" : MessageLookupByLibrary.simpleMessage("Descargo de responsabilidad y condiciones de servicio"),
+    "doNotCloseTheAppTapForMoreInfo" : MessageLookupByLibrary.simpleMessage("No cierres la aplicación. Toca para obtener más información..."),
+    "done" : MessageLookupByLibrary.simpleMessage("Hecho"),
+    "dontAskAgain" : MessageLookupByLibrary.simpleMessage("No vuelvas a preguntar"),
+    "dontWantPassword" : MessageLookupByLibrary.simpleMessage("no quiero una contraseña"),
+    "duration" : MessageLookupByLibrary.simpleMessage("Duración"),
+    "editContact" : MessageLookupByLibrary.simpleMessage("Editar contacto"),
+    "emptyCoin" : m29,
+    "emptyExportPass" : MessageLookupByLibrary.simpleMessage("La contraseña de cifrado no puede estar vacía"),
+    "emptyImportPass" : MessageLookupByLibrary.simpleMessage("La contraseña no puede estar vacía"),
+    "emptyName" : MessageLookupByLibrary.simpleMessage("El nombre del contacto no puede estar vacío"),
+    "emptyWallet" : MessageLookupByLibrary.simpleMessage("El nombre de la billetera no debe estar vacío"),
+    "enableNotificationsForActivationProgress" : MessageLookupByLibrary.simpleMessage("Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación."),
+    "enableTestCoins" : MessageLookupByLibrary.simpleMessage("Habilitar monedas de prueba"),
+    "enablingTooManyAssetsSpan1" : MessageLookupByLibrary.simpleMessage("Tu tienes"),
+    "enablingTooManyAssetsSpan2" : MessageLookupByLibrary.simpleMessage("activos habilitados y tratando de habilitar"),
+    "enablingTooManyAssetsSpan3" : MessageLookupByLibrary.simpleMessage("más. El límite máximo de activos habilitados es"),
+    "enablingTooManyAssetsSpan4" : MessageLookupByLibrary.simpleMessage(". Desactive algunos antes de agregar otros nuevos."),
+    "enablingTooManyAssetsTitle" : MessageLookupByLibrary.simpleMessage("Intentando habilitar demasiados activos"),
+    "encryptingWallet" : MessageLookupByLibrary.simpleMessage("Billetera cifrada"),
+    "englishLanguage" : MessageLookupByLibrary.simpleMessage("Inglés"),
+    "enterNewPinCode" : MessageLookupByLibrary.simpleMessage("Ingrese su nuevo PIN"),
+    "enterOldPinCode" : MessageLookupByLibrary.simpleMessage("Ingrese su antiguo PIN"),
+    "enterPinCode" : MessageLookupByLibrary.simpleMessage("Ingresa tu numero PIN"),
+    "enterSeedPhrase" : MessageLookupByLibrary.simpleMessage("Ingrese su Semilla de 12 palabras"),
+    "enterSellAmount" : MessageLookupByLibrary.simpleMessage("Primero debe ingresar el monto de la venta"),
+    "enterpassword" : MessageLookupByLibrary.simpleMessage("Por favor ingrese su contraseña para continuar."),
+    "errorAmountBalance" : MessageLookupByLibrary.simpleMessage("No hay suficiente equilibrio"),
+    "errorNotAValidAddress" : MessageLookupByLibrary.simpleMessage("No es una dirección válida"),
+    "errorNotAValidAddressSegWit" : MessageLookupByLibrary.simpleMessage("Las direcciones de Segwit no son compatibles (todavía)"),
+    "errorNotEnoughGas" : m31,
+    "errorTryAgain" : MessageLookupByLibrary.simpleMessage("Error, inténtalo de nuevo"),
+    "errorTryLater" : MessageLookupByLibrary.simpleMessage("Error, intente más tarde"),
+    "errorValueEmpty" : MessageLookupByLibrary.simpleMessage("El valor es demasiado alto o bajo"),
+    "errorValueNotEmpty" : MessageLookupByLibrary.simpleMessage("Por favor ingrese datos"),
+    "estimateValue" : MessageLookupByLibrary.simpleMessage("Valor total estimado"),
+    "eulaParagraphe1" : m32,
+    "eulaParagraphe10" : m33,
+    "eulaParagraphe11" : m34,
+    "eulaParagraphe12" : MessageLookupByLibrary.simpleMessage("When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
+    "eulaParagraphe13" : m35,
+    "eulaParagraphe14" : m36,
+    "eulaParagraphe15" : m37,
+    "eulaParagraphe16" : m38,
+    "eulaParagraphe17" : m39,
+    "eulaParagraphe18" : m40,
+    "eulaParagraphe19" : m41,
+    "eulaParagraphe2" : m42,
+    "eulaParagraphe3" : MessageLookupByLibrary.simpleMessage("By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
+    "eulaParagraphe4" : MessageLookupByLibrary.simpleMessage("We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
+    "eulaParagraphe5" : m43,
+    "eulaParagraphe6" : m44,
+    "eulaParagraphe7" : MessageLookupByLibrary.simpleMessage("We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
+    "eulaParagraphe8" : MessageLookupByLibrary.simpleMessage("You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
+    "eulaParagraphe9" : MessageLookupByLibrary.simpleMessage("We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
+    "eulaTitle1" : m45,
+    "eulaTitle10" : MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
+    "eulaTitle11" : MessageLookupByLibrary.simpleMessage("INTELLECTUAL PROPERTY RIGHTS"),
+    "eulaTitle12" : MessageLookupByLibrary.simpleMessage("DISCLAIMER"),
+    "eulaTitle13" : MessageLookupByLibrary.simpleMessage("REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY"),
+    "eulaTitle14" : MessageLookupByLibrary.simpleMessage("GENERAL RISK FACTORS"),
+    "eulaTitle15" : MessageLookupByLibrary.simpleMessage("INDEMNIFICATION"),
+    "eulaTitle16" : MessageLookupByLibrary.simpleMessage("RISK DISCLOSURES RELATING TO THE WALLET"),
+    "eulaTitle17" : MessageLookupByLibrary.simpleMessage("NO INVESTMENT ADVICE OR BROKERAGE"),
+    "eulaTitle18" : MessageLookupByLibrary.simpleMessage("TERMINATION"),
+    "eulaTitle19" : MessageLookupByLibrary.simpleMessage("THIRD PARTY RIGHTS"),
+    "eulaTitle2" : MessageLookupByLibrary.simpleMessage("TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)"),
+    "eulaTitle20" : MessageLookupByLibrary.simpleMessage("OUR LEGAL OBLIGATIONS"),
+    "eulaTitle3" : MessageLookupByLibrary.simpleMessage("TERMS AND CONDITIONS OF USE AND DISCLAIMER"),
+    "eulaTitle4" : MessageLookupByLibrary.simpleMessage("GENERAL USE"),
+    "eulaTitle5" : MessageLookupByLibrary.simpleMessage("MODIFICATIONS"),
+    "eulaTitle6" : MessageLookupByLibrary.simpleMessage("LIMITATIONS ON USE"),
+    "eulaTitle7" : MessageLookupByLibrary.simpleMessage("ACCOUNTS AND MEMBERSHIP"),
+    "eulaTitle8" : MessageLookupByLibrary.simpleMessage("BACKUPS"),
+    "eulaTitle9" : MessageLookupByLibrary.simpleMessage("GENERAL WARNING"),
+    "exampleHintSeed" : MessageLookupByLibrary.simpleMessage("Ejemplo: build case level ..."),
+    "exchangeExpedient" : MessageLookupByLibrary.simpleMessage("Expediente"),
+    "exchangeExpensive" : MessageLookupByLibrary.simpleMessage("Caro"),
+    "exchangeIdentical" : MessageLookupByLibrary.simpleMessage("Identico a CEX"),
+    "exchangeRate" : MessageLookupByLibrary.simpleMessage("Tipo de cambio:"),
+    "exchangeTitle" : MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
+    "exportButton" : MessageLookupByLibrary.simpleMessage("Exportar"),
+    "exportContactsTitle" : MessageLookupByLibrary.simpleMessage("Contactos"),
+    "exportDesc" : MessageLookupByLibrary.simpleMessage("Seleccione elementos para exportar a un archivo cifrado."),
+    "exportLink" : MessageLookupByLibrary.simpleMessage("Exportar"),
+    "exportNotesTitle" : MessageLookupByLibrary.simpleMessage("Notas"),
+    "exportSuccessTitle" : MessageLookupByLibrary.simpleMessage("Los elementos se han exportado correctamente:"),
+    "exportSwapsTitle" : MessageLookupByLibrary.simpleMessage("Intercambios"),
+    "exportTitle" : MessageLookupByLibrary.simpleMessage("Exportar"),
+    "fakeBalanceAmt" : MessageLookupByLibrary.simpleMessage("Cantidad de saldo falso:"),
+    "faqTitle" : MessageLookupByLibrary.simpleMessage("Preguntas frecuentes"),
+    "faucetError" : MessageLookupByLibrary.simpleMessage("Error"),
+    "faucetInProgress" : m46,
+    "faucetName" : MessageLookupByLibrary.simpleMessage("GRIFO"),
+    "faucetSuccess" : MessageLookupByLibrary.simpleMessage("Éxito"),
+    "faucetTimedOut" : MessageLookupByLibrary.simpleMessage("Tiempo de espera agotado"),
+    "feedNewsTab" : MessageLookupByLibrary.simpleMessage("Noticias"),
+    "feedNotFound" : MessageLookupByLibrary.simpleMessage("Nada aquí"),
+    "feedNotifTitle" : m47,
+    "feedReadMore" : MessageLookupByLibrary.simpleMessage("Leer más..."),
+    "feedTab" : MessageLookupByLibrary.simpleMessage("Informacion"),
+    "feedTitle" : MessageLookupByLibrary.simpleMessage("Noticias"),
+    "feedUnableToProceed" : MessageLookupByLibrary.simpleMessage("No se puede continuar con la actualización de noticias"),
+    "feedUnableToUpdate" : MessageLookupByLibrary.simpleMessage("No se puede obtener la actualización de noticias"),
+    "feedUpToDate" : MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
+    "feedUpdated" : MessageLookupByLibrary.simpleMessage("Fuente de noticias actualizada"),
+    "feedback" : MessageLookupByLibrary.simpleMessage("Compartir archivo de registro"),
+    "feesError" : m48,
+    "filtersAll" : MessageLookupByLibrary.simpleMessage("Todo"),
+    "filtersButton" : MessageLookupByLibrary.simpleMessage("Filtro"),
+    "filtersClearAll" : MessageLookupByLibrary.simpleMessage("Borrar todos los filtros"),
+    "filtersFailed" : MessageLookupByLibrary.simpleMessage("Fallido"),
+    "filtersFrom" : MessageLookupByLibrary.simpleMessage("Partir de la fecha"),
+    "filtersMaker" : MessageLookupByLibrary.simpleMessage("Vendedor"),
+    "filtersReceive" : MessageLookupByLibrary.simpleMessage("Recibir moneda"),
+    "filtersSell" : MessageLookupByLibrary.simpleMessage("Vender moneda"),
+    "filtersStatus" : MessageLookupByLibrary.simpleMessage("Estado"),
+    "filtersSuccessful" : MessageLookupByLibrary.simpleMessage("Exitoso"),
+    "filtersTaker" : MessageLookupByLibrary.simpleMessage("Comprador"),
+    "filtersTo" : MessageLookupByLibrary.simpleMessage("Hasta la fecha"),
+    "filtersType" : MessageLookupByLibrary.simpleMessage("Comprador/Vendedor"),
+    "fingerprint" : MessageLookupByLibrary.simpleMessage("Huella dactilar"),
+    "finishingUp" : MessageLookupByLibrary.simpleMessage("Terminando, por favor espera."),
+    "foundQrCode" : MessageLookupByLibrary.simpleMessage("Código QR encontrado"),
+    "frenchLanguage" : MessageLookupByLibrary.simpleMessage("Francés"),
+    "from" : MessageLookupByLibrary.simpleMessage("Desde"),
+    "futureTransactions" : MessageLookupByLibrary.simpleMessage("Sincronizaremos las transacciones futuras realizadas después de la activación asociada con su clave pública. Esta es la opción más rápida y ocupa la menor cantidad de almacenamiento."),
+    "gasFee" : m49,
+    "gasLimit" : MessageLookupByLibrary.simpleMessage("Limite de Gas"),
+    "gasNotActive" : m50,
+    "gasPrice" : MessageLookupByLibrary.simpleMessage("Precio de Gas"),
+    "generalPinNotActive" : MessageLookupByLibrary.simpleMessage("La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN."),
+    "getBackupPhrase" : MessageLookupByLibrary.simpleMessage("Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!"),
+    "gettingTxWait" : MessageLookupByLibrary.simpleMessage("Obteniendo transacción, por favor espere"),
+    "goToPorfolio" : MessageLookupByLibrary.simpleMessage("Ir al portafolio"),
+    "helpLink" : MessageLookupByLibrary.simpleMessage("Ayuda"),
+    "helpTitle" : MessageLookupByLibrary.simpleMessage("Ayuda y apoyo"),
+    "hideBalance" : MessageLookupByLibrary.simpleMessage("Ocultar saldos"),
+    "hintConfirmPassword" : MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
+    "hintCreatePassword" : MessageLookupByLibrary.simpleMessage("Crear contraseña"),
+    "hintCurrentPassword" : MessageLookupByLibrary.simpleMessage("Contraseña actual"),
+    "hintEnterPassword" : MessageLookupByLibrary.simpleMessage("Ingresa tu contraseña"),
+    "hintEnterSeedPhrase" : MessageLookupByLibrary.simpleMessage("Ingrese su frase inicial"),
+    "hintNameYourWallet" : MessageLookupByLibrary.simpleMessage("Nombra tu billetera"),
+    "hintPassword" : MessageLookupByLibrary.simpleMessage("Clave"),
+    "history" : MessageLookupByLibrary.simpleMessage("historia"),
+    "hours" : MessageLookupByLibrary.simpleMessage("h"),
+    "hungarianLanguage" : MessageLookupByLibrary.simpleMessage("Húngaro"),
+    "iUnderstand" : MessageLookupByLibrary.simpleMessage("Entiendo"),
+    "importButton" : MessageLookupByLibrary.simpleMessage("Importar"),
+    "importDecryptError" : MessageLookupByLibrary.simpleMessage("Contraseña no válida o datos dañados"),
+    "importDesc" : MessageLookupByLibrary.simpleMessage("Elementos a importar:"),
+    "importFileNotFound" : MessageLookupByLibrary.simpleMessage("Archivo no encontrado"),
+    "importInvalidSwapData" : MessageLookupByLibrary.simpleMessage("Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido."),
+    "importLink" : MessageLookupByLibrary.simpleMessage("Importar"),
+    "importLoadDesc" : MessageLookupByLibrary.simpleMessage("Seleccione el archivo cifrado para importar."),
+    "importLoadSwapDesc" : MessageLookupByLibrary.simpleMessage("Seleccione el archivo de intercambio de texto sin formato para importar."),
+    "importLoading" : MessageLookupByLibrary.simpleMessage("Abriendo..."),
+    "importPassCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "importPassOk" : MessageLookupByLibrary.simpleMessage("Ok"),
+    "importPassword" : MessageLookupByLibrary.simpleMessage("Clave"),
+    "importSingleSwapLink" : MessageLookupByLibrary.simpleMessage("Importar un Intercambio"),
+    "importSingleSwapTitle" : MessageLookupByLibrary.simpleMessage("Importar Intercambio"),
+    "importSomeItemsSkippedWarning" : MessageLookupByLibrary.simpleMessage("Se han saltado algunos elementos"),
+    "importSuccessTitle" : MessageLookupByLibrary.simpleMessage("Los elementos se han importado correctamente:"),
+    "importSwapFailed" : MessageLookupByLibrary.simpleMessage("No se pudo importar el intercambio"),
+    "importSwapJsonDecodingError" : MessageLookupByLibrary.simpleMessage("Error al decodificar el archivo json"),
+    "importTitle" : MessageLookupByLibrary.simpleMessage("Importar"),
+    "incomingTransactionsProtectionSettings" : m52,
+    "infoPasswordDialog" : MessageLookupByLibrary.simpleMessage("Utilice una contraseña segura y no la almacene en el mismo dispositivo"),
+    "infoTrade1" : MessageLookupByLibrary.simpleMessage("¡La solicitud de intercambio no se puede deshacer y es un evento final!"),
+    "infoTrade2" : MessageLookupByLibrary.simpleMessage("El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!"),
+    "infoWalletPassword" : MessageLookupByLibrary.simpleMessage("Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad."),
+    "insufficientBalanceToPay" : m53,
+    "insufficientText" : MessageLookupByLibrary.simpleMessage("El volumen mínimo requerido por este pedido es"),
+    "insufficientTitle" : MessageLookupByLibrary.simpleMessage("Volumen insuficiente"),
+    "internetRefreshButton" : MessageLookupByLibrary.simpleMessage("Actualizar"),
+    "internetRestored" : MessageLookupByLibrary.simpleMessage("Conexión a Internet restaurada"),
+    "invalidSwap" : MessageLookupByLibrary.simpleMessage("No se puede continuar con el intercambio"),
+    "invalidSwapDetailsLink" : MessageLookupByLibrary.simpleMessage("Detalles"),
+    "isUnavailable" : m55,
+    "japaneseLanguage" : MessageLookupByLibrary.simpleMessage("Japonés"),
+    "koreanLanguage" : MessageLookupByLibrary.simpleMessage("Coreano"),
+    "language" : MessageLookupByLibrary.simpleMessage("Idioma"),
+    "latestTxs" : MessageLookupByLibrary.simpleMessage("Últimas transacciones"),
+    "legalTitle" : MessageLookupByLibrary.simpleMessage("Legal"),
+    "less" : MessageLookupByLibrary.simpleMessage("menos"),
+    "lessThanCaution" : m56,
+    "loading" : MessageLookupByLibrary.simpleMessage("Cargando..."),
+    "loadingOrderbook" : MessageLookupByLibrary.simpleMessage("Cargando libro de ordenes..."),
+    "lockScreen" : MessageLookupByLibrary.simpleMessage("La pantalla está bloqueada"),
+    "lockScreenAuth" : MessageLookupByLibrary.simpleMessage("¡Por favor, autentícate!"),
+    "login" : MessageLookupByLibrary.simpleMessage("acceso"),
+    "logout" : MessageLookupByLibrary.simpleMessage("Cerrar sesión"),
+    "logoutOnExit" : MessageLookupByLibrary.simpleMessage("Cerrar sesión al salir"),
+    "logoutWarning" : MessageLookupByLibrary.simpleMessage("¿Estás seguro de que quieres cerrar sesión ahora?"),
+    "logoutsettings" : MessageLookupByLibrary.simpleMessage("Configuración de cierre de sesión"),
+    "longMinutes" : MessageLookupByLibrary.simpleMessage("Minutos"),
+    "makeAorder" : MessageLookupByLibrary.simpleMessage("hacer un pedido"),
+    "makerDetailsCancel" : MessageLookupByLibrary.simpleMessage("Cancelar orden"),
+    "makerDetailsCreated" : MessageLookupByLibrary.simpleMessage("Createdo en"),
+    "makerDetailsFor" : MessageLookupByLibrary.simpleMessage("Recibir"),
+    "makerDetailsId" : MessageLookupByLibrary.simpleMessage("ID de Orden"),
+    "makerDetailsNoSwaps" : MessageLookupByLibrary.simpleMessage("Este pedido no inició intercambios"),
+    "makerDetailsPrice" : MessageLookupByLibrary.simpleMessage("Precio"),
+    "makerDetailsSell" : MessageLookupByLibrary.simpleMessage("Vender"),
+    "makerDetailsSwaps" : MessageLookupByLibrary.simpleMessage("Intercambios iniciados por este pedido"),
+    "makerDetailsTitle" : MessageLookupByLibrary.simpleMessage("Detalles del pedido del fabricante"),
+    "makerOrder" : MessageLookupByLibrary.simpleMessage("Orden de Vendedor"),
+    "marketplace" : MessageLookupByLibrary.simpleMessage("Mercado"),
+    "marketsChart" : MessageLookupByLibrary.simpleMessage("Gráfico"),
+    "marketsDepth" : MessageLookupByLibrary.simpleMessage("Profundidad"),
+    "marketsNoAsks" : MessageLookupByLibrary.simpleMessage("No se encontraron solicitudes"),
+    "marketsNoBids" : MessageLookupByLibrary.simpleMessage("No se encontraron ofertas"),
+    "marketsOrderDetails" : MessageLookupByLibrary.simpleMessage("Detalles del Pedido"),
+    "marketsOrderbook" : MessageLookupByLibrary.simpleMessage("LIBRO DE ORDENES"),
+    "marketsPrice" : MessageLookupByLibrary.simpleMessage("PRECIO"),
+    "marketsSelectCoins" : MessageLookupByLibrary.simpleMessage("Por favor seleccione monedas"),
+    "marketsTab" : MessageLookupByLibrary.simpleMessage("Mercados"),
+    "marketsTitle" : MessageLookupByLibrary.simpleMessage("MERCADOS"),
+    "matchExportPass" : MessageLookupByLibrary.simpleMessage("Las contraseñas deben coincidir"),
+    "matchingCamoChange" : MessageLookupByLibrary.simpleMessage("Cambiar"),
+    "matchingCamoPinError" : MessageLookupByLibrary.simpleMessage("Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje."),
+    "matchingCamoTitle" : MessageLookupByLibrary.simpleMessage("PIN Invalido"),
+    "max" : MessageLookupByLibrary.simpleMessage("MAXIMO"),
+    "maxOrder" : MessageLookupByLibrary.simpleMessage("Volumen máximo de pedidos:"),
+    "media" : MessageLookupByLibrary.simpleMessage("Noticias"),
+    "mediaBrowse" : MessageLookupByLibrary.simpleMessage("NAVEGAR"),
+    "mediaBrowseFeed" : MessageLookupByLibrary.simpleMessage("NAVEGAR RSS"),
+    "mediaBy" : MessageLookupByLibrary.simpleMessage("By"),
+    "mediaNotSavedDescription" : MessageLookupByLibrary.simpleMessage("NO TIENES ARTÍCULOS GUARDADOS"),
+    "mediaSaved" : MessageLookupByLibrary.simpleMessage("GUARDADO"),
+    "memo" : MessageLookupByLibrary.simpleMessage("Memorándum"),
+    "merge" : MessageLookupByLibrary.simpleMessage("Unir"),
+    "mergedValue" : MessageLookupByLibrary.simpleMessage("Valor combinado:"),
+    "milliseconds" : MessageLookupByLibrary.simpleMessage("ms"),
+    "min" : MessageLookupByLibrary.simpleMessage("Min"),
+    "minOrder" : MessageLookupByLibrary.simpleMessage("Volumen mínimo de pedido:"),
+    "minValue" : m58,
+    "minValueBuy" : m59,
+    "minValueOrder" : m60,
+    "minValueSell" : m61,
+    "minVolumeInput" : m62,
+    "minVolumeIsTDH" : MessageLookupByLibrary.simpleMessage("Debe ser menor que el monto de venta"),
+    "minVolumeTitle" : MessageLookupByLibrary.simpleMessage("Volumen mínimo requerido"),
+    "minVolumeToggle" : MessageLookupByLibrary.simpleMessage("Usar volumen mínimo personalizado"),
+    "minimizingWillTerminate" : MessageLookupByLibrary.simpleMessage("Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación."),
+    "minutes" : MessageLookupByLibrary.simpleMessage("m"),
+    "mobileDataWarning" : m63,
+    "moreInfo" : MessageLookupByLibrary.simpleMessage("Más información"),
+    "moreTab" : MessageLookupByLibrary.simpleMessage("Mas"),
+    "multiActivateGas" : m64,
+    "multiBaseAmtPlaceholder" : MessageLookupByLibrary.simpleMessage("Cantidad"),
+    "multiBasePlaceholder" : MessageLookupByLibrary.simpleMessage("Moneda"),
+    "multiBaseSelectTitle" : MessageLookupByLibrary.simpleMessage("Vender"),
+    "multiConfirmCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "multiConfirmConfirm" : MessageLookupByLibrary.simpleMessage("Confirmar"),
+    "multiConfirmTitle" : m65,
+    "multiCreate" : MessageLookupByLibrary.simpleMessage("Crear"),
+    "multiCreateOrder" : MessageLookupByLibrary.simpleMessage("Orden"),
+    "multiCreateOrders" : MessageLookupByLibrary.simpleMessage("Ordenes"),
+    "multiEthFee" : MessageLookupByLibrary.simpleMessage("costo"),
+    "multiFiatCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "multiFiatDesc" : MessageLookupByLibrary.simpleMessage("Ingrese la cantidad de dinero para recibir:"),
+    "multiFiatFill" : MessageLookupByLibrary.simpleMessage("Autollenarl"),
+    "multiFixErrors" : MessageLookupByLibrary.simpleMessage("Corrija todos los errores antes de continuar"),
+    "multiInvalidAmt" : MessageLookupByLibrary.simpleMessage("Monto invalido"),
+    "multiInvalidSellAmt" : MessageLookupByLibrary.simpleMessage("Cantidad de venta no válido"),
+    "multiLowGas" : m66,
+    "multiLowerThanFee" : m67,
+    "multiMaxSellAmt" : MessageLookupByLibrary.simpleMessage("La cantidad máxima de venta es"),
+    "multiMinReceiveAmt" : MessageLookupByLibrary.simpleMessage("La cantidad mínima recibida es"),
+    "multiMinSellAmt" : MessageLookupByLibrary.simpleMessage("La cantidad mínima de venta es"),
+    "multiReceiveTitle" : MessageLookupByLibrary.simpleMessage("Recibir:"),
+    "multiSellTitle" : MessageLookupByLibrary.simpleMessage("Vender:"),
+    "multiTab" : MessageLookupByLibrary.simpleMessage("Multi"),
+    "multiTableAmt" : MessageLookupByLibrary.simpleMessage("Recibir Cntd."),
+    "multiTablePrice" : MessageLookupByLibrary.simpleMessage("Precio/CEX"),
+    "networkFee" : MessageLookupByLibrary.simpleMessage("Tarifa de red"),
+    "newAccount" : MessageLookupByLibrary.simpleMessage("nueva cuenta"),
+    "newAccountUpper" : MessageLookupByLibrary.simpleMessage("Nueva Cuenta"),
+    "newValue" : MessageLookupByLibrary.simpleMessage("Nuevo valor:"),
+    "newsFeed" : MessageLookupByLibrary.simpleMessage("Noticias"),
+    "next" : MessageLookupByLibrary.simpleMessage("próximo"),
+    "no" : MessageLookupByLibrary.simpleMessage("No"),
+    "noArticles" : MessageLookupByLibrary.simpleMessage("No hay noticias. Vuelva a consultar más tarde."),
+    "noCoinFound" : MessageLookupByLibrary.simpleMessage("No se encontró ninguna moneda"),
+    "noFunds" : MessageLookupByLibrary.simpleMessage("Sin Fondos"),
+    "noFundsDetected" : MessageLookupByLibrary.simpleMessage("No hay fondos disponibles, por favor deposite."),
+    "noInternet" : MessageLookupByLibrary.simpleMessage("Sin conexión a Internet"),
+    "noItemsToExport" : MessageLookupByLibrary.simpleMessage("No hay artículos seleccionados"),
+    "noItemsToImport" : MessageLookupByLibrary.simpleMessage("No hay artículos seleccionados"),
+    "noMatchingOrders" : MessageLookupByLibrary.simpleMessage("No se encontraron pedidos coincidentes"),
+    "noOrder" : m68,
+    "noOrderAvailable" : MessageLookupByLibrary.simpleMessage("Haga clic para crear un pedido"),
+    "noOrders" : MessageLookupByLibrary.simpleMessage("No hay pedidos, por favor vaya al comercio."),
+    "noRewardYet" : MessageLookupByLibrary.simpleMessage("No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora."),
+    "noRewards" : MessageLookupByLibrary.simpleMessage("No hay recompensas reclamables"),
+    "noSuchCoin" : MessageLookupByLibrary.simpleMessage("No hay tal moneda"),
+    "noSwaps" : MessageLookupByLibrary.simpleMessage("No historia."),
+    "noTxs" : MessageLookupByLibrary.simpleMessage("Sin transacciones"),
+    "nonNumericInput" : MessageLookupByLibrary.simpleMessage("El valor debe ser numérico."),
+    "none" : MessageLookupByLibrary.simpleMessage("Ninguno"),
+    "notEnoughGas" : m69,
+    "notEnoughtBalanceForFee" : MessageLookupByLibrary.simpleMessage("No hay suficiente saldo para las tarifas: opere con una cantidad menor"),
+    "noteOnOrder" : MessageLookupByLibrary.simpleMessage("Nota: el pedido emparejado no se puede cancelar de nuevo"),
+    "notePlaceholder" : MessageLookupByLibrary.simpleMessage("Añadir Nota"),
+    "noteTitle" : MessageLookupByLibrary.simpleMessage("Nota"),
+    "nothingFound" : MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
+    "notifSwapCompletedText" : m70,
+    "notifSwapCompletedTitle" : MessageLookupByLibrary.simpleMessage("Intercambio completado"),
+    "notifSwapFailedText" : m71,
+    "notifSwapFailedTitle" : MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
+    "notifSwapStartedText" : m72,
+    "notifSwapStartedTitle" : MessageLookupByLibrary.simpleMessage("Nuevo intercambio iniciado"),
+    "notifSwapStatusTitle" : MessageLookupByLibrary.simpleMessage("Cambio de estado cambiado"),
+    "notifSwapTimeoutText" : m73,
+    "notifSwapTimeoutTitle" : MessageLookupByLibrary.simpleMessage("Se agotó el tiempo de intercambio"),
+    "notifTxText" : m74,
+    "notifTxTitle" : MessageLookupByLibrary.simpleMessage("Transaccion entrante"),
+    "numberAssets" : m75,
+    "officialPressRelease" : MessageLookupByLibrary.simpleMessage("comunicado de prensa oficial"),
+    "okButton" : MessageLookupByLibrary.simpleMessage("Ok"),
+    "oldLogsDelete" : MessageLookupByLibrary.simpleMessage("Borrar"),
+    "oldLogsTitle" : MessageLookupByLibrary.simpleMessage("Registros antiguos"),
+    "oldLogsUsed" : MessageLookupByLibrary.simpleMessage("Espacio usado"),
+    "openMessage" : MessageLookupByLibrary.simpleMessage("Abrir mensaje de error"),
+    "orderBookLess" : MessageLookupByLibrary.simpleMessage("Menos"),
+    "orderBookMore" : MessageLookupByLibrary.simpleMessage("Más"),
+    "orderCancel" : m76,
+    "orderCreated" : MessageLookupByLibrary.simpleMessage("Pedido creado"),
+    "orderCreatedInfo" : MessageLookupByLibrary.simpleMessage("Pedido creado con éxito"),
+    "orderDetailsAddress" : MessageLookupByLibrary.simpleMessage("Direccion"),
+    "orderDetailsCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "orderDetailsExpedient" : m77,
+    "orderDetailsExpensive" : m78,
+    "orderDetailsFor" : MessageLookupByLibrary.simpleMessage("for"),
+    "orderDetailsIdentical" : MessageLookupByLibrary.simpleMessage("Idéntico a CEX"),
+    "orderDetailsMin" : MessageLookupByLibrary.simpleMessage("min."),
+    "orderDetailsPrice" : MessageLookupByLibrary.simpleMessage("Precio"),
+    "orderDetailsReceive" : MessageLookupByLibrary.simpleMessage("Recibir"),
+    "orderDetailsSelect" : MessageLookupByLibrary.simpleMessage("Seleccione"),
+    "orderDetailsSells" : MessageLookupByLibrary.simpleMessage("Ventas"),
+    "orderDetailsSettings" : MessageLookupByLibrary.simpleMessage("Abra detalles con un solo toque y seleccione Ordenar con un toque largo"),
+    "orderDetailsSpend" : MessageLookupByLibrary.simpleMessage("Gastar"),
+    "orderDetailsTitle" : MessageLookupByLibrary.simpleMessage("Detalles"),
+    "orderFilled" : m79,
+    "orderMatched" : MessageLookupByLibrary.simpleMessage("Orden Triangulada"),
+    "orderMatching" : MessageLookupByLibrary.simpleMessage("Triangulación de órdenes"),
+    "orderTypePartial" : MessageLookupByLibrary.simpleMessage("Orden"),
+    "orderTypeUnknown" : MessageLookupByLibrary.simpleMessage("Orden desconocida"),
+    "orders" : MessageLookupByLibrary.simpleMessage("ordenes"),
+    "ordersActive" : MessageLookupByLibrary.simpleMessage("Activo"),
+    "ordersHistory" : MessageLookupByLibrary.simpleMessage("Historial"),
+    "ordersTableAmount" : m80,
+    "ordersTablePrice" : m81,
+    "ordersTableTotal" : m82,
+    "overwrite" : MessageLookupByLibrary.simpleMessage("Sobrescribir"),
+    "ownOrder" : MessageLookupByLibrary.simpleMessage("Esta es tu propia orden!"),
+    "paidFromBalance" : MessageLookupByLibrary.simpleMessage("Pagado del saldo:"),
+    "paidFromVolume" : MessageLookupByLibrary.simpleMessage("Pagado del volumen recibido:"),
+    "paidWith" : MessageLookupByLibrary.simpleMessage("Pagado con"),
+    "passwordRequirement" : MessageLookupByLibrary.simpleMessage("La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial."),
+    "pastTransactionsFromDate" : MessageLookupByLibrary.simpleMessage("Su billetera mostrará sus transacciones pasadas realizadas después de la fecha especificada."),
+    "paymentUriDetailsAccept" : MessageLookupByLibrary.simpleMessage("Pagar"),
+    "paymentUriDetailsAcceptQuestion" : MessageLookupByLibrary.simpleMessage("¿Acepta esta transacción?"),
+    "paymentUriDetailsAddressSpan" : MessageLookupByLibrary.simpleMessage("A Direccion"),
+    "paymentUriDetailsAmountSpan" : MessageLookupByLibrary.simpleMessage("Monto:"),
+    "paymentUriDetailsCoinSpan" : MessageLookupByLibrary.simpleMessage("Moneda:"),
+    "paymentUriDetailsDeny" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "paymentUriDetailsTitle" : MessageLookupByLibrary.simpleMessage("Pago solicitado"),
+    "paymentUriInactiveCoin" : m83,
+    "placeOrder" : MessageLookupByLibrary.simpleMessage("Haga su pedido"),
+    "pleaseAddCoin" : MessageLookupByLibrary.simpleMessage("Por favor agregue una moneda"),
+    "pleaseRestart" : MessageLookupByLibrary.simpleMessage("Reinicie la aplicación para volver a intentarlo o presione el botón a continuación."),
+    "portfolio" : MessageLookupByLibrary.simpleMessage("Portfolio"),
+    "poweredOnKmd" : MessageLookupByLibrary.simpleMessage("Desarrollado por Komodo"),
+    "price" : MessageLookupByLibrary.simpleMessage("price"),
+    "privateKey" : MessageLookupByLibrary.simpleMessage("Llave Privada"),
+    "privateKeys" : MessageLookupByLibrary.simpleMessage("Llaves Privadas"),
+    "protectionCtrlConfirmations" : MessageLookupByLibrary.simpleMessage("Confirmaciones"),
+    "protectionCtrlCustom" : MessageLookupByLibrary.simpleMessage("Usar configuraciones de protección personalizadas"),
+    "protectionCtrlOff" : MessageLookupByLibrary.simpleMessage("DESACTIVADO"),
+    "protectionCtrlOn" : MessageLookupByLibrary.simpleMessage("ACTIVADO"),
+    "protectionCtrlWarning" : MessageLookupByLibrary.simpleMessage("Advertencia, este intercambio atómico no está protegido por dPoW."),
+    "pubkey" : MessageLookupByLibrary.simpleMessage("Llave Publica"),
+    "qrCodeScanner" : MessageLookupByLibrary.simpleMessage("Escáner de código QR"),
+    "question_1" : MessageLookupByLibrary.simpleMessage("¿Guardás mis llaves privadas?"),
+    "question_10" : m84,
+    "question_2" : m85,
+    "question_3" : MessageLookupByLibrary.simpleMessage("¿Cuánto tiempo toma cada intercambio atómico?"),
+    "question_4" : MessageLookupByLibrary.simpleMessage("¿Necesito estar en línea durante la duración del intercambio?"),
+    "question_5" : m86,
+    "question_6" : MessageLookupByLibrary.simpleMessage("¿Ofrecen soporte al usuario?"),
+    "question_7" : MessageLookupByLibrary.simpleMessage("¿Tiene restricciones de país?"),
+    "question_8" : m87,
+    "question_9" : m88,
+    "rebrandingAnnouncement" : MessageLookupByLibrary.simpleMessage("¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de \'AtomicDEX\' a \'Komodo Wallet\'"),
+    "receive" : MessageLookupByLibrary.simpleMessage("RECIBIR"),
+    "receiveLower" : MessageLookupByLibrary.simpleMessage("Recibir"),
+    "recommendSeedMessage" : MessageLookupByLibrary.simpleMessage("Recomendamos almacenarlo fuera de línea."),
+    "remove" : MessageLookupByLibrary.simpleMessage("Desactivar"),
+    "requestedTrade" : MessageLookupByLibrary.simpleMessage("Comercio solicitado"),
+    "reset" : MessageLookupByLibrary.simpleMessage("RESETEAR"),
+    "resetTitle" : MessageLookupByLibrary.simpleMessage("Restablecer formulario"),
+    "restoreWallet" : MessageLookupByLibrary.simpleMessage("RESTAURAR"),
+    "retryActivating" : MessageLookupByLibrary.simpleMessage("Volviendo a intentar activar todas las monedas..."),
+    "retryAll" : MessageLookupByLibrary.simpleMessage("Vuelva a intentar activar todo"),
+    "rewardsButton" : MessageLookupByLibrary.simpleMessage("Reclama tus recompensas"),
+    "rewardsCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
+    "rewardsError" : MessageLookupByLibrary.simpleMessage("Algo salió mal. Por favor, inténtelo de nuevo más tarde."),
+    "rewardsInProgressLong" : MessageLookupByLibrary.simpleMessage("La transacción está en curso"),
+    "rewardsInProgressShort" : MessageLookupByLibrary.simpleMessage("procesando"),
+    "rewardsLowAmountLong" : MessageLookupByLibrary.simpleMessage("Cantidad de UTXO inferior a 10 KMD"),
+    "rewardsLowAmountShort" : MessageLookupByLibrary.simpleMessage("<10 KMD"),
+    "rewardsOneHourLong" : MessageLookupByLibrary.simpleMessage("Aún no ha pasado una hora"),
+    "rewardsOneHourShort" : MessageLookupByLibrary.simpleMessage("<1 hora"),
+    "rewardsPopupOk" : MessageLookupByLibrary.simpleMessage("Ok"),
+    "rewardsPopupTitle" : MessageLookupByLibrary.simpleMessage("Estado de recompensas:"),
+    "rewardsReadMore" : MessageLookupByLibrary.simpleMessage("Obtenga más información sobre las recompensas para usuarios activos de KMD"),
+    "rewardsReceive" : MessageLookupByLibrary.simpleMessage("Recibir"),
+    "rewardsSuccess" : m89,
+    "rewardsTableFiat" : MessageLookupByLibrary.simpleMessage("Fiat"),
+    "rewardsTableRewards" : MessageLookupByLibrary.simpleMessage("Recompensas,\nKMD"),
+    "rewardsTableStatus" : MessageLookupByLibrary.simpleMessage("Estado"),
+    "rewardsTableTime" : MessageLookupByLibrary.simpleMessage("Tiempo\nrestante"),
+    "rewardsTableTitle" : MessageLookupByLibrary.simpleMessage("Información de recompensas:"),
+    "rewardsTableUXTO" : MessageLookupByLibrary.simpleMessage("UTXO\ncantidad,\nKMD"),
+    "rewardsTimeDays" : m90,
+    "rewardsTimeHours" : m91,
+    "rewardsTimeMin" : m92,
+    "rewardsTitle" : MessageLookupByLibrary.simpleMessage("Información de recompensas"),
+    "russianLanguage" : MessageLookupByLibrary.simpleMessage("Ruso"),
+    "saveMerged" : MessageLookupByLibrary.simpleMessage("Guardar combinado"),
+    "scrollToContinue" : MessageLookupByLibrary.simpleMessage("Desplácese hacia abajo para continuar..."),
+    "searchFilterCoin" : MessageLookupByLibrary.simpleMessage("Buscar una moneda"),
+    "searchFilterSubtitleAVX" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens de Avax"),
+    "searchFilterSubtitleBEP" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens BEP"),
+    "searchFilterSubtitleCosmos" : MessageLookupByLibrary.simpleMessage("Seleccionar todo Cosmos Network"),
+    "searchFilterSubtitleERC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens ERC"),
+    "searchFilterSubtitleETC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens ETC"),
+    "searchFilterSubtitleFTM" : MessageLookupByLibrary.simpleMessage("Seleccionar todas las fichas de Fantom"),
+    "searchFilterSubtitleHCO" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens de HecoChain"),
+    "searchFilterSubtitleHRC" : MessageLookupByLibrary.simpleMessage("Seleccionar todas las fichas de armonía"),
+    "searchFilterSubtitleIris" : MessageLookupByLibrary.simpleMessage("Seleccionar todo Iris Network"),
+    "searchFilterSubtitleKRC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens de Kucoin"),
+    "searchFilterSubtitleMVR" : MessageLookupByLibrary.simpleMessage("Seleccione todas las fichas de Moonriver"),
+    "searchFilterSubtitlePLG" : MessageLookupByLibrary.simpleMessage("Seleccione todas las fichas de polígono"),
+    "searchFilterSubtitleQRC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens QRC"),
+    "searchFilterSubtitleSBCH" : MessageLookupByLibrary.simpleMessage("Seleccione todos los tokens SmartBCH"),
+    "searchFilterSubtitleSLP" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens SLP"),
+    "searchFilterSubtitleSmartChain" : MessageLookupByLibrary.simpleMessage("Seleccione todos los SmartChains"),
+    "searchFilterSubtitleTestCoins" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los activos de prueba"),
+    "searchFilterSubtitleUBQ" : MessageLookupByLibrary.simpleMessage("Seleccionar todas las monedas Ubiq"),
+    "searchFilterSubtitleZHTLC" : MessageLookupByLibrary.simpleMessage("Seleccione todas las monedas ZHTLC"),
+    "searchFilterSubtitleutxo" : MessageLookupByLibrary.simpleMessage("Seleccione todas las monedas UTXO"),
+    "searchForTicker" : MessageLookupByLibrary.simpleMessage("Buscar teletipo"),
+    "seconds" : MessageLookupByLibrary.simpleMessage("s"),
+    "security" : MessageLookupByLibrary.simpleMessage("Seguridad"),
+    "seeOrders" : m93,
+    "seeTxHistory" : MessageLookupByLibrary.simpleMessage("Ver historial de transacciones"),
+    "seedPhrase" : MessageLookupByLibrary.simpleMessage("Frase Semilla"),
+    "seedPhraseTitle" : MessageLookupByLibrary.simpleMessage("Tu nueva frase semilla"),
+    "selectCoin" : MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
+    "selectCoinInfo" : MessageLookupByLibrary.simpleMessage("Seleccione las monedas que desea agregar a su cartera."),
+    "selectCoinTitle" : MessageLookupByLibrary.simpleMessage("Activar monedas:"),
+    "selectCoinToBuy" : MessageLookupByLibrary.simpleMessage("Seleccione la moneda que desea COMPRAR"),
+    "selectCoinToSell" : MessageLookupByLibrary.simpleMessage("Seleccione la moneda que desea VENDER"),
+    "selectDate" : MessageLookupByLibrary.simpleMessage("Seleccione una fecha"),
+    "selectFileImport" : MessageLookupByLibrary.simpleMessage("Seleccione Archivo"),
+    "selectLanguage" : MessageLookupByLibrary.simpleMessage("Seleccione el idioma"),
+    "selectPaymentMethod" : MessageLookupByLibrary.simpleMessage("Selecciona tu forma de pago"),
+    "selectedOrder" : MessageLookupByLibrary.simpleMessage("Orden seleccionado:"),
+    "sell" : MessageLookupByLibrary.simpleMessage("Vender"),
+    "sellTestCoinWarning" : MessageLookupByLibrary.simpleMessage("¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!"),
+    "send" : MessageLookupByLibrary.simpleMessage("ENVIAR"),
+    "setUpPassword" : MessageLookupByLibrary.simpleMessage("CONFIGURAR UNA CONTRASEÑA"),
+    "settingDialogSpan1" : MessageLookupByLibrary.simpleMessage("Estás seguro de que quieres eliminar"),
+    "settingDialogSpan2" : MessageLookupByLibrary.simpleMessage("billetera?"),
+    "settingDialogSpan3" : MessageLookupByLibrary.simpleMessage("Si es así, asegúrese de"),
+    "settingDialogSpan4" : MessageLookupByLibrary.simpleMessage("guardar su frase inicial."),
+    "settingDialogSpan5" : MessageLookupByLibrary.simpleMessage("Para restaurar su billetera en el futuro."),
+    "settingLanguageTitle" : MessageLookupByLibrary.simpleMessage("Idiomas"),
+    "settings" : MessageLookupByLibrary.simpleMessage("Ajustes"),
+    "share" : MessageLookupByLibrary.simpleMessage("Compartir"),
+    "shareAddress" : m94,
+    "showAddress" : MessageLookupByLibrary.simpleMessage("Mostrar dirección"),
+    "showDetails" : MessageLookupByLibrary.simpleMessage("Mostrar detalles"),
+    "showMyOrders" : MessageLookupByLibrary.simpleMessage("Mostrar mis pedidos"),
+    "showingOrders" : m96,
+    "signInWithPassword" : MessageLookupByLibrary.simpleMessage("Iniciar sesión con contraseña"),
+    "signInWithSeedPhrase" : MessageLookupByLibrary.simpleMessage("¿Olvidó la contraseña? Restaurar billetera desde semilla"),
+    "simple" : MessageLookupByLibrary.simpleMessage("Sencillo"),
+    "simpleTradeActivate" : MessageLookupByLibrary.simpleMessage("Activar"),
+    "simpleTradeBuyHint" : m97,
+    "simpleTradeBuyTitle" : MessageLookupByLibrary.simpleMessage("Comprar"),
+    "simpleTradeClose" : MessageLookupByLibrary.simpleMessage("Cerrar"),
+    "simpleTradeMaxActiveCoins" : m98,
+    "simpleTradeNotActive" : m99,
+    "simpleTradeRecieve" : MessageLookupByLibrary.simpleMessage("Recibir"),
+    "simpleTradeSellHint" : m100,
+    "simpleTradeSellTitle" : MessageLookupByLibrary.simpleMessage("Vender"),
+    "simpleTradeSend" : MessageLookupByLibrary.simpleMessage("Enviar"),
+    "simpleTradeShowLess" : MessageLookupByLibrary.simpleMessage("Muestra menos"),
+    "simpleTradeShowMore" : MessageLookupByLibrary.simpleMessage("Mostrar mas"),
+    "simpleTradeUnableActivate" : m101,
+    "skip" : MessageLookupByLibrary.simpleMessage("Omitir"),
+    "snackbarDismiss" : MessageLookupByLibrary.simpleMessage("Descartar"),
+    "soundCantPlayThatMsg" : m102,
+    "soundPlayedWhen" : m103,
+    "soundSettingsLink" : MessageLookupByLibrary.simpleMessage("Sonido"),
+    "soundSettingsTitle" : MessageLookupByLibrary.simpleMessage("Ajustes de sonido"),
+    "soundsDialogTitle" : MessageLookupByLibrary.simpleMessage("Sonidos"),
+    "soundsDoNotShowAgain" : MessageLookupByLibrary.simpleMessage("Entendido, no lo muestres más."),
+    "soundsExplanation" : MessageLookupByLibrary.simpleMessage("Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo."),
+    "soundsNote" : MessageLookupByLibrary.simpleMessage("Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación."),
+    "spanishLanguage" : MessageLookupByLibrary.simpleMessage("Español"),
+    "startDate" : MessageLookupByLibrary.simpleMessage("Fecha de inicio"),
+    "startSwap" : MessageLookupByLibrary.simpleMessage("Iniciar intercambio"),
+    "step" : MessageLookupByLibrary.simpleMessage("Paso"),
+    "success" : MessageLookupByLibrary.simpleMessage("¡Éxito!"),
+    "support" : MessageLookupByLibrary.simpleMessage("Apoyo"),
+    "supportLinksDesc" : m104,
+    "swap" : MessageLookupByLibrary.simpleMessage("intercambio"),
+    "swapCurrent" : MessageLookupByLibrary.simpleMessage("Actual"),
+    "swapDetailTitle" : MessageLookupByLibrary.simpleMessage("CONFIRMAR DETALLES DE CAMBIO"),
+    "swapEstimated" : MessageLookupByLibrary.simpleMessage("Estimado"),
+    "swapFailed" : MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
+    "swapGasActivate" : m105,
+    "swapGasAmount" : m106,
+    "swapGasAmountRequired" : m107,
+    "swapOngoing" : MessageLookupByLibrary.simpleMessage("Intercambio en curso"),
+    "swapProgress" : MessageLookupByLibrary.simpleMessage("Detalles del Progreso"),
+    "swapStarted" : MessageLookupByLibrary.simpleMessage("Iniciado"),
+    "swapSucceful" : MessageLookupByLibrary.simpleMessage("Intercambio exitoso"),
+    "swapTotal" : MessageLookupByLibrary.simpleMessage("Total"),
+    "swapUUID" : MessageLookupByLibrary.simpleMessage("Intercambiar UUID"),
+    "switchTheme" : MessageLookupByLibrary.simpleMessage("Cambiar Tema"),
+    "syncFromDate" : MessageLookupByLibrary.simpleMessage("Sincronización desde la fecha especificada"),
+    "syncFromSaplingActivation" : MessageLookupByLibrary.simpleMessage("Sincronización desde la activación del retoño"),
+    "syncNewTransactions" : MessageLookupByLibrary.simpleMessage("Sincronizar nuevas transacciones"),
+    "tagAVX20" : MessageLookupByLibrary.simpleMessage("AVX20"),
+    "tagBEP20" : MessageLookupByLibrary.simpleMessage("BEP20"),
+    "tagERC20" : MessageLookupByLibrary.simpleMessage("ERC20"),
+    "tagETC" : MessageLookupByLibrary.simpleMessage("ETC"),
+    "tagFTM20" : MessageLookupByLibrary.simpleMessage("FTM20"),
+    "tagHCO20" : MessageLookupByLibrary.simpleMessage("HCO20"),
+    "tagHRC20" : MessageLookupByLibrary.simpleMessage("HRC20"),
+    "tagKMD" : MessageLookupByLibrary.simpleMessage("KMD"),
+    "tagKRC20" : MessageLookupByLibrary.simpleMessage("KRC20"),
+    "tagMVR20" : MessageLookupByLibrary.simpleMessage("MVR20"),
+    "tagPLG20" : MessageLookupByLibrary.simpleMessage("PLG20"),
+    "tagQRC20" : MessageLookupByLibrary.simpleMessage("QRC20"),
+    "tagSBCH" : MessageLookupByLibrary.simpleMessage("SBCH"),
+    "tagUBQ" : MessageLookupByLibrary.simpleMessage("UBQ"),
+    "tagZHTLC" : MessageLookupByLibrary.simpleMessage("ZHTLC"),
+    "takerOrder" : MessageLookupByLibrary.simpleMessage("Orden de Comprador"),
+    "timeOut" : MessageLookupByLibrary.simpleMessage("Se acabó el tiempo"),
+    "titleCreatePassword" : MessageLookupByLibrary.simpleMessage("CREA UNA CONTRASEÑA"),
+    "titleCurrentAsk" : MessageLookupByLibrary.simpleMessage("Pedido seleccionado"),
+    "to" : MessageLookupByLibrary.simpleMessage("Para"),
+    "toAddress" : MessageLookupByLibrary.simpleMessage("Hacia:"),
+    "tooManyAssetsEnabledSpan1" : MessageLookupByLibrary.simpleMessage("Tu tienes"),
+    "tooManyAssetsEnabledSpan2" : MessageLookupByLibrary.simpleMessage("activos habilitados. El límite máximo de activos habilitados es"),
+    "tooManyAssetsEnabledSpan3" : MessageLookupByLibrary.simpleMessage(". Desactive algunos antes de agregar otros nuevos."),
+    "tooManyAssetsEnabledTitle" : MessageLookupByLibrary.simpleMessage("Demasiados recursos habilitados"),
+    "totalFees" : MessageLookupByLibrary.simpleMessage("Tarifas totales:"),
+    "trade" : MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
+    "tradeCompleted" : MessageLookupByLibrary.simpleMessage("¡CAMBIO COMPLETADO!"),
+    "tradeDetail" : MessageLookupByLibrary.simpleMessage("DETALLES INTERCAMBIO"),
+    "tradePreimageError" : MessageLookupByLibrary.simpleMessage("Error al calcular las tarifas comerciales"),
+    "tradingFee" : MessageLookupByLibrary.simpleMessage("tarifa de negociación:"),
+    "tradingMode" : MessageLookupByLibrary.simpleMessage("Modo de comercio:"),
+    "transactionAddress" : MessageLookupByLibrary.simpleMessage("Dirección de transacción"),
+    "transactionHidden" : MessageLookupByLibrary.simpleMessage("Transacción oculta"),
+    "transactionHiddenPhishing" : MessageLookupByLibrary.simpleMessage("Esta transacción fue ocultada debido a un posible intento de phishing."),
+    "tryRestarting" : MessageLookupByLibrary.simpleMessage("Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación."),
+    "turkishLanguage" : MessageLookupByLibrary.simpleMessage("Turco"),
+    "txBlock" : MessageLookupByLibrary.simpleMessage("Bloque"),
+    "txConfirmations" : MessageLookupByLibrary.simpleMessage("Confirmaciones"),
+    "txConfirmed" : MessageLookupByLibrary.simpleMessage("CONFIRMADO"),
+    "txFee" : MessageLookupByLibrary.simpleMessage("Tarifa"),
+    "txFeeTitle" : MessageLookupByLibrary.simpleMessage("tarifa de transacción:"),
+    "txHash" : MessageLookupByLibrary.simpleMessage("ID de transacción"),
+    "txLimitExceeded" : MessageLookupByLibrary.simpleMessage("Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde."),
+    "txNotConfirmed" : MessageLookupByLibrary.simpleMessage("INCONFIRMADO"),
+    "txleft" : m109,
+    "ukrainianLanguage" : MessageLookupByLibrary.simpleMessage("Ucranio"),
+    "unlock" : MessageLookupByLibrary.simpleMessage("desbloquear"),
+    "unlockFunds" : MessageLookupByLibrary.simpleMessage("Desbloquear fondos"),
+    "unlockSuccess" : m110,
+    "unspendable" : MessageLookupByLibrary.simpleMessage("ingastable"),
+    "updatesAvailable" : MessageLookupByLibrary.simpleMessage("Nueva versión disponible"),
+    "updatesChecking" : MessageLookupByLibrary.simpleMessage("Comprobando actualizaciones..."),
+    "updatesCurrentVersion" : m111,
+    "updatesNotifAvailable" : MessageLookupByLibrary.simpleMessage("Nueva versión disponible. Por favor actualice."),
+    "updatesNotifAvailableVersion" : m112,
+    "updatesNotifTitle" : MessageLookupByLibrary.simpleMessage("Actualización disponible"),
+    "updatesSkip" : MessageLookupByLibrary.simpleMessage("Saltar por ahora"),
+    "updatesTitle" : m113,
+    "updatesUpToDate" : MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
+    "updatesUpdate" : MessageLookupByLibrary.simpleMessage("Actualizar"),
+    "uriInsufficientBalanceSpan1" : MessageLookupByLibrary.simpleMessage("No hay suficiente saldo para escaneado"),
+    "uriInsufficientBalanceSpan2" : MessageLookupByLibrary.simpleMessage("solicitud de pago."),
+    "uriInsufficientBalanceTitle" : MessageLookupByLibrary.simpleMessage("Saldo insuficiente"),
+    "value" : MessageLookupByLibrary.simpleMessage("Valor:"),
+    "version" : MessageLookupByLibrary.simpleMessage("version"),
+    "viewInExplorerButton" : MessageLookupByLibrary.simpleMessage("Explorador"),
+    "viewSeedAndKeys" : MessageLookupByLibrary.simpleMessage("Semilla y Claves Privadas"),
+    "volumes" : MessageLookupByLibrary.simpleMessage("Volumenes"),
+    "walletInUse" : MessageLookupByLibrary.simpleMessage("El nombre de la billetera ya está en uso"),
+    "walletMaxChar" : MessageLookupByLibrary.simpleMessage("El nombre de la billetera debe tener un máximo de 40 caracteres"),
+    "walletOnly" : MessageLookupByLibrary.simpleMessage("Solo billetera"),
+    "warning" : MessageLookupByLibrary.simpleMessage("¡Advertencia!"),
+    "warningOkBtn" : MessageLookupByLibrary.simpleMessage("Ok"),
+    "warningShareLogs" : MessageLookupByLibrary.simpleMessage("Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos."),
+    "weFailedTo" : m114,
+    "weFailedToActivate" : m115,
+    "welcomeInfo" : m116,
+    "welcomeLetSetUp" : MessageLookupByLibrary.simpleMessage("¡VAMOS A PREPARARNOS!"),
+    "welcomeTitle" : MessageLookupByLibrary.simpleMessage("BIENVENIDO"),
+    "welcomeWallet" : MessageLookupByLibrary.simpleMessage("wallet"),
+    "willBeRedirected" : MessageLookupByLibrary.simpleMessage("Se le redirigirá a la página del portafolio al finalizar."),
+    "willTakeTime" : MessageLookupByLibrary.simpleMessage("Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas."),
+    "withdraw" : MessageLookupByLibrary.simpleMessage("Retirar"),
+    "withdrawCameraAccessText" : m117,
+    "withdrawCameraAccessTitle" : MessageLookupByLibrary.simpleMessage("Acceso Denegado"),
+    "withdrawConfirm" : MessageLookupByLibrary.simpleMessage("Confirmar Retiro"),
+    "withdrawConfirmError" : MessageLookupByLibrary.simpleMessage("Algo salió mal. Vuelva a intentarlo más tarde."),
+    "withdrawValue" : m118,
+    "wrongCoinSpan1" : MessageLookupByLibrary.simpleMessage("Está intentando escanear un código QR de pago para"),
+    "wrongCoinSpan2" : MessageLookupByLibrary.simpleMessage("pero tu estas en la"),
+    "wrongCoinSpan3" : MessageLookupByLibrary.simpleMessage("pantalla de retirar"),
+    "wrongCoinTitle" : MessageLookupByLibrary.simpleMessage("Moneda equivocada"),
+    "wrongPassword" : MessageLookupByLibrary.simpleMessage("Las contraseñas no coinciden. Inténtalo de nuevo."),
+    "yes" : MessageLookupByLibrary.simpleMessage("Sí"),
+    "you have a fresh order that is trying to match with an existing order" : MessageLookupByLibrary.simpleMessage("tiene un pedido nuevo que está tratando de coincidir con un pedido existente"),
+    "you have an active swap in progress" : MessageLookupByLibrary.simpleMessage("tienes un intercambio activo en curso"),
+    "you have an order that new orders can match with" : MessageLookupByLibrary.simpleMessage("tiene un pedido con el que pueden coincidir nuevos pedidos"),
+    "youAreSending" : MessageLookupByLibrary.simpleMessage("Usted está enviando:"),
+    "youWillReceiveClaim" : m119,
+    "youWillReceived" : MessageLookupByLibrary.simpleMessage("Usted recibirá:"),
+    "yourWallet" : MessageLookupByLibrary.simpleMessage("Su billetera")
+  };
 }

--- a/lib/l10n/messages_es.dart
+++ b/lib/l10n/messages_es.dart
@@ -31,31 +31,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m5(title) => "Solo mostrar contactos con direcciones ${title}";
 
-  static m6(abbr) => "No puede enviar fondos a la dirección ${abbr} porque ${abbr} no está activado. Por favor, vaya a la cartera.";
+  static m6(abbr) =>
+      "No puede enviar fondos a la dirección ${abbr} porque ${abbr} no está activado. Por favor, vaya a la cartera.";
 
-  static m7(appName) => "¡No! ${appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.";
+  static m7(appName) =>
+      "¡No! ${appName} no tiene custodia. Nunca almacenamos datos confidenciales, incluidas sus claves privadas, frases iniciales o PIN. Estos datos solo se almacenan en el dispositivo del usuario y nunca lo abandonan. Usted tiene el control total de sus activos.";
 
-  static m8(appName) => "${appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.";
+  static m8(appName) =>
+      "${appName} está disponible para dispositivos móviles en Android y iPhone, y para computadoras de escritorio en <a href=\"https://komodoplatform.com/\">sistemas operativos Windows, Mac y Linux</a>.";
 
-  static m9(appName) => "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n${appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.";
+  static m9(appName) =>
+      "Por lo general, otros DEX solo le permiten intercambiar monedas digitales que se basan en una sola red blockchain y solo permiten realizar un solo pedido con los mismos fondos.\n\n${appName} le permite intercambiar de forma nativa en blockchains diferentes. También puede realizar varios pedidos con los mismos fondos. Por ejemplo, puede vender 0.1 BTC por KMD, QTUM o VRSC: el primer pedido que se ejecuta automáticamente cancela todos los demás pedidos.";
 
-  static m10(appName) => "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a ${appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.";
+  static m10(appName) =>
+      "Varios factores determinan el tiempo de procesamiento de cada intercambio. El tiempo de procesar una transacción depende de cada red (Bitcoin suele ser la más lenta). Además, el usuario puede personalizar las preferencias de seguridad. Por ejemplo, puede pedirle a ${appName} que considere una transacción KMD procesada despues de solo 3 confirmaciones, lo que hace que el tiempo de intercambio sea más corto en comparación con la espera de una <a href=\"https://komodoplatform.com/security-delayed-proof-of-work-dpow/\">notarization</a>.";
 
-  static m11(appName) => "Hay dos categorías de tarifas a tener en cuenta al intercambiar en ${appName}.\n\n1. ${appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.";
+  static m11(appName) =>
+      "Hay dos categorías de tarifas a tener en cuenta al intercambiar en ${appName}.\n\n1. ${appName} cobra aproximadamente un 0,13 % (1/777 del volumen de la transacción, pero no menos de 0,0001) como tarifa de transacción para las órdenes del comprador, y las órdenes del vendedor no tienen tarifas.\n\n2. Tanto los vendedores como los compradores deberán pagar tarifas de red normales a las blockchains involucradas al realizar transacciones de intercambio atómico.\n\nLas tarifas de red pueden variar mucho según el par de monedas seleccionadas.";
 
-  static m12(name, link, appName, appCompanyShort) => "¡Sí! ${appName} ofrece soporte a través de <a href=\"${link}\">${appCompanyShort} ${name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!";
+  static m12(name, link, appName, appCompanyShort) =>
+      "¡Sí! ${appName} ofrece soporte a través de <a href=\"${link}\">${appCompanyShort} ${name}</a>. ¡El equipo y la comunidad siempre están dispuestos a ayudar!";
 
-  static m13(appName) => "¡No! ${appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.";
+  static m13(appName) =>
+      "¡No! ${appName} es completamente descentralizado. No es posible limitar el acceso de los usuarios por parte de ningún tercero.";
 
-  static m14(appName, appCompanyShort) => "${appName} está desarrollado por el equipo de ${appCompanyShort}. ${appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.";
+  static m14(appName, appCompanyShort) =>
+      "${appName} está desarrollado por el equipo de ${appCompanyShort}. ${appCompanyShort} es uno de los proyectos de blockchain más consolidados que trabaja en soluciones innovadoras como intercambios decentralizados, seguridad de blockchains y una arquitectura multicadena interoperable.";
 
-  static m15(appName) => "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de ${appName} siempre está lista para ayudar!";
+  static m15(appName) =>
+      "¡Absolutamente! Puede leer nuestra <a href=\"https://developers.komodoplatform.com/\">documentación para desarrolladores</a> para obtener más detalles o contactarnos con sus consultas sobre asociaciones. ¿Tiene una pregunta técnica específica? ¡La comunidad de desarrolladores de ${appName} siempre está lista para ayudar!";
 
   static m16(coinName1, coinName2) => "basado en ${coinName1}/${coinName2}";
 
-  static m17(batteryLevelCritical) => "La carga de su batería es crítica (${batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.";
+  static m17(batteryLevelCritical) =>
+      "La carga de su batería es crítica (${batteryLevelCritical}%) para realizar un intercambio de manera segura. Póngalo a cargar y vuelva a intentarlo.";
 
-  static m18(batteryLevelLow) => "La carga de la batería es inferior al ${batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.";
+  static m18(batteryLevelLow) =>
+      "La carga de la batería es inferior al ${batteryLevelLow}%. Considere la posibilidad de cargar el teléfono.";
 
   static m19(seconde) => "Ordermatch en curso, ¡espere ${seconde} segundos!";
 
@@ -63,1017 +75,1483 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "¿Cuál es la palabra ${index} en su frase inicial?";
 
-  static m22(protocolName) => "Las monedas ${protocolName} están activadas";
+  static m22(coin) => "activación de ${coin} cancelada";
 
-  static m23(protocolName) => "${protocolName} monedas activadas con éxito";
+  static m24(protocolName) => "Las monedas ${protocolName} están activadas";
 
-  static m24(protocolName) => "Las monedas ${protocolName} no están activadas";
+  static m25(protocolName) => "${protocolName} monedas activadas con éxito";
 
-  static m25(name) => "¿Está seguro de que desea eliminar el contacto ${name}?";
+  static m26(protocolName) => "Las monedas ${protocolName} no están activadas";
 
-  static m26(iUnderstand) => "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"${iUnderstand}\" en el cuadro a continuación.";
+  static m27(name) => "¿Está seguro de que desea eliminar el contacto ${name}?";
 
-  static m27(coinName) => "recibir tarifa de transacción de ${coinName}";
+  static m28(iUnderstand) =>
+      "Las frases semilla personalizadas pueden ser menos seguras y más fáciles de descifrar que una frase semilla o clave privada (WIF) compatible con BIP39 generada. Para confirmar que comprende el riesgo y sabe lo que está haciendo, escriba \"${iUnderstand}\" en el cuadro a continuación.";
 
-  static m28(coinName) => "enviar tarifa de transacción de ${coinName}";
+  static m29(coinName) => "recibir tarifa de transacción de ${coinName}";
 
-  static m29(abbr) => "Introduzca la dirección ${abbr} ";
+  static m30(coinName) => "enviar tarifa de transacción de ${coinName}";
 
-  static m31(gas) => "No hay suficiente gas: usa al menos ${gas} Gwei";
+  static m31(abbr) => "Introduzca la dirección ${abbr} ";
 
-  static m32(appName, appCompanyLong) => "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
+  static m33(gas) => "No hay suficiente gas: usa al menos ${gas} Gwei";
 
-  static m33(appCompanyLong) => "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
+  static m34(appName, appCompanyLong) =>
+      "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m34(appCompanyShort, appCompanyLong) => "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
+  static m35(appCompanyLong) =>
+      "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m35(appCompanyLong) => "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
+  static m36(appCompanyShort, appCompanyLong) =>
+      "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m36(appCompanyLong) => "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
+  static m37(appCompanyLong) =>
+      "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m37(appCompanyLong) => "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
+  static m38(appCompanyLong) =>
+      "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m38(appCompanyShort, appCompanyLong) => "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
+  static m39(appCompanyLong) =>
+      "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m39(appCompanyLong) => "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
+  static m40(appCompanyShort, appCompanyLong) =>
+      "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m40(appCompanyLong) => "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
+  static m41(appCompanyLong) =>
+      "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m41(appName, appCompanyLong) => "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
+  static m42(appCompanyLong) =>
+      "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m42(appName, appCompanyLong) => "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
+  static m43(appName, appCompanyLong) =>
+      "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m43(appName) => "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
+  static m44(appName, appCompanyLong) =>
+      "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m44(appName, appCompanyLong) => "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
+  static m45(appName) =>
+      "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m45(appName) => "End-User License Agreement (EULA) of ${appName} mobile:";
+  static m46(appName, appCompanyLong) =>
+      "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m46(coin) => "Enviando solicitud a la llave ${coin}...";
+  static m47(appName) =>
+      "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m47(appCompanyShort) => "${appCompanyShort} noticias";
+  static m48(coinAbbr) => "No se pudo cancelar la activación de ${coinAbbr}";
 
-  static m48(value) => "Las tarifas deben ser de hasta ${value}";
+  static m49(coin) => "Enviando solicitud a la llave ${coin}...";
 
-  static m49(coin) => " tarifa${coin} ";
+  static m50(appCompanyShort) => "${appCompanyShort} noticias";
 
-  static m50(coin) => "Activa ${coin}.";
+  static m51(value) => "Las tarifas deben ser de hasta ${value}";
 
-  static m52(coinName) => "Configuración de protección de txs entrantes de ${coinName}";
+  static m52(coin) => " tarifa${coin} ";
 
-  static m53(abbr) => " El saldo de ${abbr} no es suficiente para pagar la tarifa de negociación";
+  static m53(coin) => "Activa ${coin}.";
 
-  static m55(coinAbbr) => "${coinAbbr} no está disponible :(";
+  static m55(coinName) =>
+      "Configuración de protección de txs entrantes de ${coinName}";
 
-  static m56(coinName) => "❗¡Precaución! ¡El mercado de ${coinName} tiene un volumen de negociación de menos de \$ 10k las 24 horas!";
+  static m56(abbr) =>
+      " El saldo de ${abbr} no es suficiente para pagar la tarifa de negociación";
 
-  static m58(coinName, number) => "La cantidad mínima para vender es ${number} ${coinName}";
+  static m58(coinAbbr) => "${coinAbbr} no está disponible :(";
 
-  static m59(coinName, number) => "La cantidad mínima para comprar es ${number}${coinName}";
+  static m59(coinName) =>
+      "❗¡Precaución! ¡El mercado de ${coinName} tiene un volumen de negociación de menos de \$ 10k las 24 horas!";
 
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) => "El monto mínimo del pedido es ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
+  static m61(coinName, number) =>
+      "La cantidad mínima para vender es ${number} ${coinName}";
 
-  static m61(coinName, number) => "La cantidad mínima para vender es ${number}${coinName}";
+  static m62(coinName, number) =>
+      "La cantidad mínima para comprar es ${number}${coinName}";
 
-  static m62(minValue, coin) => "Debe ser mayor que ${minValue} ${coin}";
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "El monto mínimo del pedido es ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
 
-  static m63(appName) => "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de ${appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.";
+  static m64(coinName, number) =>
+      "La cantidad mínima para vender es ${number}${coinName}";
 
-  static m64(coin) => "Active ${coin} y añada saldo primero";
+  static m65(minValue, coin) => "Debe ser mayor que ${minValue} ${coin}";
 
-  static m65(number) => "Crear ${number} pedido(s):";
+  static m66(appName) =>
+      "Tenga en cuenta que ahora está utilizando datos móviles y la participación en la red P2P de ${appName} consume tráfico de Internet. Es mejor usar una red WiFi si su plan de datos móviles es costoso.";
 
-  static m66(coin) => " El saldo de${coin} es demasiado bajo";
+  static m67(coin) => "Active ${coin} y añada saldo primero";
 
-  static m67(coin, fee) => "No hay suficientes ${coin} para pagar las tarifas. El saldo MÍN es ${fee} ${coin}";
+  static m68(number) => "Crear ${number} pedido(s):";
 
-  static m68(coinName) => "Ingrese la cantidad de ${coinName}.";
+  static m69(coin) => " El saldo de${coin} es demasiado bajo";
 
-  static m69(coin) => "¡No hay suficiente ${coin} para la transacción!";
+  static m70(coin, fee) =>
+      "No hay suficientes ${coin} para pagar las tarifas. El saldo MÍN es ${fee} ${coin}";
 
-  static m70(sell, buy) => " El intercambio de${sell}/${buy} se completó con éxito";
+  static m71(coinName) => "Ingrese la cantidad de ${coinName}.";
 
-  static m71(sell, buy) => "${sell}/${buy} intercambio fallido";
+  static m72(coin) => "¡No hay suficiente ${coin} para la transacción!";
 
-  static m72(sell, buy) => "${sell}/${buy} intercambio iniciado";
+  static m73(sell, buy) =>
+      " El intercambio de${sell}/${buy} se completó con éxito";
 
-  static m73(sell, buy) => "${sell}/${buy} intercambio se agotó";
+  static m74(sell, buy) => "${sell}/${buy} intercambio fallido";
 
-  static m74(coin) => "¡Ha recibido una transacción de ${coin}!";
+  static m75(sell, buy) => "${sell}/${buy} intercambio iniciado";
 
-  static m75(assets) => "${assets} activos";
+  static m76(sell, buy) => "${sell}/${buy} intercambio se agotó";
 
-  static m76(coin) => "Todos los pedidos de ${coin} serán cancelados.";
+  static m77(coin) => "¡Ha recibido una transacción de ${coin}!";
 
-  static m77(delta) => "Expediente: CEX +${delta}%";
+  static m78(assets) => "${assets} activos";
 
-  static m78(delta) => "Caro: CEX ${delta}%";
+  static m79(coin) => "Todos los pedidos de ${coin} serán cancelados.";
 
-  static m79(fill) => "${fill}% llenado";
+  static m80(delta) => "Expediente: CEX +${delta}%";
 
-  static m80(coin) => "Cantidad (${coin})";
+  static m81(delta) => "Caro: CEX ${delta}%";
 
-  static m81(coin) => "Precio (${coin})";
+  static m82(fill) => "${fill}% llenado";
 
-  static m82(coin) => "Total (${coin})";
+  static m83(coin) => "Cantidad (${coin})";
 
-  static m83(abbr) => "${abbr} no está activo. Activa e inténtalo de nuevo..";
+  static m84(coin) => "Precio (${coin})";
 
-  static m84(appName) => "¿En qué dispositivos puedo usar ${appName}?";
+  static m85(coin) => "Total (${coin})";
 
-  static m85(appName) => "¿En qué se diferencia el comercio en ${appName} del comercio en otros DEX?";
+  static m86(abbr) => "${abbr} no está activo. Activa e inténtalo de nuevo..";
 
-  static m86(appName) => "¿Cómo se calculan las tarifas de ${appName}?";
+  static m87(appName) => "¿En qué dispositivos puedo usar ${appName}?";
 
-  static m87(appName) => "¿Quién está detrás de ${appName}?";
+  static m88(appName) =>
+      "¿En qué se diferencia el comercio en ${appName} del comercio en otros DEX?";
 
-  static m88(appName) => "¿Es posible desarrollar mi propio intercambio con ${appName}?";
+  static m89(appName) => "¿Cómo se calculan las tarifas de ${appName}?";
 
-  static m89(amount) => "¡Éxito! ${amount} KMD recibido.";
+  static m90(appName) => "¿Quién está detrás de ${appName}?";
 
-  static m90(dd) => "${dd} dias(s)";
+  static m91(appName) =>
+      "¿Es posible desarrollar mi propio intercambio con ${appName}?";
 
-  static m91(hh, minutes) => "${hh}h ${minutes}m";
+  static m92(amount) => "¡Éxito! ${amount} KMD recibido.";
 
-  static m92(mm) => "${mm}min";
+  static m93(dd) => "${dd} dias(s)";
 
-  static m93(amount) => "Haga clic para ver ${amount} pedidos";
+  static m94(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m94(coinName, address) => "Mi ${coinName} dirección:\n${address}";
+  static m95(mm) => "${mm}min";
 
-  static m96(count, maxCount) => "Mostrando ${count} de ${maxCount} pedidos.";
+  static m96(amount) => "Haga clic para ver ${amount} pedidos";
 
-  static m97(coin) => "Ingrese la cantidad de ${coin} para comprar";
+  static m97(coinName, address) => "Mi ${coinName} dirección:\n${address}";
 
-  static m98(maxCoins) => "El número máximo de monedas activas es ${maxCoins}. Por favor, desactive algunos.";
+  static m99(count, maxCount) => "Mostrando ${count} de ${maxCount} pedidos.";
 
-  static m99(coin) => "${coin} no está activo!";
+  static m100(coin) => "Ingrese la cantidad de ${coin} para comprar";
 
-  static m100(coin) => "Ingrese la cantidad de ${coin} para vender";
+  static m101(maxCoins) =>
+      "El número máximo de monedas activas es ${maxCoins}. Por favor, desactive algunos.";
 
-  static m101(coin) => "No se puede activar ${coin}";
+  static m102(coin) => "${coin} no está activo!";
 
-  static m102(description) => "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando ${description}.";
+  static m103(coin) => "Ingrese la cantidad de ${coin} para vender";
 
-  static m103(description) => "Jugado cuando ${description}";
+  static m104(coin) => "No se puede activar ${coin}";
 
-  static m104(appName) => "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación ${appName}, puede informar y obtener asistencia de nuestro equipo.";
+  static m105(description) =>
+      "Elija un archivo mp3 o wav, por favor. Lo reproduciremos cuando ${description}.";
 
-  static m105(coin) => "Activa ${coin} y recarga el saldo primero";
+  static m106(description) => "Jugado cuando ${description}";
 
-  static m106(coin) => "El saldo de ${coin} no es suficiente para pagar las tarifas de transacción.";
+  static m107(appName) =>
+      "Si tiene alguna pregunta o cree que ha encontrado un problema técnico con la aplicación ${appName}, puede informar y obtener asistencia de nuestro equipo.";
 
-  static m107(coin, amount) => " El saldo de${coin} no es suficiente para pagar las tarifas de transacción. ${coin} ${amount} obligatorio.";
+  static m108(coin) => "Activa ${coin} y recarga el saldo primero";
 
-  static m109(left) => "Transacciones restantes: ${left}";
+  static m109(coin) =>
+      "El saldo de ${coin} no es suficiente para pagar las tarifas de transacción.";
 
-  static m110(amnt, hash) => "Desbloqueó con éxito ${amnt} fondos - TX: ${hash}";
+  static m110(coin, amount) =>
+      " El saldo de${coin} no es suficiente para pagar las tarifas de transacción. ${coin} ${amount} obligatorio.";
 
-  static m111(version) => "Estás usando la versión ${version}";
+  static m112(left) => "Transacciones restantes: ${left}";
 
-  static m112(version) => "Versión ${version} disponible. Por favor actualice.";
+  static m113(amnt, hash) =>
+      "Desbloqueó con éxito ${amnt} fondos - TX: ${hash}";
 
-  static m113(appName) => "${appName} actualizar";
+  static m114(version) => "Estás usando la versión ${version}";
 
-  static m114(coinAbbr) => "No pudimos activar ${coinAbbr}";
+  static m115(version) => "Versión ${version} disponible. Por favor actualice.";
 
-  static m115(coinAbbr) => "No pudimos activar ${coinAbbr}.\nReinicie la aplicación para volver a intentarlo.";
+  static m116(appName) => "${appName} actualizar";
 
-  static m116(appName) => "${appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.";
+  static m117(coinAbbr) => "No pudimos activar ${coinAbbr}";
 
-  static m117(appName) => "Previamente le has negado a ${appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.";
+  static m118(coinAbbr) =>
+      "No pudimos activar ${coinAbbr}.\nReinicie la aplicación para volver a intentarlo.";
 
-  static m118(amount, coinName) => "RETIRAR ${amount} ${coinName}";
+  static m119(appName) =>
+      "${appName} móvil es una billetera multimoneda de próxima generación con funcionalidad DEX nativa de tercera generación y más.";
 
-  static m119(amount, coin) => "Recibirás ${amount} ${coin}";
+  static m120(appName) =>
+      "Previamente le has negado a ${appName} el acceso a la cámara.\nCambia manualmente el permiso de la cámara en la configuración de tu teléfono para continuar con el escaneo del código QR.";
+
+  static m121(amount, coinName) => "RETIRAR ${amount} ${coinName}";
+
+  static m122(amount, coin) => "Recibirás ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) => <String, Function> {
-    "Active" : MessageLookupByLibrary.simpleMessage("Activo"),
-    "Applause" : MessageLookupByLibrary.simpleMessage("Aplausos"),
-    "Can\'t play that" : MessageLookupByLibrary.simpleMessage("no puedo escuchar eso"),
-    "Failed" : MessageLookupByLibrary.simpleMessage("Fallido"),
-    "Maker" : MessageLookupByLibrary.simpleMessage("Vendedor"),
-    "Optional" : MessageLookupByLibrary.simpleMessage("Opcional"),
-    "Play at full volume" : MessageLookupByLibrary.simpleMessage("Juega a todo volumen"),
-    "Sound" : MessageLookupByLibrary.simpleMessage("Sonido"),
-    "Taker" : MessageLookupByLibrary.simpleMessage("Comprador"),
-    "a swap fails" : MessageLookupByLibrary.simpleMessage("un intercambio falla"),
-    "a swap runs to completion" : MessageLookupByLibrary.simpleMessage("un intercambio se ejecuta hasta su finalización"),
-    "accepteula" : MessageLookupByLibrary.simpleMessage("Aceptar EULA"),
-    "accepttac" : MessageLookupByLibrary.simpleMessage("Aceptar TERMINOS y CONDICIONES"),
-    "activateAccessBiometric" : MessageLookupByLibrary.simpleMessage("Activar protección biométrica"),
-    "activateAccessPin" : MessageLookupByLibrary.simpleMessage("Activar la protección con PIN"),
-    "activateCoins" : m0,
-    "activating" : m1,
-    "activation" : m2,
-    "activationInProgress" : m3,
-    "addCoin" : MessageLookupByLibrary.simpleMessage("Activar moneda"),
-    "addingCoinSuccess" : m4,
-    "addressAdd" : MessageLookupByLibrary.simpleMessage("Añadir Direccion"),
-    "addressBook" : MessageLookupByLibrary.simpleMessage("Directorio"),
-    "addressBookEmpty" : MessageLookupByLibrary.simpleMessage("La libreta de direcciones está vacía"),
-    "addressBookFilter" : m5,
-    "addressBookTitle" : MessageLookupByLibrary.simpleMessage("Directorio"),
-    "addressCoinInactive" : m6,
-    "addressNotFound" : MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
-    "addressSelectCoin" : MessageLookupByLibrary.simpleMessage("Seleccionar Moneda"),
-    "addressSend" : MessageLookupByLibrary.simpleMessage("Dirección de los destinatarios"),
-    "advanced" : MessageLookupByLibrary.simpleMessage("Avanzado"),
-    "all" : MessageLookupByLibrary.simpleMessage("TODOS"),
-    "allPastTransactions" : MessageLookupByLibrary.simpleMessage("Su billetera mostrará cualquier transacción pasada. Esto requerirá mucho almacenamiento y tiempo, ya que todos los bloques se descargarán y escanearán."),
-    "allowCustomSeed" : MessageLookupByLibrary.simpleMessage("Permitir semilla personalizada"),
-    "alreadyExists" : MessageLookupByLibrary.simpleMessage("Ya existe"),
-    "amount" : MessageLookupByLibrary.simpleMessage("Cantidad"),
-    "amountToSell" : MessageLookupByLibrary.simpleMessage("Cantidad a Vender"),
-    "answer_1" : m7,
-    "answer_10" : m8,
-    "answer_2" : m9,
-    "answer_3" : m10,
-    "answer_4" : MessageLookupByLibrary.simpleMessage("Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico."),
-    "answer_5" : m11,
-    "answer_6" : m12,
-    "answer_7" : m13,
-    "answer_8" : m14,
-    "answer_9" : m15,
-    "areYouSure" : MessageLookupByLibrary.simpleMessage("ESTAS SEGURO?"),
-    "authenticate" : MessageLookupByLibrary.simpleMessage("autenticar"),
-    "automaticRedirected" : MessageLookupByLibrary.simpleMessage("Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación."),
-    "availableVolume" : MessageLookupByLibrary.simpleMessage("volumen máximo"),
-    "back" : MessageLookupByLibrary.simpleMessage("back"),
-    "backupTitle" : MessageLookupByLibrary.simpleMessage("Respaldo"),
-    "basedOnCoinRatio" : m16,
-    "batteryCriticalError" : m17,
-    "batteryLowWarning" : m18,
-    "batterySavingWarning" : MessageLookupByLibrary.simpleMessage("Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio."),
-    "bestAvailableRate" : MessageLookupByLibrary.simpleMessage("Tipo de cambio"),
-    "builtKomodo" : MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
-    "builtOnKmd" : MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
-    "buy" : MessageLookupByLibrary.simpleMessage("Comprar"),
-    "buyOrderType" : MessageLookupByLibrary.simpleMessage("Convertir a Vendedor si no coincide"),
-    "buySuccessWaiting" : MessageLookupByLibrary.simpleMessage("Intercambio emitido, por favor espere!"),
-    "buySuccessWaitingError" : m19,
-    "buyTestCoinWarning" : MessageLookupByLibrary.simpleMessage("¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!"),
-    "camoPinBioProtectionConflict" : MessageLookupByLibrary.simpleMessage("El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo."),
-    "camoPinBioProtectionConflictTitle" : MessageLookupByLibrary.simpleMessage("Conflicto entre PIN de camuflaje y bioprotección."),
-    "camoPinChange" : MessageLookupByLibrary.simpleMessage("Cambiar PIN de camuflaje"),
-    "camoPinCreate" : MessageLookupByLibrary.simpleMessage("Crear PIN de camuflaje"),
-    "camoPinDesc" : MessageLookupByLibrary.simpleMessage("Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración"),
-    "camoPinInvalid" : MessageLookupByLibrary.simpleMessage("PIN de camuflaje no válido"),
-    "camoPinLink" : MessageLookupByLibrary.simpleMessage("Camuflajear PIN"),
-    "camoPinNotFound" : MessageLookupByLibrary.simpleMessage("PIN de camuflaje no encontrado"),
-    "camoPinOff" : MessageLookupByLibrary.simpleMessage("Desactivado"),
-    "camoPinOn" : MessageLookupByLibrary.simpleMessage("Activado"),
-    "camoPinSaved" : MessageLookupByLibrary.simpleMessage("PIN de camuflaje guardado"),
-    "camoPinTitle" : MessageLookupByLibrary.simpleMessage("Camuflajear el PIN"),
-    "camoSetupSubtitle" : MessageLookupByLibrary.simpleMessage("Ingrese el nuevo PIN de camuflaje"),
-    "camoSetupTitle" : MessageLookupByLibrary.simpleMessage("Configuración de PIN de camuflaje"),
-    "camouflageSetup" : MessageLookupByLibrary.simpleMessage("Configuración de PIN de camuflaje"),
-    "cancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "cancelActivation" : MessageLookupByLibrary.simpleMessage("Cancelar activación"),
-    "cancelActivationQuestion" : MessageLookupByLibrary.simpleMessage("¿Estás seguro de que deseas cancelar la activación?"),
-    "cancelButton" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "cancelOrder" : MessageLookupByLibrary.simpleMessage("Cancelar orden"),
-    "candleChartError" : MessageLookupByLibrary.simpleMessage("Algo salió mal. Vuelve a intentarlo más tarde."),
-    "cantDeleteDefaultCoinOk" : MessageLookupByLibrary.simpleMessage("Ok"),
-    "cantDeleteDefaultCoinSpan" : MessageLookupByLibrary.simpleMessage("es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar."),
-    "cantDeleteDefaultCoinTitle" : MessageLookupByLibrary.simpleMessage("No se puede deshabilitar"),
-    "cex" : MessageLookupByLibrary.simpleMessage("CEX"),
-    "cexChangeRate" : MessageLookupByLibrary.simpleMessage("Tasa de Cambio CEX"),
-    "cexData" : MessageLookupByLibrary.simpleMessage("data de CEX"),
-    "cexDataDesc" : MessageLookupByLibrary.simpleMessage("Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>)."),
-    "cexRate" : MessageLookupByLibrary.simpleMessage("Tasa CEX"),
-    "changePin" : MessageLookupByLibrary.simpleMessage("Cambiar código PIN"),
-    "checkForUpdates" : MessageLookupByLibrary.simpleMessage("Buscar actualizaciones"),
-    "checkOut" : MessageLookupByLibrary.simpleMessage("Verificar"),
-    "checkSeedPhrase" : MessageLookupByLibrary.simpleMessage("Comprobar la frase inicial"),
-    "checkSeedPhraseButton1" : MessageLookupByLibrary.simpleMessage("SEGUIR"),
-    "checkSeedPhraseButton2" : MessageLookupByLibrary.simpleMessage("VOLVER Y VERIFICAR DE NUEVO"),
-    "checkSeedPhraseHint" : m20,
-    "checkSeedPhraseInfo" : MessageLookupByLibrary.simpleMessage("Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee."),
-    "checkSeedPhraseSubtile" : m21,
-    "checkSeedPhraseTitle" : MessageLookupByLibrary.simpleMessage("VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA"),
-    "chineseLanguage" : MessageLookupByLibrary.simpleMessage("Chino"),
-    "claim" : MessageLookupByLibrary.simpleMessage("afirmar"),
-    "claimTitle" : MessageLookupByLibrary.simpleMessage("¿Reclamar su recompensa KMD?"),
-    "clickToSee" : MessageLookupByLibrary.simpleMessage("Clic para ver"),
-    "clipboard" : MessageLookupByLibrary.simpleMessage("Copiado al portapapeles"),
-    "clipboardCopy" : MessageLookupByLibrary.simpleMessage("Copiar al portapapeles"),
-    "close" : MessageLookupByLibrary.simpleMessage("Cerrar"),
-    "closeMessage" : MessageLookupByLibrary.simpleMessage("Cerrar mensaje de error"),
-    "closePreview" : MessageLookupByLibrary.simpleMessage("Cerrar prevista"),
-    "code" : MessageLookupByLibrary.simpleMessage("Código:"),
-    "cofirmCancelActivation" : MessageLookupByLibrary.simpleMessage("¿Estás seguro de que deseas cancelar la activación?"),
-    "coinSelectClear" : MessageLookupByLibrary.simpleMessage("Remover"),
-    "coinSelectNotFound" : MessageLookupByLibrary.simpleMessage("No hay monedas activas"),
-    "coinSelectTitle" : MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
-    "coinsActivatedLimitReached" : MessageLookupByLibrary.simpleMessage("Ha seleccionado el número máximo de activos"),
-    "coinsAreActivated" : m22,
-    "coinsAreActivatedSuccessfully" : m23,
-    "coinsAreNotActivated" : m24,
-    "comingSoon" : MessageLookupByLibrary.simpleMessage("Próximamente..."),
-    "commingsoon" : MessageLookupByLibrary.simpleMessage("Detalles de TX próximamente!"),
-    "commingsoonGeneral" : MessageLookupByLibrary.simpleMessage("¡Detalles muy pronto!"),
-    "commissionFee" : MessageLookupByLibrary.simpleMessage("cuota de comisión"),
-    "comparedTo24hrCex" : MessageLookupByLibrary.simpleMessage("en comparación con el promedio Precio CEX 24h"),
-    "comparedToCex" : MessageLookupByLibrary.simpleMessage("comparable a CEX"),
-    "configureWallet" : MessageLookupByLibrary.simpleMessage("Configurando su billetera, por favor espere..."),
-    "confirm" : MessageLookupByLibrary.simpleMessage("Confirmar"),
-    "confirmCamouflageSetup" : MessageLookupByLibrary.simpleMessage("Confirmar PIN de camuflaje"),
-    "confirmCancel" : MessageLookupByLibrary.simpleMessage("¿Está seguro de que desea cancelar el pedido?"),
-    "confirmPassword" : MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
-    "confirmPin" : MessageLookupByLibrary.simpleMessage("Confirmar código PIN"),
-    "confirmSeed" : MessageLookupByLibrary.simpleMessage("Confirmar frase semilla"),
-    "confirmeula" : MessageLookupByLibrary.simpleMessage("Al hacer clic en los botones a continuación, confirma haber leído el \'EULA\' y los \'Términos y condiciones\' y acepta estos"),
-    "connecting" : MessageLookupByLibrary.simpleMessage("Conectando..."),
-    "contactCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "contactDelete" : MessageLookupByLibrary.simpleMessage("Borrar Contacto"),
-    "contactDeleteBtn" : MessageLookupByLibrary.simpleMessage("Borrar"),
-    "contactDeleteWarning" : m25,
-    "contactDiscardBtn" : MessageLookupByLibrary.simpleMessage("Descartar"),
-    "contactEdit" : MessageLookupByLibrary.simpleMessage("Editar"),
-    "contactExit" : MessageLookupByLibrary.simpleMessage("Salir"),
-    "contactExitWarning" : MessageLookupByLibrary.simpleMessage("Descartar tus cambios?"),
-    "contactNotFound" : MessageLookupByLibrary.simpleMessage("No se encontraron contactos"),
-    "contactSave" : MessageLookupByLibrary.simpleMessage("Guardar"),
-    "contactTitle" : MessageLookupByLibrary.simpleMessage("Detalles de contacto"),
-    "contactTitleName" : MessageLookupByLibrary.simpleMessage("Nombre"),
-    "contract" : MessageLookupByLibrary.simpleMessage("Contrato"),
-    "convert" : MessageLookupByLibrary.simpleMessage("Convertir"),
-    "couldNotLaunchUrl" : MessageLookupByLibrary.simpleMessage("No se pudo iniciar la URL"),
-    "couldntImportError" : MessageLookupByLibrary.simpleMessage("No se pudo importar:"),
-    "create" : MessageLookupByLibrary.simpleMessage("intercambiar"),
-    "createAWallet" : MessageLookupByLibrary.simpleMessage("CREAR UNA CARTERA"),
-    "createContact" : MessageLookupByLibrary.simpleMessage("Crear Contacto"),
-    "createPin" : MessageLookupByLibrary.simpleMessage("Crear numero PIN"),
-    "currency" : MessageLookupByLibrary.simpleMessage("Moneda"),
-    "currencyDialogTitle" : MessageLookupByLibrary.simpleMessage("Moneda"),
-    "currentValue" : MessageLookupByLibrary.simpleMessage("Valor actual:"),
-    "customFee" : MessageLookupByLibrary.simpleMessage("Costo de Transacción Personalizado"),
-    "customFeeWarning" : MessageLookupByLibrary.simpleMessage("¡Solo use tarifas personalizadas si sabe lo que está haciendo!"),
-    "customSeedWarning" : m26,
-    "dPow" : MessageLookupByLibrary.simpleMessage("Seguridad de Komodo dPoW"),
-    "date" : MessageLookupByLibrary.simpleMessage("Fecha"),
-    "decryptingWallet" : MessageLookupByLibrary.simpleMessage("Billetera de descifrado"),
-    "delete" : MessageLookupByLibrary.simpleMessage("Borrar"),
-    "deleteConfirm" : MessageLookupByLibrary.simpleMessage("Confirmar desactivación"),
-    "deleteSpan1" : MessageLookupByLibrary.simpleMessage("¿Quieres eliminar"),
-    "deleteSpan2" : MessageLookupByLibrary.simpleMessage("de tu cartera? Todos los pedidos no emparejados serán cancelados."),
-    "deleteSpan3" : MessageLookupByLibrary.simpleMessage(" también se desactivará"),
-    "deleteWallet" : MessageLookupByLibrary.simpleMessage("Eliminar Billetera"),
-    "deletingWallet" : MessageLookupByLibrary.simpleMessage("Eliminando billetera..."),
-    "detailedFeesReceiveCoinTransactionFee" : m27,
-    "detailedFeesSendCoinTransactionFee" : m28,
-    "detailedFeesSendTradingFeeTransactionFee" : MessageLookupByLibrary.simpleMessage("enviar tarifa comercial tarifa de transacción"),
-    "detailedFeesTradingFee" : MessageLookupByLibrary.simpleMessage("tarifa comercial"),
-    "details" : MessageLookupByLibrary.simpleMessage("detalles"),
-    "deutscheLanguage" : MessageLookupByLibrary.simpleMessage("Alemán"),
-    "developerTitle" : MessageLookupByLibrary.simpleMessage("Desarrollador"),
-    "dex" : MessageLookupByLibrary.simpleMessage("DEX"),
-    "dexIsNotAvailable" : MessageLookupByLibrary.simpleMessage("DEX no está disponible para esta moneda"),
-    "disableScreenshots" : MessageLookupByLibrary.simpleMessage("Desactivar capturas de pantalla/vista previa"),
-    "disclaimerAndTos" : MessageLookupByLibrary.simpleMessage("Descargo de responsabilidad y condiciones de servicio"),
-    "doNotCloseTheAppTapForMoreInfo" : MessageLookupByLibrary.simpleMessage("No cierres la aplicación. Toca para obtener más información..."),
-    "done" : MessageLookupByLibrary.simpleMessage("Hecho"),
-    "dontAskAgain" : MessageLookupByLibrary.simpleMessage("No vuelvas a preguntar"),
-    "dontWantPassword" : MessageLookupByLibrary.simpleMessage("no quiero una contraseña"),
-    "duration" : MessageLookupByLibrary.simpleMessage("Duración"),
-    "editContact" : MessageLookupByLibrary.simpleMessage("Editar contacto"),
-    "emptyCoin" : m29,
-    "emptyExportPass" : MessageLookupByLibrary.simpleMessage("La contraseña de cifrado no puede estar vacía"),
-    "emptyImportPass" : MessageLookupByLibrary.simpleMessage("La contraseña no puede estar vacía"),
-    "emptyName" : MessageLookupByLibrary.simpleMessage("El nombre del contacto no puede estar vacío"),
-    "emptyWallet" : MessageLookupByLibrary.simpleMessage("El nombre de la billetera no debe estar vacío"),
-    "enableNotificationsForActivationProgress" : MessageLookupByLibrary.simpleMessage("Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación."),
-    "enableTestCoins" : MessageLookupByLibrary.simpleMessage("Habilitar monedas de prueba"),
-    "enablingTooManyAssetsSpan1" : MessageLookupByLibrary.simpleMessage("Tu tienes"),
-    "enablingTooManyAssetsSpan2" : MessageLookupByLibrary.simpleMessage("activos habilitados y tratando de habilitar"),
-    "enablingTooManyAssetsSpan3" : MessageLookupByLibrary.simpleMessage("más. El límite máximo de activos habilitados es"),
-    "enablingTooManyAssetsSpan4" : MessageLookupByLibrary.simpleMessage(". Desactive algunos antes de agregar otros nuevos."),
-    "enablingTooManyAssetsTitle" : MessageLookupByLibrary.simpleMessage("Intentando habilitar demasiados activos"),
-    "encryptingWallet" : MessageLookupByLibrary.simpleMessage("Billetera cifrada"),
-    "englishLanguage" : MessageLookupByLibrary.simpleMessage("Inglés"),
-    "enterNewPinCode" : MessageLookupByLibrary.simpleMessage("Ingrese su nuevo PIN"),
-    "enterOldPinCode" : MessageLookupByLibrary.simpleMessage("Ingrese su antiguo PIN"),
-    "enterPinCode" : MessageLookupByLibrary.simpleMessage("Ingresa tu numero PIN"),
-    "enterSeedPhrase" : MessageLookupByLibrary.simpleMessage("Ingrese su Semilla de 12 palabras"),
-    "enterSellAmount" : MessageLookupByLibrary.simpleMessage("Primero debe ingresar el monto de la venta"),
-    "enterpassword" : MessageLookupByLibrary.simpleMessage("Por favor ingrese su contraseña para continuar."),
-    "errorAmountBalance" : MessageLookupByLibrary.simpleMessage("No hay suficiente equilibrio"),
-    "errorNotAValidAddress" : MessageLookupByLibrary.simpleMessage("No es una dirección válida"),
-    "errorNotAValidAddressSegWit" : MessageLookupByLibrary.simpleMessage("Las direcciones de Segwit no son compatibles (todavía)"),
-    "errorNotEnoughGas" : m31,
-    "errorTryAgain" : MessageLookupByLibrary.simpleMessage("Error, inténtalo de nuevo"),
-    "errorTryLater" : MessageLookupByLibrary.simpleMessage("Error, intente más tarde"),
-    "errorValueEmpty" : MessageLookupByLibrary.simpleMessage("El valor es demasiado alto o bajo"),
-    "errorValueNotEmpty" : MessageLookupByLibrary.simpleMessage("Por favor ingrese datos"),
-    "estimateValue" : MessageLookupByLibrary.simpleMessage("Valor total estimado"),
-    "eulaParagraphe1" : m32,
-    "eulaParagraphe10" : m33,
-    "eulaParagraphe11" : m34,
-    "eulaParagraphe12" : MessageLookupByLibrary.simpleMessage("When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-    "eulaParagraphe13" : m35,
-    "eulaParagraphe14" : m36,
-    "eulaParagraphe15" : m37,
-    "eulaParagraphe16" : m38,
-    "eulaParagraphe17" : m39,
-    "eulaParagraphe18" : m40,
-    "eulaParagraphe19" : m41,
-    "eulaParagraphe2" : m42,
-    "eulaParagraphe3" : MessageLookupByLibrary.simpleMessage("By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
-    "eulaParagraphe4" : MessageLookupByLibrary.simpleMessage("We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-    "eulaParagraphe5" : m43,
-    "eulaParagraphe6" : m44,
-    "eulaParagraphe7" : MessageLookupByLibrary.simpleMessage("We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
-    "eulaParagraphe8" : MessageLookupByLibrary.simpleMessage("You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
-    "eulaParagraphe9" : MessageLookupByLibrary.simpleMessage("We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-    "eulaTitle1" : m45,
-    "eulaTitle10" : MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
-    "eulaTitle11" : MessageLookupByLibrary.simpleMessage("INTELLECTUAL PROPERTY RIGHTS"),
-    "eulaTitle12" : MessageLookupByLibrary.simpleMessage("DISCLAIMER"),
-    "eulaTitle13" : MessageLookupByLibrary.simpleMessage("REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY"),
-    "eulaTitle14" : MessageLookupByLibrary.simpleMessage("GENERAL RISK FACTORS"),
-    "eulaTitle15" : MessageLookupByLibrary.simpleMessage("INDEMNIFICATION"),
-    "eulaTitle16" : MessageLookupByLibrary.simpleMessage("RISK DISCLOSURES RELATING TO THE WALLET"),
-    "eulaTitle17" : MessageLookupByLibrary.simpleMessage("NO INVESTMENT ADVICE OR BROKERAGE"),
-    "eulaTitle18" : MessageLookupByLibrary.simpleMessage("TERMINATION"),
-    "eulaTitle19" : MessageLookupByLibrary.simpleMessage("THIRD PARTY RIGHTS"),
-    "eulaTitle2" : MessageLookupByLibrary.simpleMessage("TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)"),
-    "eulaTitle20" : MessageLookupByLibrary.simpleMessage("OUR LEGAL OBLIGATIONS"),
-    "eulaTitle3" : MessageLookupByLibrary.simpleMessage("TERMS AND CONDITIONS OF USE AND DISCLAIMER"),
-    "eulaTitle4" : MessageLookupByLibrary.simpleMessage("GENERAL USE"),
-    "eulaTitle5" : MessageLookupByLibrary.simpleMessage("MODIFICATIONS"),
-    "eulaTitle6" : MessageLookupByLibrary.simpleMessage("LIMITATIONS ON USE"),
-    "eulaTitle7" : MessageLookupByLibrary.simpleMessage("ACCOUNTS AND MEMBERSHIP"),
-    "eulaTitle8" : MessageLookupByLibrary.simpleMessage("BACKUPS"),
-    "eulaTitle9" : MessageLookupByLibrary.simpleMessage("GENERAL WARNING"),
-    "exampleHintSeed" : MessageLookupByLibrary.simpleMessage("Ejemplo: build case level ..."),
-    "exchangeExpedient" : MessageLookupByLibrary.simpleMessage("Expediente"),
-    "exchangeExpensive" : MessageLookupByLibrary.simpleMessage("Caro"),
-    "exchangeIdentical" : MessageLookupByLibrary.simpleMessage("Identico a CEX"),
-    "exchangeRate" : MessageLookupByLibrary.simpleMessage("Tipo de cambio:"),
-    "exchangeTitle" : MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
-    "exportButton" : MessageLookupByLibrary.simpleMessage("Exportar"),
-    "exportContactsTitle" : MessageLookupByLibrary.simpleMessage("Contactos"),
-    "exportDesc" : MessageLookupByLibrary.simpleMessage("Seleccione elementos para exportar a un archivo cifrado."),
-    "exportLink" : MessageLookupByLibrary.simpleMessage("Exportar"),
-    "exportNotesTitle" : MessageLookupByLibrary.simpleMessage("Notas"),
-    "exportSuccessTitle" : MessageLookupByLibrary.simpleMessage("Los elementos se han exportado correctamente:"),
-    "exportSwapsTitle" : MessageLookupByLibrary.simpleMessage("Intercambios"),
-    "exportTitle" : MessageLookupByLibrary.simpleMessage("Exportar"),
-    "fakeBalanceAmt" : MessageLookupByLibrary.simpleMessage("Cantidad de saldo falso:"),
-    "faqTitle" : MessageLookupByLibrary.simpleMessage("Preguntas frecuentes"),
-    "faucetError" : MessageLookupByLibrary.simpleMessage("Error"),
-    "faucetInProgress" : m46,
-    "faucetName" : MessageLookupByLibrary.simpleMessage("GRIFO"),
-    "faucetSuccess" : MessageLookupByLibrary.simpleMessage("Éxito"),
-    "faucetTimedOut" : MessageLookupByLibrary.simpleMessage("Tiempo de espera agotado"),
-    "feedNewsTab" : MessageLookupByLibrary.simpleMessage("Noticias"),
-    "feedNotFound" : MessageLookupByLibrary.simpleMessage("Nada aquí"),
-    "feedNotifTitle" : m47,
-    "feedReadMore" : MessageLookupByLibrary.simpleMessage("Leer más..."),
-    "feedTab" : MessageLookupByLibrary.simpleMessage("Informacion"),
-    "feedTitle" : MessageLookupByLibrary.simpleMessage("Noticias"),
-    "feedUnableToProceed" : MessageLookupByLibrary.simpleMessage("No se puede continuar con la actualización de noticias"),
-    "feedUnableToUpdate" : MessageLookupByLibrary.simpleMessage("No se puede obtener la actualización de noticias"),
-    "feedUpToDate" : MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
-    "feedUpdated" : MessageLookupByLibrary.simpleMessage("Fuente de noticias actualizada"),
-    "feedback" : MessageLookupByLibrary.simpleMessage("Compartir archivo de registro"),
-    "feesError" : m48,
-    "filtersAll" : MessageLookupByLibrary.simpleMessage("Todo"),
-    "filtersButton" : MessageLookupByLibrary.simpleMessage("Filtro"),
-    "filtersClearAll" : MessageLookupByLibrary.simpleMessage("Borrar todos los filtros"),
-    "filtersFailed" : MessageLookupByLibrary.simpleMessage("Fallido"),
-    "filtersFrom" : MessageLookupByLibrary.simpleMessage("Partir de la fecha"),
-    "filtersMaker" : MessageLookupByLibrary.simpleMessage("Vendedor"),
-    "filtersReceive" : MessageLookupByLibrary.simpleMessage("Recibir moneda"),
-    "filtersSell" : MessageLookupByLibrary.simpleMessage("Vender moneda"),
-    "filtersStatus" : MessageLookupByLibrary.simpleMessage("Estado"),
-    "filtersSuccessful" : MessageLookupByLibrary.simpleMessage("Exitoso"),
-    "filtersTaker" : MessageLookupByLibrary.simpleMessage("Comprador"),
-    "filtersTo" : MessageLookupByLibrary.simpleMessage("Hasta la fecha"),
-    "filtersType" : MessageLookupByLibrary.simpleMessage("Comprador/Vendedor"),
-    "fingerprint" : MessageLookupByLibrary.simpleMessage("Huella dactilar"),
-    "finishingUp" : MessageLookupByLibrary.simpleMessage("Terminando, por favor espera."),
-    "foundQrCode" : MessageLookupByLibrary.simpleMessage("Código QR encontrado"),
-    "frenchLanguage" : MessageLookupByLibrary.simpleMessage("Francés"),
-    "from" : MessageLookupByLibrary.simpleMessage("Desde"),
-    "futureTransactions" : MessageLookupByLibrary.simpleMessage("Sincronizaremos las transacciones futuras realizadas después de la activación asociada con su clave pública. Esta es la opción más rápida y ocupa la menor cantidad de almacenamiento."),
-    "gasFee" : m49,
-    "gasLimit" : MessageLookupByLibrary.simpleMessage("Limite de Gas"),
-    "gasNotActive" : m50,
-    "gasPrice" : MessageLookupByLibrary.simpleMessage("Precio de Gas"),
-    "generalPinNotActive" : MessageLookupByLibrary.simpleMessage("La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN."),
-    "getBackupPhrase" : MessageLookupByLibrary.simpleMessage("Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!"),
-    "gettingTxWait" : MessageLookupByLibrary.simpleMessage("Obteniendo transacción, por favor espere"),
-    "goToPorfolio" : MessageLookupByLibrary.simpleMessage("Ir al portafolio"),
-    "helpLink" : MessageLookupByLibrary.simpleMessage("Ayuda"),
-    "helpTitle" : MessageLookupByLibrary.simpleMessage("Ayuda y apoyo"),
-    "hideBalance" : MessageLookupByLibrary.simpleMessage("Ocultar saldos"),
-    "hintConfirmPassword" : MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
-    "hintCreatePassword" : MessageLookupByLibrary.simpleMessage("Crear contraseña"),
-    "hintCurrentPassword" : MessageLookupByLibrary.simpleMessage("Contraseña actual"),
-    "hintEnterPassword" : MessageLookupByLibrary.simpleMessage("Ingresa tu contraseña"),
-    "hintEnterSeedPhrase" : MessageLookupByLibrary.simpleMessage("Ingrese su frase inicial"),
-    "hintNameYourWallet" : MessageLookupByLibrary.simpleMessage("Nombra tu billetera"),
-    "hintPassword" : MessageLookupByLibrary.simpleMessage("Clave"),
-    "history" : MessageLookupByLibrary.simpleMessage("historia"),
-    "hours" : MessageLookupByLibrary.simpleMessage("h"),
-    "hungarianLanguage" : MessageLookupByLibrary.simpleMessage("Húngaro"),
-    "iUnderstand" : MessageLookupByLibrary.simpleMessage("Entiendo"),
-    "importButton" : MessageLookupByLibrary.simpleMessage("Importar"),
-    "importDecryptError" : MessageLookupByLibrary.simpleMessage("Contraseña no válida o datos dañados"),
-    "importDesc" : MessageLookupByLibrary.simpleMessage("Elementos a importar:"),
-    "importFileNotFound" : MessageLookupByLibrary.simpleMessage("Archivo no encontrado"),
-    "importInvalidSwapData" : MessageLookupByLibrary.simpleMessage("Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido."),
-    "importLink" : MessageLookupByLibrary.simpleMessage("Importar"),
-    "importLoadDesc" : MessageLookupByLibrary.simpleMessage("Seleccione el archivo cifrado para importar."),
-    "importLoadSwapDesc" : MessageLookupByLibrary.simpleMessage("Seleccione el archivo de intercambio de texto sin formato para importar."),
-    "importLoading" : MessageLookupByLibrary.simpleMessage("Abriendo..."),
-    "importPassCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "importPassOk" : MessageLookupByLibrary.simpleMessage("Ok"),
-    "importPassword" : MessageLookupByLibrary.simpleMessage("Clave"),
-    "importSingleSwapLink" : MessageLookupByLibrary.simpleMessage("Importar un Intercambio"),
-    "importSingleSwapTitle" : MessageLookupByLibrary.simpleMessage("Importar Intercambio"),
-    "importSomeItemsSkippedWarning" : MessageLookupByLibrary.simpleMessage("Se han saltado algunos elementos"),
-    "importSuccessTitle" : MessageLookupByLibrary.simpleMessage("Los elementos se han importado correctamente:"),
-    "importSwapFailed" : MessageLookupByLibrary.simpleMessage("No se pudo importar el intercambio"),
-    "importSwapJsonDecodingError" : MessageLookupByLibrary.simpleMessage("Error al decodificar el archivo json"),
-    "importTitle" : MessageLookupByLibrary.simpleMessage("Importar"),
-    "incomingTransactionsProtectionSettings" : m52,
-    "infoPasswordDialog" : MessageLookupByLibrary.simpleMessage("Utilice una contraseña segura y no la almacene en el mismo dispositivo"),
-    "infoTrade1" : MessageLookupByLibrary.simpleMessage("¡La solicitud de intercambio no se puede deshacer y es un evento final!"),
-    "infoTrade2" : MessageLookupByLibrary.simpleMessage("El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!"),
-    "infoWalletPassword" : MessageLookupByLibrary.simpleMessage("Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad."),
-    "insufficientBalanceToPay" : m53,
-    "insufficientText" : MessageLookupByLibrary.simpleMessage("El volumen mínimo requerido por este pedido es"),
-    "insufficientTitle" : MessageLookupByLibrary.simpleMessage("Volumen insuficiente"),
-    "internetRefreshButton" : MessageLookupByLibrary.simpleMessage("Actualizar"),
-    "internetRestored" : MessageLookupByLibrary.simpleMessage("Conexión a Internet restaurada"),
-    "invalidSwap" : MessageLookupByLibrary.simpleMessage("No se puede continuar con el intercambio"),
-    "invalidSwapDetailsLink" : MessageLookupByLibrary.simpleMessage("Detalles"),
-    "isUnavailable" : m55,
-    "japaneseLanguage" : MessageLookupByLibrary.simpleMessage("Japonés"),
-    "koreanLanguage" : MessageLookupByLibrary.simpleMessage("Coreano"),
-    "language" : MessageLookupByLibrary.simpleMessage("Idioma"),
-    "latestTxs" : MessageLookupByLibrary.simpleMessage("Últimas transacciones"),
-    "legalTitle" : MessageLookupByLibrary.simpleMessage("Legal"),
-    "less" : MessageLookupByLibrary.simpleMessage("menos"),
-    "lessThanCaution" : m56,
-    "loading" : MessageLookupByLibrary.simpleMessage("Cargando..."),
-    "loadingOrderbook" : MessageLookupByLibrary.simpleMessage("Cargando libro de ordenes..."),
-    "lockScreen" : MessageLookupByLibrary.simpleMessage("La pantalla está bloqueada"),
-    "lockScreenAuth" : MessageLookupByLibrary.simpleMessage("¡Por favor, autentícate!"),
-    "login" : MessageLookupByLibrary.simpleMessage("acceso"),
-    "logout" : MessageLookupByLibrary.simpleMessage("Cerrar sesión"),
-    "logoutOnExit" : MessageLookupByLibrary.simpleMessage("Cerrar sesión al salir"),
-    "logoutWarning" : MessageLookupByLibrary.simpleMessage("¿Estás seguro de que quieres cerrar sesión ahora?"),
-    "logoutsettings" : MessageLookupByLibrary.simpleMessage("Configuración de cierre de sesión"),
-    "longMinutes" : MessageLookupByLibrary.simpleMessage("Minutos"),
-    "makeAorder" : MessageLookupByLibrary.simpleMessage("hacer un pedido"),
-    "makerDetailsCancel" : MessageLookupByLibrary.simpleMessage("Cancelar orden"),
-    "makerDetailsCreated" : MessageLookupByLibrary.simpleMessage("Createdo en"),
-    "makerDetailsFor" : MessageLookupByLibrary.simpleMessage("Recibir"),
-    "makerDetailsId" : MessageLookupByLibrary.simpleMessage("ID de Orden"),
-    "makerDetailsNoSwaps" : MessageLookupByLibrary.simpleMessage("Este pedido no inició intercambios"),
-    "makerDetailsPrice" : MessageLookupByLibrary.simpleMessage("Precio"),
-    "makerDetailsSell" : MessageLookupByLibrary.simpleMessage("Vender"),
-    "makerDetailsSwaps" : MessageLookupByLibrary.simpleMessage("Intercambios iniciados por este pedido"),
-    "makerDetailsTitle" : MessageLookupByLibrary.simpleMessage("Detalles del pedido del fabricante"),
-    "makerOrder" : MessageLookupByLibrary.simpleMessage("Orden de Vendedor"),
-    "marketplace" : MessageLookupByLibrary.simpleMessage("Mercado"),
-    "marketsChart" : MessageLookupByLibrary.simpleMessage("Gráfico"),
-    "marketsDepth" : MessageLookupByLibrary.simpleMessage("Profundidad"),
-    "marketsNoAsks" : MessageLookupByLibrary.simpleMessage("No se encontraron solicitudes"),
-    "marketsNoBids" : MessageLookupByLibrary.simpleMessage("No se encontraron ofertas"),
-    "marketsOrderDetails" : MessageLookupByLibrary.simpleMessage("Detalles del Pedido"),
-    "marketsOrderbook" : MessageLookupByLibrary.simpleMessage("LIBRO DE ORDENES"),
-    "marketsPrice" : MessageLookupByLibrary.simpleMessage("PRECIO"),
-    "marketsSelectCoins" : MessageLookupByLibrary.simpleMessage("Por favor seleccione monedas"),
-    "marketsTab" : MessageLookupByLibrary.simpleMessage("Mercados"),
-    "marketsTitle" : MessageLookupByLibrary.simpleMessage("MERCADOS"),
-    "matchExportPass" : MessageLookupByLibrary.simpleMessage("Las contraseñas deben coincidir"),
-    "matchingCamoChange" : MessageLookupByLibrary.simpleMessage("Cambiar"),
-    "matchingCamoPinError" : MessageLookupByLibrary.simpleMessage("Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje."),
-    "matchingCamoTitle" : MessageLookupByLibrary.simpleMessage("PIN Invalido"),
-    "max" : MessageLookupByLibrary.simpleMessage("MAXIMO"),
-    "maxOrder" : MessageLookupByLibrary.simpleMessage("Volumen máximo de pedidos:"),
-    "media" : MessageLookupByLibrary.simpleMessage("Noticias"),
-    "mediaBrowse" : MessageLookupByLibrary.simpleMessage("NAVEGAR"),
-    "mediaBrowseFeed" : MessageLookupByLibrary.simpleMessage("NAVEGAR RSS"),
-    "mediaBy" : MessageLookupByLibrary.simpleMessage("By"),
-    "mediaNotSavedDescription" : MessageLookupByLibrary.simpleMessage("NO TIENES ARTÍCULOS GUARDADOS"),
-    "mediaSaved" : MessageLookupByLibrary.simpleMessage("GUARDADO"),
-    "memo" : MessageLookupByLibrary.simpleMessage("Memorándum"),
-    "merge" : MessageLookupByLibrary.simpleMessage("Unir"),
-    "mergedValue" : MessageLookupByLibrary.simpleMessage("Valor combinado:"),
-    "milliseconds" : MessageLookupByLibrary.simpleMessage("ms"),
-    "min" : MessageLookupByLibrary.simpleMessage("Min"),
-    "minOrder" : MessageLookupByLibrary.simpleMessage("Volumen mínimo de pedido:"),
-    "minValue" : m58,
-    "minValueBuy" : m59,
-    "minValueOrder" : m60,
-    "minValueSell" : m61,
-    "minVolumeInput" : m62,
-    "minVolumeIsTDH" : MessageLookupByLibrary.simpleMessage("Debe ser menor que el monto de venta"),
-    "minVolumeTitle" : MessageLookupByLibrary.simpleMessage("Volumen mínimo requerido"),
-    "minVolumeToggle" : MessageLookupByLibrary.simpleMessage("Usar volumen mínimo personalizado"),
-    "minimizingWillTerminate" : MessageLookupByLibrary.simpleMessage("Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación."),
-    "minutes" : MessageLookupByLibrary.simpleMessage("m"),
-    "mobileDataWarning" : m63,
-    "moreInfo" : MessageLookupByLibrary.simpleMessage("Más información"),
-    "moreTab" : MessageLookupByLibrary.simpleMessage("Mas"),
-    "multiActivateGas" : m64,
-    "multiBaseAmtPlaceholder" : MessageLookupByLibrary.simpleMessage("Cantidad"),
-    "multiBasePlaceholder" : MessageLookupByLibrary.simpleMessage("Moneda"),
-    "multiBaseSelectTitle" : MessageLookupByLibrary.simpleMessage("Vender"),
-    "multiConfirmCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "multiConfirmConfirm" : MessageLookupByLibrary.simpleMessage("Confirmar"),
-    "multiConfirmTitle" : m65,
-    "multiCreate" : MessageLookupByLibrary.simpleMessage("Crear"),
-    "multiCreateOrder" : MessageLookupByLibrary.simpleMessage("Orden"),
-    "multiCreateOrders" : MessageLookupByLibrary.simpleMessage("Ordenes"),
-    "multiEthFee" : MessageLookupByLibrary.simpleMessage("costo"),
-    "multiFiatCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "multiFiatDesc" : MessageLookupByLibrary.simpleMessage("Ingrese la cantidad de dinero para recibir:"),
-    "multiFiatFill" : MessageLookupByLibrary.simpleMessage("Autollenarl"),
-    "multiFixErrors" : MessageLookupByLibrary.simpleMessage("Corrija todos los errores antes de continuar"),
-    "multiInvalidAmt" : MessageLookupByLibrary.simpleMessage("Monto invalido"),
-    "multiInvalidSellAmt" : MessageLookupByLibrary.simpleMessage("Cantidad de venta no válido"),
-    "multiLowGas" : m66,
-    "multiLowerThanFee" : m67,
-    "multiMaxSellAmt" : MessageLookupByLibrary.simpleMessage("La cantidad máxima de venta es"),
-    "multiMinReceiveAmt" : MessageLookupByLibrary.simpleMessage("La cantidad mínima recibida es"),
-    "multiMinSellAmt" : MessageLookupByLibrary.simpleMessage("La cantidad mínima de venta es"),
-    "multiReceiveTitle" : MessageLookupByLibrary.simpleMessage("Recibir:"),
-    "multiSellTitle" : MessageLookupByLibrary.simpleMessage("Vender:"),
-    "multiTab" : MessageLookupByLibrary.simpleMessage("Multi"),
-    "multiTableAmt" : MessageLookupByLibrary.simpleMessage("Recibir Cntd."),
-    "multiTablePrice" : MessageLookupByLibrary.simpleMessage("Precio/CEX"),
-    "networkFee" : MessageLookupByLibrary.simpleMessage("Tarifa de red"),
-    "newAccount" : MessageLookupByLibrary.simpleMessage("nueva cuenta"),
-    "newAccountUpper" : MessageLookupByLibrary.simpleMessage("Nueva Cuenta"),
-    "newValue" : MessageLookupByLibrary.simpleMessage("Nuevo valor:"),
-    "newsFeed" : MessageLookupByLibrary.simpleMessage("Noticias"),
-    "next" : MessageLookupByLibrary.simpleMessage("próximo"),
-    "no" : MessageLookupByLibrary.simpleMessage("No"),
-    "noArticles" : MessageLookupByLibrary.simpleMessage("No hay noticias. Vuelva a consultar más tarde."),
-    "noCoinFound" : MessageLookupByLibrary.simpleMessage("No se encontró ninguna moneda"),
-    "noFunds" : MessageLookupByLibrary.simpleMessage("Sin Fondos"),
-    "noFundsDetected" : MessageLookupByLibrary.simpleMessage("No hay fondos disponibles, por favor deposite."),
-    "noInternet" : MessageLookupByLibrary.simpleMessage("Sin conexión a Internet"),
-    "noItemsToExport" : MessageLookupByLibrary.simpleMessage("No hay artículos seleccionados"),
-    "noItemsToImport" : MessageLookupByLibrary.simpleMessage("No hay artículos seleccionados"),
-    "noMatchingOrders" : MessageLookupByLibrary.simpleMessage("No se encontraron pedidos coincidentes"),
-    "noOrder" : m68,
-    "noOrderAvailable" : MessageLookupByLibrary.simpleMessage("Haga clic para crear un pedido"),
-    "noOrders" : MessageLookupByLibrary.simpleMessage("No hay pedidos, por favor vaya al comercio."),
-    "noRewardYet" : MessageLookupByLibrary.simpleMessage("No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora."),
-    "noRewards" : MessageLookupByLibrary.simpleMessage("No hay recompensas reclamables"),
-    "noSuchCoin" : MessageLookupByLibrary.simpleMessage("No hay tal moneda"),
-    "noSwaps" : MessageLookupByLibrary.simpleMessage("No historia."),
-    "noTxs" : MessageLookupByLibrary.simpleMessage("Sin transacciones"),
-    "nonNumericInput" : MessageLookupByLibrary.simpleMessage("El valor debe ser numérico."),
-    "none" : MessageLookupByLibrary.simpleMessage("Ninguno"),
-    "notEnoughGas" : m69,
-    "notEnoughtBalanceForFee" : MessageLookupByLibrary.simpleMessage("No hay suficiente saldo para las tarifas: opere con una cantidad menor"),
-    "noteOnOrder" : MessageLookupByLibrary.simpleMessage("Nota: el pedido emparejado no se puede cancelar de nuevo"),
-    "notePlaceholder" : MessageLookupByLibrary.simpleMessage("Añadir Nota"),
-    "noteTitle" : MessageLookupByLibrary.simpleMessage("Nota"),
-    "nothingFound" : MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
-    "notifSwapCompletedText" : m70,
-    "notifSwapCompletedTitle" : MessageLookupByLibrary.simpleMessage("Intercambio completado"),
-    "notifSwapFailedText" : m71,
-    "notifSwapFailedTitle" : MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
-    "notifSwapStartedText" : m72,
-    "notifSwapStartedTitle" : MessageLookupByLibrary.simpleMessage("Nuevo intercambio iniciado"),
-    "notifSwapStatusTitle" : MessageLookupByLibrary.simpleMessage("Cambio de estado cambiado"),
-    "notifSwapTimeoutText" : m73,
-    "notifSwapTimeoutTitle" : MessageLookupByLibrary.simpleMessage("Se agotó el tiempo de intercambio"),
-    "notifTxText" : m74,
-    "notifTxTitle" : MessageLookupByLibrary.simpleMessage("Transaccion entrante"),
-    "numberAssets" : m75,
-    "officialPressRelease" : MessageLookupByLibrary.simpleMessage("comunicado de prensa oficial"),
-    "okButton" : MessageLookupByLibrary.simpleMessage("Ok"),
-    "oldLogsDelete" : MessageLookupByLibrary.simpleMessage("Borrar"),
-    "oldLogsTitle" : MessageLookupByLibrary.simpleMessage("Registros antiguos"),
-    "oldLogsUsed" : MessageLookupByLibrary.simpleMessage("Espacio usado"),
-    "openMessage" : MessageLookupByLibrary.simpleMessage("Abrir mensaje de error"),
-    "orderBookLess" : MessageLookupByLibrary.simpleMessage("Menos"),
-    "orderBookMore" : MessageLookupByLibrary.simpleMessage("Más"),
-    "orderCancel" : m76,
-    "orderCreated" : MessageLookupByLibrary.simpleMessage("Pedido creado"),
-    "orderCreatedInfo" : MessageLookupByLibrary.simpleMessage("Pedido creado con éxito"),
-    "orderDetailsAddress" : MessageLookupByLibrary.simpleMessage("Direccion"),
-    "orderDetailsCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "orderDetailsExpedient" : m77,
-    "orderDetailsExpensive" : m78,
-    "orderDetailsFor" : MessageLookupByLibrary.simpleMessage("for"),
-    "orderDetailsIdentical" : MessageLookupByLibrary.simpleMessage("Idéntico a CEX"),
-    "orderDetailsMin" : MessageLookupByLibrary.simpleMessage("min."),
-    "orderDetailsPrice" : MessageLookupByLibrary.simpleMessage("Precio"),
-    "orderDetailsReceive" : MessageLookupByLibrary.simpleMessage("Recibir"),
-    "orderDetailsSelect" : MessageLookupByLibrary.simpleMessage("Seleccione"),
-    "orderDetailsSells" : MessageLookupByLibrary.simpleMessage("Ventas"),
-    "orderDetailsSettings" : MessageLookupByLibrary.simpleMessage("Abra detalles con un solo toque y seleccione Ordenar con un toque largo"),
-    "orderDetailsSpend" : MessageLookupByLibrary.simpleMessage("Gastar"),
-    "orderDetailsTitle" : MessageLookupByLibrary.simpleMessage("Detalles"),
-    "orderFilled" : m79,
-    "orderMatched" : MessageLookupByLibrary.simpleMessage("Orden Triangulada"),
-    "orderMatching" : MessageLookupByLibrary.simpleMessage("Triangulación de órdenes"),
-    "orderTypePartial" : MessageLookupByLibrary.simpleMessage("Orden"),
-    "orderTypeUnknown" : MessageLookupByLibrary.simpleMessage("Orden desconocida"),
-    "orders" : MessageLookupByLibrary.simpleMessage("ordenes"),
-    "ordersActive" : MessageLookupByLibrary.simpleMessage("Activo"),
-    "ordersHistory" : MessageLookupByLibrary.simpleMessage("Historial"),
-    "ordersTableAmount" : m80,
-    "ordersTablePrice" : m81,
-    "ordersTableTotal" : m82,
-    "overwrite" : MessageLookupByLibrary.simpleMessage("Sobrescribir"),
-    "ownOrder" : MessageLookupByLibrary.simpleMessage("Esta es tu propia orden!"),
-    "paidFromBalance" : MessageLookupByLibrary.simpleMessage("Pagado del saldo:"),
-    "paidFromVolume" : MessageLookupByLibrary.simpleMessage("Pagado del volumen recibido:"),
-    "paidWith" : MessageLookupByLibrary.simpleMessage("Pagado con"),
-    "passwordRequirement" : MessageLookupByLibrary.simpleMessage("La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial."),
-    "pastTransactionsFromDate" : MessageLookupByLibrary.simpleMessage("Su billetera mostrará sus transacciones pasadas realizadas después de la fecha especificada."),
-    "paymentUriDetailsAccept" : MessageLookupByLibrary.simpleMessage("Pagar"),
-    "paymentUriDetailsAcceptQuestion" : MessageLookupByLibrary.simpleMessage("¿Acepta esta transacción?"),
-    "paymentUriDetailsAddressSpan" : MessageLookupByLibrary.simpleMessage("A Direccion"),
-    "paymentUriDetailsAmountSpan" : MessageLookupByLibrary.simpleMessage("Monto:"),
-    "paymentUriDetailsCoinSpan" : MessageLookupByLibrary.simpleMessage("Moneda:"),
-    "paymentUriDetailsDeny" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "paymentUriDetailsTitle" : MessageLookupByLibrary.simpleMessage("Pago solicitado"),
-    "paymentUriInactiveCoin" : m83,
-    "placeOrder" : MessageLookupByLibrary.simpleMessage("Haga su pedido"),
-    "pleaseAddCoin" : MessageLookupByLibrary.simpleMessage("Por favor agregue una moneda"),
-    "pleaseRestart" : MessageLookupByLibrary.simpleMessage("Reinicie la aplicación para volver a intentarlo o presione el botón a continuación."),
-    "portfolio" : MessageLookupByLibrary.simpleMessage("Portfolio"),
-    "poweredOnKmd" : MessageLookupByLibrary.simpleMessage("Desarrollado por Komodo"),
-    "price" : MessageLookupByLibrary.simpleMessage("price"),
-    "privateKey" : MessageLookupByLibrary.simpleMessage("Llave Privada"),
-    "privateKeys" : MessageLookupByLibrary.simpleMessage("Llaves Privadas"),
-    "protectionCtrlConfirmations" : MessageLookupByLibrary.simpleMessage("Confirmaciones"),
-    "protectionCtrlCustom" : MessageLookupByLibrary.simpleMessage("Usar configuraciones de protección personalizadas"),
-    "protectionCtrlOff" : MessageLookupByLibrary.simpleMessage("DESACTIVADO"),
-    "protectionCtrlOn" : MessageLookupByLibrary.simpleMessage("ACTIVADO"),
-    "protectionCtrlWarning" : MessageLookupByLibrary.simpleMessage("Advertencia, este intercambio atómico no está protegido por dPoW."),
-    "pubkey" : MessageLookupByLibrary.simpleMessage("Llave Publica"),
-    "qrCodeScanner" : MessageLookupByLibrary.simpleMessage("Escáner de código QR"),
-    "question_1" : MessageLookupByLibrary.simpleMessage("¿Guardás mis llaves privadas?"),
-    "question_10" : m84,
-    "question_2" : m85,
-    "question_3" : MessageLookupByLibrary.simpleMessage("¿Cuánto tiempo toma cada intercambio atómico?"),
-    "question_4" : MessageLookupByLibrary.simpleMessage("¿Necesito estar en línea durante la duración del intercambio?"),
-    "question_5" : m86,
-    "question_6" : MessageLookupByLibrary.simpleMessage("¿Ofrecen soporte al usuario?"),
-    "question_7" : MessageLookupByLibrary.simpleMessage("¿Tiene restricciones de país?"),
-    "question_8" : m87,
-    "question_9" : m88,
-    "rebrandingAnnouncement" : MessageLookupByLibrary.simpleMessage("¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de \'AtomicDEX\' a \'Komodo Wallet\'"),
-    "receive" : MessageLookupByLibrary.simpleMessage("RECIBIR"),
-    "receiveLower" : MessageLookupByLibrary.simpleMessage("Recibir"),
-    "recommendSeedMessage" : MessageLookupByLibrary.simpleMessage("Recomendamos almacenarlo fuera de línea."),
-    "remove" : MessageLookupByLibrary.simpleMessage("Desactivar"),
-    "requestedTrade" : MessageLookupByLibrary.simpleMessage("Comercio solicitado"),
-    "reset" : MessageLookupByLibrary.simpleMessage("RESETEAR"),
-    "resetTitle" : MessageLookupByLibrary.simpleMessage("Restablecer formulario"),
-    "restoreWallet" : MessageLookupByLibrary.simpleMessage("RESTAURAR"),
-    "retryActivating" : MessageLookupByLibrary.simpleMessage("Volviendo a intentar activar todas las monedas..."),
-    "retryAll" : MessageLookupByLibrary.simpleMessage("Vuelva a intentar activar todo"),
-    "rewardsButton" : MessageLookupByLibrary.simpleMessage("Reclama tus recompensas"),
-    "rewardsCancel" : MessageLookupByLibrary.simpleMessage("Cancelar"),
-    "rewardsError" : MessageLookupByLibrary.simpleMessage("Algo salió mal. Por favor, inténtelo de nuevo más tarde."),
-    "rewardsInProgressLong" : MessageLookupByLibrary.simpleMessage("La transacción está en curso"),
-    "rewardsInProgressShort" : MessageLookupByLibrary.simpleMessage("procesando"),
-    "rewardsLowAmountLong" : MessageLookupByLibrary.simpleMessage("Cantidad de UTXO inferior a 10 KMD"),
-    "rewardsLowAmountShort" : MessageLookupByLibrary.simpleMessage("<10 KMD"),
-    "rewardsOneHourLong" : MessageLookupByLibrary.simpleMessage("Aún no ha pasado una hora"),
-    "rewardsOneHourShort" : MessageLookupByLibrary.simpleMessage("<1 hora"),
-    "rewardsPopupOk" : MessageLookupByLibrary.simpleMessage("Ok"),
-    "rewardsPopupTitle" : MessageLookupByLibrary.simpleMessage("Estado de recompensas:"),
-    "rewardsReadMore" : MessageLookupByLibrary.simpleMessage("Obtenga más información sobre las recompensas para usuarios activos de KMD"),
-    "rewardsReceive" : MessageLookupByLibrary.simpleMessage("Recibir"),
-    "rewardsSuccess" : m89,
-    "rewardsTableFiat" : MessageLookupByLibrary.simpleMessage("Fiat"),
-    "rewardsTableRewards" : MessageLookupByLibrary.simpleMessage("Recompensas,\nKMD"),
-    "rewardsTableStatus" : MessageLookupByLibrary.simpleMessage("Estado"),
-    "rewardsTableTime" : MessageLookupByLibrary.simpleMessage("Tiempo\nrestante"),
-    "rewardsTableTitle" : MessageLookupByLibrary.simpleMessage("Información de recompensas:"),
-    "rewardsTableUXTO" : MessageLookupByLibrary.simpleMessage("UTXO\ncantidad,\nKMD"),
-    "rewardsTimeDays" : m90,
-    "rewardsTimeHours" : m91,
-    "rewardsTimeMin" : m92,
-    "rewardsTitle" : MessageLookupByLibrary.simpleMessage("Información de recompensas"),
-    "russianLanguage" : MessageLookupByLibrary.simpleMessage("Ruso"),
-    "saveMerged" : MessageLookupByLibrary.simpleMessage("Guardar combinado"),
-    "scrollToContinue" : MessageLookupByLibrary.simpleMessage("Desplácese hacia abajo para continuar..."),
-    "searchFilterCoin" : MessageLookupByLibrary.simpleMessage("Buscar una moneda"),
-    "searchFilterSubtitleAVX" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens de Avax"),
-    "searchFilterSubtitleBEP" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens BEP"),
-    "searchFilterSubtitleCosmos" : MessageLookupByLibrary.simpleMessage("Seleccionar todo Cosmos Network"),
-    "searchFilterSubtitleERC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens ERC"),
-    "searchFilterSubtitleETC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens ETC"),
-    "searchFilterSubtitleFTM" : MessageLookupByLibrary.simpleMessage("Seleccionar todas las fichas de Fantom"),
-    "searchFilterSubtitleHCO" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens de HecoChain"),
-    "searchFilterSubtitleHRC" : MessageLookupByLibrary.simpleMessage("Seleccionar todas las fichas de armonía"),
-    "searchFilterSubtitleIris" : MessageLookupByLibrary.simpleMessage("Seleccionar todo Iris Network"),
-    "searchFilterSubtitleKRC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens de Kucoin"),
-    "searchFilterSubtitleMVR" : MessageLookupByLibrary.simpleMessage("Seleccione todas las fichas de Moonriver"),
-    "searchFilterSubtitlePLG" : MessageLookupByLibrary.simpleMessage("Seleccione todas las fichas de polígono"),
-    "searchFilterSubtitleQRC" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens QRC"),
-    "searchFilterSubtitleSBCH" : MessageLookupByLibrary.simpleMessage("Seleccione todos los tokens SmartBCH"),
-    "searchFilterSubtitleSLP" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los tokens SLP"),
-    "searchFilterSubtitleSmartChain" : MessageLookupByLibrary.simpleMessage("Seleccione todos los SmartChains"),
-    "searchFilterSubtitleTestCoins" : MessageLookupByLibrary.simpleMessage("Seleccionar todos los activos de prueba"),
-    "searchFilterSubtitleUBQ" : MessageLookupByLibrary.simpleMessage("Seleccionar todas las monedas Ubiq"),
-    "searchFilterSubtitleZHTLC" : MessageLookupByLibrary.simpleMessage("Seleccione todas las monedas ZHTLC"),
-    "searchFilterSubtitleutxo" : MessageLookupByLibrary.simpleMessage("Seleccione todas las monedas UTXO"),
-    "searchForTicker" : MessageLookupByLibrary.simpleMessage("Buscar teletipo"),
-    "seconds" : MessageLookupByLibrary.simpleMessage("s"),
-    "security" : MessageLookupByLibrary.simpleMessage("Seguridad"),
-    "seeOrders" : m93,
-    "seeTxHistory" : MessageLookupByLibrary.simpleMessage("Ver historial de transacciones"),
-    "seedPhrase" : MessageLookupByLibrary.simpleMessage("Frase Semilla"),
-    "seedPhraseTitle" : MessageLookupByLibrary.simpleMessage("Tu nueva frase semilla"),
-    "selectCoin" : MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
-    "selectCoinInfo" : MessageLookupByLibrary.simpleMessage("Seleccione las monedas que desea agregar a su cartera."),
-    "selectCoinTitle" : MessageLookupByLibrary.simpleMessage("Activar monedas:"),
-    "selectCoinToBuy" : MessageLookupByLibrary.simpleMessage("Seleccione la moneda que desea COMPRAR"),
-    "selectCoinToSell" : MessageLookupByLibrary.simpleMessage("Seleccione la moneda que desea VENDER"),
-    "selectDate" : MessageLookupByLibrary.simpleMessage("Seleccione una fecha"),
-    "selectFileImport" : MessageLookupByLibrary.simpleMessage("Seleccione Archivo"),
-    "selectLanguage" : MessageLookupByLibrary.simpleMessage("Seleccione el idioma"),
-    "selectPaymentMethod" : MessageLookupByLibrary.simpleMessage("Selecciona tu forma de pago"),
-    "selectedOrder" : MessageLookupByLibrary.simpleMessage("Orden seleccionado:"),
-    "sell" : MessageLookupByLibrary.simpleMessage("Vender"),
-    "sellTestCoinWarning" : MessageLookupByLibrary.simpleMessage("¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!"),
-    "send" : MessageLookupByLibrary.simpleMessage("ENVIAR"),
-    "setUpPassword" : MessageLookupByLibrary.simpleMessage("CONFIGURAR UNA CONTRASEÑA"),
-    "settingDialogSpan1" : MessageLookupByLibrary.simpleMessage("Estás seguro de que quieres eliminar"),
-    "settingDialogSpan2" : MessageLookupByLibrary.simpleMessage("billetera?"),
-    "settingDialogSpan3" : MessageLookupByLibrary.simpleMessage("Si es así, asegúrese de"),
-    "settingDialogSpan4" : MessageLookupByLibrary.simpleMessage("guardar su frase inicial."),
-    "settingDialogSpan5" : MessageLookupByLibrary.simpleMessage("Para restaurar su billetera en el futuro."),
-    "settingLanguageTitle" : MessageLookupByLibrary.simpleMessage("Idiomas"),
-    "settings" : MessageLookupByLibrary.simpleMessage("Ajustes"),
-    "share" : MessageLookupByLibrary.simpleMessage("Compartir"),
-    "shareAddress" : m94,
-    "showAddress" : MessageLookupByLibrary.simpleMessage("Mostrar dirección"),
-    "showDetails" : MessageLookupByLibrary.simpleMessage("Mostrar detalles"),
-    "showMyOrders" : MessageLookupByLibrary.simpleMessage("Mostrar mis pedidos"),
-    "showingOrders" : m96,
-    "signInWithPassword" : MessageLookupByLibrary.simpleMessage("Iniciar sesión con contraseña"),
-    "signInWithSeedPhrase" : MessageLookupByLibrary.simpleMessage("¿Olvidó la contraseña? Restaurar billetera desde semilla"),
-    "simple" : MessageLookupByLibrary.simpleMessage("Sencillo"),
-    "simpleTradeActivate" : MessageLookupByLibrary.simpleMessage("Activar"),
-    "simpleTradeBuyHint" : m97,
-    "simpleTradeBuyTitle" : MessageLookupByLibrary.simpleMessage("Comprar"),
-    "simpleTradeClose" : MessageLookupByLibrary.simpleMessage("Cerrar"),
-    "simpleTradeMaxActiveCoins" : m98,
-    "simpleTradeNotActive" : m99,
-    "simpleTradeRecieve" : MessageLookupByLibrary.simpleMessage("Recibir"),
-    "simpleTradeSellHint" : m100,
-    "simpleTradeSellTitle" : MessageLookupByLibrary.simpleMessage("Vender"),
-    "simpleTradeSend" : MessageLookupByLibrary.simpleMessage("Enviar"),
-    "simpleTradeShowLess" : MessageLookupByLibrary.simpleMessage("Muestra menos"),
-    "simpleTradeShowMore" : MessageLookupByLibrary.simpleMessage("Mostrar mas"),
-    "simpleTradeUnableActivate" : m101,
-    "skip" : MessageLookupByLibrary.simpleMessage("Omitir"),
-    "snackbarDismiss" : MessageLookupByLibrary.simpleMessage("Descartar"),
-    "soundCantPlayThatMsg" : m102,
-    "soundPlayedWhen" : m103,
-    "soundSettingsLink" : MessageLookupByLibrary.simpleMessage("Sonido"),
-    "soundSettingsTitle" : MessageLookupByLibrary.simpleMessage("Ajustes de sonido"),
-    "soundsDialogTitle" : MessageLookupByLibrary.simpleMessage("Sonidos"),
-    "soundsDoNotShowAgain" : MessageLookupByLibrary.simpleMessage("Entendido, no lo muestres más."),
-    "soundsExplanation" : MessageLookupByLibrary.simpleMessage("Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo."),
-    "soundsNote" : MessageLookupByLibrary.simpleMessage("Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación."),
-    "spanishLanguage" : MessageLookupByLibrary.simpleMessage("Español"),
-    "startDate" : MessageLookupByLibrary.simpleMessage("Fecha de inicio"),
-    "startSwap" : MessageLookupByLibrary.simpleMessage("Iniciar intercambio"),
-    "step" : MessageLookupByLibrary.simpleMessage("Paso"),
-    "success" : MessageLookupByLibrary.simpleMessage("¡Éxito!"),
-    "support" : MessageLookupByLibrary.simpleMessage("Apoyo"),
-    "supportLinksDesc" : m104,
-    "swap" : MessageLookupByLibrary.simpleMessage("intercambio"),
-    "swapCurrent" : MessageLookupByLibrary.simpleMessage("Actual"),
-    "swapDetailTitle" : MessageLookupByLibrary.simpleMessage("CONFIRMAR DETALLES DE CAMBIO"),
-    "swapEstimated" : MessageLookupByLibrary.simpleMessage("Estimado"),
-    "swapFailed" : MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
-    "swapGasActivate" : m105,
-    "swapGasAmount" : m106,
-    "swapGasAmountRequired" : m107,
-    "swapOngoing" : MessageLookupByLibrary.simpleMessage("Intercambio en curso"),
-    "swapProgress" : MessageLookupByLibrary.simpleMessage("Detalles del Progreso"),
-    "swapStarted" : MessageLookupByLibrary.simpleMessage("Iniciado"),
-    "swapSucceful" : MessageLookupByLibrary.simpleMessage("Intercambio exitoso"),
-    "swapTotal" : MessageLookupByLibrary.simpleMessage("Total"),
-    "swapUUID" : MessageLookupByLibrary.simpleMessage("Intercambiar UUID"),
-    "switchTheme" : MessageLookupByLibrary.simpleMessage("Cambiar Tema"),
-    "syncFromDate" : MessageLookupByLibrary.simpleMessage("Sincronización desde la fecha especificada"),
-    "syncFromSaplingActivation" : MessageLookupByLibrary.simpleMessage("Sincronización desde la activación del retoño"),
-    "syncNewTransactions" : MessageLookupByLibrary.simpleMessage("Sincronizar nuevas transacciones"),
-    "tagAVX20" : MessageLookupByLibrary.simpleMessage("AVX20"),
-    "tagBEP20" : MessageLookupByLibrary.simpleMessage("BEP20"),
-    "tagERC20" : MessageLookupByLibrary.simpleMessage("ERC20"),
-    "tagETC" : MessageLookupByLibrary.simpleMessage("ETC"),
-    "tagFTM20" : MessageLookupByLibrary.simpleMessage("FTM20"),
-    "tagHCO20" : MessageLookupByLibrary.simpleMessage("HCO20"),
-    "tagHRC20" : MessageLookupByLibrary.simpleMessage("HRC20"),
-    "tagKMD" : MessageLookupByLibrary.simpleMessage("KMD"),
-    "tagKRC20" : MessageLookupByLibrary.simpleMessage("KRC20"),
-    "tagMVR20" : MessageLookupByLibrary.simpleMessage("MVR20"),
-    "tagPLG20" : MessageLookupByLibrary.simpleMessage("PLG20"),
-    "tagQRC20" : MessageLookupByLibrary.simpleMessage("QRC20"),
-    "tagSBCH" : MessageLookupByLibrary.simpleMessage("SBCH"),
-    "tagUBQ" : MessageLookupByLibrary.simpleMessage("UBQ"),
-    "tagZHTLC" : MessageLookupByLibrary.simpleMessage("ZHTLC"),
-    "takerOrder" : MessageLookupByLibrary.simpleMessage("Orden de Comprador"),
-    "timeOut" : MessageLookupByLibrary.simpleMessage("Se acabó el tiempo"),
-    "titleCreatePassword" : MessageLookupByLibrary.simpleMessage("CREA UNA CONTRASEÑA"),
-    "titleCurrentAsk" : MessageLookupByLibrary.simpleMessage("Pedido seleccionado"),
-    "to" : MessageLookupByLibrary.simpleMessage("Para"),
-    "toAddress" : MessageLookupByLibrary.simpleMessage("Hacia:"),
-    "tooManyAssetsEnabledSpan1" : MessageLookupByLibrary.simpleMessage("Tu tienes"),
-    "tooManyAssetsEnabledSpan2" : MessageLookupByLibrary.simpleMessage("activos habilitados. El límite máximo de activos habilitados es"),
-    "tooManyAssetsEnabledSpan3" : MessageLookupByLibrary.simpleMessage(". Desactive algunos antes de agregar otros nuevos."),
-    "tooManyAssetsEnabledTitle" : MessageLookupByLibrary.simpleMessage("Demasiados recursos habilitados"),
-    "totalFees" : MessageLookupByLibrary.simpleMessage("Tarifas totales:"),
-    "trade" : MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
-    "tradeCompleted" : MessageLookupByLibrary.simpleMessage("¡CAMBIO COMPLETADO!"),
-    "tradeDetail" : MessageLookupByLibrary.simpleMessage("DETALLES INTERCAMBIO"),
-    "tradePreimageError" : MessageLookupByLibrary.simpleMessage("Error al calcular las tarifas comerciales"),
-    "tradingFee" : MessageLookupByLibrary.simpleMessage("tarifa de negociación:"),
-    "tradingMode" : MessageLookupByLibrary.simpleMessage("Modo de comercio:"),
-    "transactionAddress" : MessageLookupByLibrary.simpleMessage("Dirección de transacción"),
-    "transactionHidden" : MessageLookupByLibrary.simpleMessage("Transacción oculta"),
-    "transactionHiddenPhishing" : MessageLookupByLibrary.simpleMessage("Esta transacción fue ocultada debido a un posible intento de phishing."),
-    "tryRestarting" : MessageLookupByLibrary.simpleMessage("Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación."),
-    "turkishLanguage" : MessageLookupByLibrary.simpleMessage("Turco"),
-    "txBlock" : MessageLookupByLibrary.simpleMessage("Bloque"),
-    "txConfirmations" : MessageLookupByLibrary.simpleMessage("Confirmaciones"),
-    "txConfirmed" : MessageLookupByLibrary.simpleMessage("CONFIRMADO"),
-    "txFee" : MessageLookupByLibrary.simpleMessage("Tarifa"),
-    "txFeeTitle" : MessageLookupByLibrary.simpleMessage("tarifa de transacción:"),
-    "txHash" : MessageLookupByLibrary.simpleMessage("ID de transacción"),
-    "txLimitExceeded" : MessageLookupByLibrary.simpleMessage("Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde."),
-    "txNotConfirmed" : MessageLookupByLibrary.simpleMessage("INCONFIRMADO"),
-    "txleft" : m109,
-    "ukrainianLanguage" : MessageLookupByLibrary.simpleMessage("Ucranio"),
-    "unlock" : MessageLookupByLibrary.simpleMessage("desbloquear"),
-    "unlockFunds" : MessageLookupByLibrary.simpleMessage("Desbloquear fondos"),
-    "unlockSuccess" : m110,
-    "unspendable" : MessageLookupByLibrary.simpleMessage("ingastable"),
-    "updatesAvailable" : MessageLookupByLibrary.simpleMessage("Nueva versión disponible"),
-    "updatesChecking" : MessageLookupByLibrary.simpleMessage("Comprobando actualizaciones..."),
-    "updatesCurrentVersion" : m111,
-    "updatesNotifAvailable" : MessageLookupByLibrary.simpleMessage("Nueva versión disponible. Por favor actualice."),
-    "updatesNotifAvailableVersion" : m112,
-    "updatesNotifTitle" : MessageLookupByLibrary.simpleMessage("Actualización disponible"),
-    "updatesSkip" : MessageLookupByLibrary.simpleMessage("Saltar por ahora"),
-    "updatesTitle" : m113,
-    "updatesUpToDate" : MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
-    "updatesUpdate" : MessageLookupByLibrary.simpleMessage("Actualizar"),
-    "uriInsufficientBalanceSpan1" : MessageLookupByLibrary.simpleMessage("No hay suficiente saldo para escaneado"),
-    "uriInsufficientBalanceSpan2" : MessageLookupByLibrary.simpleMessage("solicitud de pago."),
-    "uriInsufficientBalanceTitle" : MessageLookupByLibrary.simpleMessage("Saldo insuficiente"),
-    "value" : MessageLookupByLibrary.simpleMessage("Valor:"),
-    "version" : MessageLookupByLibrary.simpleMessage("version"),
-    "viewInExplorerButton" : MessageLookupByLibrary.simpleMessage("Explorador"),
-    "viewSeedAndKeys" : MessageLookupByLibrary.simpleMessage("Semilla y Claves Privadas"),
-    "volumes" : MessageLookupByLibrary.simpleMessage("Volumenes"),
-    "walletInUse" : MessageLookupByLibrary.simpleMessage("El nombre de la billetera ya está en uso"),
-    "walletMaxChar" : MessageLookupByLibrary.simpleMessage("El nombre de la billetera debe tener un máximo de 40 caracteres"),
-    "walletOnly" : MessageLookupByLibrary.simpleMessage("Solo billetera"),
-    "warning" : MessageLookupByLibrary.simpleMessage("¡Advertencia!"),
-    "warningOkBtn" : MessageLookupByLibrary.simpleMessage("Ok"),
-    "warningShareLogs" : MessageLookupByLibrary.simpleMessage("Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos."),
-    "weFailedTo" : m114,
-    "weFailedToActivate" : m115,
-    "welcomeInfo" : m116,
-    "welcomeLetSetUp" : MessageLookupByLibrary.simpleMessage("¡VAMOS A PREPARARNOS!"),
-    "welcomeTitle" : MessageLookupByLibrary.simpleMessage("BIENVENIDO"),
-    "welcomeWallet" : MessageLookupByLibrary.simpleMessage("wallet"),
-    "willBeRedirected" : MessageLookupByLibrary.simpleMessage("Se le redirigirá a la página del portafolio al finalizar."),
-    "willTakeTime" : MessageLookupByLibrary.simpleMessage("Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas."),
-    "withdraw" : MessageLookupByLibrary.simpleMessage("Retirar"),
-    "withdrawCameraAccessText" : m117,
-    "withdrawCameraAccessTitle" : MessageLookupByLibrary.simpleMessage("Acceso Denegado"),
-    "withdrawConfirm" : MessageLookupByLibrary.simpleMessage("Confirmar Retiro"),
-    "withdrawConfirmError" : MessageLookupByLibrary.simpleMessage("Algo salió mal. Vuelva a intentarlo más tarde."),
-    "withdrawValue" : m118,
-    "wrongCoinSpan1" : MessageLookupByLibrary.simpleMessage("Está intentando escanear un código QR de pago para"),
-    "wrongCoinSpan2" : MessageLookupByLibrary.simpleMessage("pero tu estas en la"),
-    "wrongCoinSpan3" : MessageLookupByLibrary.simpleMessage("pantalla de retirar"),
-    "wrongCoinTitle" : MessageLookupByLibrary.simpleMessage("Moneda equivocada"),
-    "wrongPassword" : MessageLookupByLibrary.simpleMessage("Las contraseñas no coinciden. Inténtalo de nuevo."),
-    "yes" : MessageLookupByLibrary.simpleMessage("Sí"),
-    "you have a fresh order that is trying to match with an existing order" : MessageLookupByLibrary.simpleMessage("tiene un pedido nuevo que está tratando de coincidir con un pedido existente"),
-    "you have an active swap in progress" : MessageLookupByLibrary.simpleMessage("tienes un intercambio activo en curso"),
-    "you have an order that new orders can match with" : MessageLookupByLibrary.simpleMessage("tiene un pedido con el que pueden coincidir nuevos pedidos"),
-    "youAreSending" : MessageLookupByLibrary.simpleMessage("Usted está enviando:"),
-    "youWillReceiveClaim" : m119,
-    "youWillReceived" : MessageLookupByLibrary.simpleMessage("Usted recibirá:"),
-    "yourWallet" : MessageLookupByLibrary.simpleMessage("Su billetera")
-  };
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "Active": MessageLookupByLibrary.simpleMessage("Activo"),
+        "Applause": MessageLookupByLibrary.simpleMessage("Aplausos"),
+        "Can\'t play that":
+            MessageLookupByLibrary.simpleMessage("no puedo escuchar eso"),
+        "Failed": MessageLookupByLibrary.simpleMessage("Fallido"),
+        "Maker": MessageLookupByLibrary.simpleMessage("Vendedor"),
+        "Optional": MessageLookupByLibrary.simpleMessage("Opcional"),
+        "Play at full volume":
+            MessageLookupByLibrary.simpleMessage("Juega a todo volumen"),
+        "Sound": MessageLookupByLibrary.simpleMessage("Sonido"),
+        "Taker": MessageLookupByLibrary.simpleMessage("Comprador"),
+        "a swap fails":
+            MessageLookupByLibrary.simpleMessage("un intercambio falla"),
+        "a swap runs to completion": MessageLookupByLibrary.simpleMessage(
+            "un intercambio se ejecuta hasta su finalización"),
+        "accepteula": MessageLookupByLibrary.simpleMessage("Aceptar EULA"),
+        "accepttac": MessageLookupByLibrary.simpleMessage(
+            "Aceptar TERMINOS y CONDICIONES"),
+        "activateAccessBiometric": MessageLookupByLibrary.simpleMessage(
+            "Activar protección biométrica"),
+        "activateAccessPin": MessageLookupByLibrary.simpleMessage(
+            "Activar la protección con PIN"),
+        "activateCoins": m0,
+        "activating": m1,
+        "activation": m2,
+        "activationCancelled": MessageLookupByLibrary.simpleMessage(
+            "Activación de monedas cancelada"),
+        "activationInProgress": m3,
+        "addCoin": MessageLookupByLibrary.simpleMessage("Activar moneda"),
+        "addingCoinSuccess": m4,
+        "addressAdd": MessageLookupByLibrary.simpleMessage("Añadir Direccion"),
+        "addressBook": MessageLookupByLibrary.simpleMessage("Directorio"),
+        "addressBookEmpty": MessageLookupByLibrary.simpleMessage(
+            "La libreta de direcciones está vacía"),
+        "addressBookFilter": m5,
+        "addressBookTitle": MessageLookupByLibrary.simpleMessage("Directorio"),
+        "addressCoinInactive": m6,
+        "addressNotFound":
+            MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
+        "addressSelectCoin":
+            MessageLookupByLibrary.simpleMessage("Seleccionar Moneda"),
+        "addressSend": MessageLookupByLibrary.simpleMessage(
+            "Dirección de los destinatarios"),
+        "advanced": MessageLookupByLibrary.simpleMessage("Avanzado"),
+        "all": MessageLookupByLibrary.simpleMessage("TODOS"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "Su billetera mostrará cualquier transacción pasada. Esto requerirá mucho almacenamiento y tiempo, ya que todos los bloques se descargarán y escanearán."),
+        "allowCustomSeed": MessageLookupByLibrary.simpleMessage(
+            "Permitir semilla personalizada"),
+        "alreadyExists": MessageLookupByLibrary.simpleMessage("Ya existe"),
+        "amount": MessageLookupByLibrary.simpleMessage("Cantidad"),
+        "amountToSell":
+            MessageLookupByLibrary.simpleMessage("Cantidad a Vender"),
+        "answer_1": m7,
+        "answer_10": m8,
+        "answer_2": m9,
+        "answer_3": m10,
+        "answer_4": MessageLookupByLibrary.simpleMessage(
+            "Si. Debe permanecer conectado al Internet y tener su aplicación ejecutándose para completar con éxito cada intercambio (las interrupciones muy breves en la conectividad generalmente no causan problemas). De lo contrario, existe el riesgo de cancelación de la operación y el riesgo de pérdida de fondos si es un comprador. El protocolo de intercambio atómico requiere que ambos participantes permanezcan en línea y monitoreen los blockchains involucrados para que el proceso permanezca atómico."),
+        "answer_5": m11,
+        "answer_6": m12,
+        "answer_7": m13,
+        "answer_8": m14,
+        "answer_9": m15,
+        "areYouSure": MessageLookupByLibrary.simpleMessage("ESTAS SEGURO?"),
+        "authenticate": MessageLookupByLibrary.simpleMessage("autenticar"),
+        "automaticRedirected": MessageLookupByLibrary.simpleMessage(
+            "Se le redirigirá automáticamente a la página de cartera cuando se complete el proceso de reintento de activación."),
+        "availableVolume":
+            MessageLookupByLibrary.simpleMessage("volumen máximo"),
+        "back": MessageLookupByLibrary.simpleMessage("back"),
+        "backupTitle": MessageLookupByLibrary.simpleMessage("Respaldo"),
+        "basedOnCoinRatio": m16,
+        "batteryCriticalError": m17,
+        "batteryLowWarning": m18,
+        "batterySavingWarning": MessageLookupByLibrary.simpleMessage(
+            "Su teléfono está en modo de ahorro de batería. Deshabilite este modo o NO ponga la aplicación en segundo plano, de lo contrario, el sistema operativo podría eliminar la aplicación y fallar el intercambio."),
+        "bestAvailableRate":
+            MessageLookupByLibrary.simpleMessage("Tipo de cambio"),
+        "builtKomodo":
+            MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
+        "builtOnKmd":
+            MessageLookupByLibrary.simpleMessage("Construido en Komodo"),
+        "buy": MessageLookupByLibrary.simpleMessage("Comprar"),
+        "buyOrderType": MessageLookupByLibrary.simpleMessage(
+            "Convertir a Vendedor si no coincide"),
+        "buySuccessWaiting": MessageLookupByLibrary.simpleMessage(
+            "Intercambio emitido, por favor espere!"),
+        "buySuccessWaitingError": m19,
+        "buyTestCoinWarning": MessageLookupByLibrary.simpleMessage(
+            "¡Advertencia, estás dispuesto a comprar monedas de prueba SIN valor real!"),
+        "camoPinBioProtectionConflict": MessageLookupByLibrary.simpleMessage(
+            "El PIN de camuflaje y la bioprotección no se pueden habilitar al mismo tiempo."),
+        "camoPinBioProtectionConflictTitle":
+            MessageLookupByLibrary.simpleMessage(
+                "Conflicto entre PIN de camuflaje y bioprotección."),
+        "camoPinChange":
+            MessageLookupByLibrary.simpleMessage("Cambiar PIN de camuflaje"),
+        "camoPinCreate":
+            MessageLookupByLibrary.simpleMessage("Crear PIN de camuflaje"),
+        "camoPinDesc": MessageLookupByLibrary.simpleMessage(
+            "Si desbloquea la aplicación con el PIN de camuflaje, se mostrará un saldo BAJO falso y la opción de configuración del PIN de camuflaje NO estará visible en la configuración"),
+        "camoPinInvalid":
+            MessageLookupByLibrary.simpleMessage("PIN de camuflaje no válido"),
+        "camoPinLink": MessageLookupByLibrary.simpleMessage("Camuflajear PIN"),
+        "camoPinNotFound": MessageLookupByLibrary.simpleMessage(
+            "PIN de camuflaje no encontrado"),
+        "camoPinOff": MessageLookupByLibrary.simpleMessage("Desactivado"),
+        "camoPinOn": MessageLookupByLibrary.simpleMessage("Activado"),
+        "camoPinSaved":
+            MessageLookupByLibrary.simpleMessage("PIN de camuflaje guardado"),
+        "camoPinTitle":
+            MessageLookupByLibrary.simpleMessage("Camuflajear el PIN"),
+        "camoSetupSubtitle": MessageLookupByLibrary.simpleMessage(
+            "Ingrese el nuevo PIN de camuflaje"),
+        "camoSetupTitle": MessageLookupByLibrary.simpleMessage(
+            "Configuración de PIN de camuflaje"),
+        "camouflageSetup": MessageLookupByLibrary.simpleMessage(
+            "Configuración de PIN de camuflaje"),
+        "cancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Cancelar activación"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "¿Estás seguro de que deseas cancelar la activación?"),
+        "cancelButton": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "cancelOrder": MessageLookupByLibrary.simpleMessage("Cancelar orden"),
+        "candleChartError": MessageLookupByLibrary.simpleMessage(
+            "Algo salió mal. Vuelve a intentarlo más tarde."),
+        "cantDeleteDefaultCoinOk": MessageLookupByLibrary.simpleMessage("Ok"),
+        "cantDeleteDefaultCoinSpan": MessageLookupByLibrary.simpleMessage(
+            "es una moneda predeterminada. Las monedas predeterminadas no se pueden desactivar."),
+        "cantDeleteDefaultCoinTitle":
+            MessageLookupByLibrary.simpleMessage("No se puede deshabilitar"),
+        "cex": MessageLookupByLibrary.simpleMessage("CEX"),
+        "cexChangeRate":
+            MessageLookupByLibrary.simpleMessage("Tasa de Cambio CEX"),
+        "cexData": MessageLookupByLibrary.simpleMessage("data de CEX"),
+        "cexDataDesc": MessageLookupByLibrary.simpleMessage(
+            "Los datos de mercados (precios, gráficos, etc.) marcados con este ícono provienen de fuentes de terceros (<a href=\"https://www.coingecko.com/\">coingecko.com</a>, <a href =\"https://openrates.io/\">openrates.io</a>)."),
+        "cexRate": MessageLookupByLibrary.simpleMessage("Tasa CEX"),
+        "changePin": MessageLookupByLibrary.simpleMessage("Cambiar código PIN"),
+        "checkForUpdates":
+            MessageLookupByLibrary.simpleMessage("Buscar actualizaciones"),
+        "checkOut": MessageLookupByLibrary.simpleMessage("Verificar"),
+        "checkSeedPhrase":
+            MessageLookupByLibrary.simpleMessage("Comprobar la frase inicial"),
+        "checkSeedPhraseButton1":
+            MessageLookupByLibrary.simpleMessage("SEGUIR"),
+        "checkSeedPhraseButton2":
+            MessageLookupByLibrary.simpleMessage("VOLVER Y VERIFICAR DE NUEVO"),
+        "checkSeedPhraseHint": m20,
+        "checkSeedPhraseInfo": MessageLookupByLibrary.simpleMessage(
+            "Tu frase semilla es importante, por eso nos gusta asegurarnos de que sea correcta. Le haremos tres preguntas diferentes sobre su frase semilla para asegurarnos de que podrá restaurar fácilmente su billetera cuando lo desee."),
+        "checkSeedPhraseSubtile": m21,
+        "checkSeedPhraseTitle": MessageLookupByLibrary.simpleMessage(
+            "VAMOS A VERIFICAR DOS VECES TU FRASE SEMILLA"),
+        "chineseLanguage": MessageLookupByLibrary.simpleMessage("Chino"),
+        "claim": MessageLookupByLibrary.simpleMessage("afirmar"),
+        "claimTitle": MessageLookupByLibrary.simpleMessage(
+            "¿Reclamar su recompensa KMD?"),
+        "clickToSee": MessageLookupByLibrary.simpleMessage("Clic para ver"),
+        "clipboard":
+            MessageLookupByLibrary.simpleMessage("Copiado al portapapeles"),
+        "clipboardCopy":
+            MessageLookupByLibrary.simpleMessage("Copiar al portapapeles"),
+        "close": MessageLookupByLibrary.simpleMessage("Cerrar"),
+        "closeMessage":
+            MessageLookupByLibrary.simpleMessage("Cerrar mensaje de error"),
+        "closePreview": MessageLookupByLibrary.simpleMessage("Cerrar prevista"),
+        "code": MessageLookupByLibrary.simpleMessage("Código:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "¿Estás seguro de que deseas cancelar la activación?"),
+        "coinActivationCancelled": m22,
+        "coinSelectClear": MessageLookupByLibrary.simpleMessage("Remover"),
+        "coinSelectNotFound":
+            MessageLookupByLibrary.simpleMessage("No hay monedas activas"),
+        "coinSelectTitle":
+            MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
+        "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
+            "Ha seleccionado el número máximo de activos"),
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
+        "comingSoon": MessageLookupByLibrary.simpleMessage("Próximamente..."),
+        "commingsoon": MessageLookupByLibrary.simpleMessage(
+            "Detalles de TX próximamente!"),
+        "commingsoonGeneral":
+            MessageLookupByLibrary.simpleMessage("¡Detalles muy pronto!"),
+        "commissionFee":
+            MessageLookupByLibrary.simpleMessage("cuota de comisión"),
+        "comparedTo24hrCex": MessageLookupByLibrary.simpleMessage(
+            "en comparación con el promedio Precio CEX 24h"),
+        "comparedToCex":
+            MessageLookupByLibrary.simpleMessage("comparable a CEX"),
+        "configureWallet": MessageLookupByLibrary.simpleMessage(
+            "Configurando su billetera, por favor espere..."),
+        "confirm": MessageLookupByLibrary.simpleMessage("Confirmar"),
+        "confirmCamouflageSetup":
+            MessageLookupByLibrary.simpleMessage("Confirmar PIN de camuflaje"),
+        "confirmCancel": MessageLookupByLibrary.simpleMessage(
+            "¿Está seguro de que desea cancelar el pedido?"),
+        "confirmPassword":
+            MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
+        "confirmPin":
+            MessageLookupByLibrary.simpleMessage("Confirmar código PIN"),
+        "confirmSeed":
+            MessageLookupByLibrary.simpleMessage("Confirmar frase semilla"),
+        "confirmeula": MessageLookupByLibrary.simpleMessage(
+            "Al hacer clic en los botones a continuación, confirma haber leído el \'EULA\' y los \'Términos y condiciones\' y acepta estos"),
+        "connecting": MessageLookupByLibrary.simpleMessage("Conectando..."),
+        "contactCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "contactDelete":
+            MessageLookupByLibrary.simpleMessage("Borrar Contacto"),
+        "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Borrar"),
+        "contactDeleteWarning": m27,
+        "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Descartar"),
+        "contactEdit": MessageLookupByLibrary.simpleMessage("Editar"),
+        "contactExit": MessageLookupByLibrary.simpleMessage("Salir"),
+        "contactExitWarning":
+            MessageLookupByLibrary.simpleMessage("Descartar tus cambios?"),
+        "contactNotFound":
+            MessageLookupByLibrary.simpleMessage("No se encontraron contactos"),
+        "contactSave": MessageLookupByLibrary.simpleMessage("Guardar"),
+        "contactTitle":
+            MessageLookupByLibrary.simpleMessage("Detalles de contacto"),
+        "contactTitleName": MessageLookupByLibrary.simpleMessage("Nombre"),
+        "contract": MessageLookupByLibrary.simpleMessage("Contrato"),
+        "convert": MessageLookupByLibrary.simpleMessage("Convertir"),
+        "couldNotLaunchUrl":
+            MessageLookupByLibrary.simpleMessage("No se pudo iniciar la URL"),
+        "couldntImportError":
+            MessageLookupByLibrary.simpleMessage("No se pudo importar:"),
+        "create": MessageLookupByLibrary.simpleMessage("intercambiar"),
+        "createAWallet":
+            MessageLookupByLibrary.simpleMessage("CREAR UNA CARTERA"),
+        "createContact": MessageLookupByLibrary.simpleMessage("Crear Contacto"),
+        "createPin": MessageLookupByLibrary.simpleMessage("Crear numero PIN"),
+        "currency": MessageLookupByLibrary.simpleMessage("Moneda"),
+        "currencyDialogTitle": MessageLookupByLibrary.simpleMessage("Moneda"),
+        "currentValue": MessageLookupByLibrary.simpleMessage("Valor actual:"),
+        "customFee": MessageLookupByLibrary.simpleMessage(
+            "Costo de Transacción Personalizado"),
+        "customFeeWarning": MessageLookupByLibrary.simpleMessage(
+            "¡Solo use tarifas personalizadas si sabe lo que está haciendo!"),
+        "customSeedWarning": m28,
+        "dPow":
+            MessageLookupByLibrary.simpleMessage("Seguridad de Komodo dPoW"),
+        "date": MessageLookupByLibrary.simpleMessage("Fecha"),
+        "decryptingWallet":
+            MessageLookupByLibrary.simpleMessage("Billetera de descifrado"),
+        "delete": MessageLookupByLibrary.simpleMessage("Borrar"),
+        "deleteConfirm":
+            MessageLookupByLibrary.simpleMessage("Confirmar desactivación"),
+        "deleteSpan1":
+            MessageLookupByLibrary.simpleMessage("¿Quieres eliminar"),
+        "deleteSpan2": MessageLookupByLibrary.simpleMessage(
+            "de tu cartera? Todos los pedidos no emparejados serán cancelados."),
+        "deleteSpan3":
+            MessageLookupByLibrary.simpleMessage(" también se desactivará"),
+        "deleteWallet":
+            MessageLookupByLibrary.simpleMessage("Eliminar Billetera"),
+        "deletingWallet":
+            MessageLookupByLibrary.simpleMessage("Eliminando billetera..."),
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
+        "detailedFeesSendTradingFeeTransactionFee":
+            MessageLookupByLibrary.simpleMessage(
+                "enviar tarifa comercial tarifa de transacción"),
+        "detailedFeesTradingFee":
+            MessageLookupByLibrary.simpleMessage("tarifa comercial"),
+        "details": MessageLookupByLibrary.simpleMessage("detalles"),
+        "deutscheLanguage": MessageLookupByLibrary.simpleMessage("Alemán"),
+        "developerTitle": MessageLookupByLibrary.simpleMessage("Desarrollador"),
+        "dex": MessageLookupByLibrary.simpleMessage("DEX"),
+        "dexIsNotAvailable": MessageLookupByLibrary.simpleMessage(
+            "DEX no está disponible para esta moneda"),
+        "disableScreenshots": MessageLookupByLibrary.simpleMessage(
+            "Desactivar capturas de pantalla/vista previa"),
+        "disclaimerAndTos": MessageLookupByLibrary.simpleMessage(
+            "Descargo de responsabilidad y condiciones de servicio"),
+        "doNotCloseTheAppTapForMoreInfo": MessageLookupByLibrary.simpleMessage(
+            "No cierres la aplicación. Toca para obtener más información..."),
+        "done": MessageLookupByLibrary.simpleMessage("Hecho"),
+        "dontAskAgain":
+            MessageLookupByLibrary.simpleMessage("No vuelvas a preguntar"),
+        "dontWantPassword":
+            MessageLookupByLibrary.simpleMessage("no quiero una contraseña"),
+        "duration": MessageLookupByLibrary.simpleMessage("Duración"),
+        "editContact": MessageLookupByLibrary.simpleMessage("Editar contacto"),
+        "emptyCoin": m31,
+        "emptyExportPass": MessageLookupByLibrary.simpleMessage(
+            "La contraseña de cifrado no puede estar vacía"),
+        "emptyImportPass": MessageLookupByLibrary.simpleMessage(
+            "La contraseña no puede estar vacía"),
+        "emptyName": MessageLookupByLibrary.simpleMessage(
+            "El nombre del contacto no puede estar vacío"),
+        "emptyWallet": MessageLookupByLibrary.simpleMessage(
+            "El nombre de la billetera no debe estar vacío"),
+        "enableNotificationsForActivationProgress":
+            MessageLookupByLibrary.simpleMessage(
+                "Habilite las notificaciones para recibir actualizaciones sobre el progreso de la activación."),
+        "enableTestCoins":
+            MessageLookupByLibrary.simpleMessage("Habilitar monedas de prueba"),
+        "enablingTooManyAssetsSpan1":
+            MessageLookupByLibrary.simpleMessage("Tu tienes"),
+        "enablingTooManyAssetsSpan2": MessageLookupByLibrary.simpleMessage(
+            "activos habilitados y tratando de habilitar"),
+        "enablingTooManyAssetsSpan3": MessageLookupByLibrary.simpleMessage(
+            "más. El límite máximo de activos habilitados es"),
+        "enablingTooManyAssetsSpan4": MessageLookupByLibrary.simpleMessage(
+            ". Desactive algunos antes de agregar otros nuevos."),
+        "enablingTooManyAssetsTitle": MessageLookupByLibrary.simpleMessage(
+            "Intentando habilitar demasiados activos"),
+        "encryptingWallet":
+            MessageLookupByLibrary.simpleMessage("Billetera cifrada"),
+        "englishLanguage": MessageLookupByLibrary.simpleMessage("Inglés"),
+        "enterNewPinCode":
+            MessageLookupByLibrary.simpleMessage("Ingrese su nuevo PIN"),
+        "enterOldPinCode":
+            MessageLookupByLibrary.simpleMessage("Ingrese su antiguo PIN"),
+        "enterPinCode":
+            MessageLookupByLibrary.simpleMessage("Ingresa tu numero PIN"),
+        "enterSeedPhrase": MessageLookupByLibrary.simpleMessage(
+            "Ingrese su Semilla de 12 palabras"),
+        "enterSellAmount": MessageLookupByLibrary.simpleMessage(
+            "Primero debe ingresar el monto de la venta"),
+        "enterpassword": MessageLookupByLibrary.simpleMessage(
+            "Por favor ingrese su contraseña para continuar."),
+        "errorAmountBalance": MessageLookupByLibrary.simpleMessage(
+            "No hay suficiente equilibrio"),
+        "errorNotAValidAddress":
+            MessageLookupByLibrary.simpleMessage("No es una dirección válida"),
+        "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
+            "Las direcciones de Segwit no son compatibles (todavía)"),
+        "errorNotEnoughGas": m33,
+        "errorTryAgain":
+            MessageLookupByLibrary.simpleMessage("Error, inténtalo de nuevo"),
+        "errorTryLater":
+            MessageLookupByLibrary.simpleMessage("Error, intente más tarde"),
+        "errorValueEmpty": MessageLookupByLibrary.simpleMessage(
+            "El valor es demasiado alto o bajo"),
+        "errorValueNotEmpty":
+            MessageLookupByLibrary.simpleMessage("Por favor ingrese datos"),
+        "estimateValue":
+            MessageLookupByLibrary.simpleMessage("Valor total estimado"),
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
+        "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
+            "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
+        "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
+            "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
+        "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
+            "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
+        "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
+            "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
+        "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
+            "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
+        "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
+            "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
+        "eulaTitle1": m47,
+        "eulaTitle10":
+            MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
+        "eulaTitle11": MessageLookupByLibrary.simpleMessage(
+            "INTELLECTUAL PROPERTY RIGHTS"),
+        "eulaTitle12": MessageLookupByLibrary.simpleMessage("DISCLAIMER"),
+        "eulaTitle13": MessageLookupByLibrary.simpleMessage(
+            "REPRESENTATIONS AND WARRANTIES, INDEMNIFICATION, AND LIMITATION OF LIABILITY"),
+        "eulaTitle14":
+            MessageLookupByLibrary.simpleMessage("GENERAL RISK FACTORS"),
+        "eulaTitle15": MessageLookupByLibrary.simpleMessage("INDEMNIFICATION"),
+        "eulaTitle16": MessageLookupByLibrary.simpleMessage(
+            "RISK DISCLOSURES RELATING TO THE WALLET"),
+        "eulaTitle17": MessageLookupByLibrary.simpleMessage(
+            "NO INVESTMENT ADVICE OR BROKERAGE"),
+        "eulaTitle18": MessageLookupByLibrary.simpleMessage("TERMINATION"),
+        "eulaTitle19":
+            MessageLookupByLibrary.simpleMessage("THIRD PARTY RIGHTS"),
+        "eulaTitle2": MessageLookupByLibrary.simpleMessage(
+            "TERMS and CONDITIONS: (APPLICATION USER AGREEMENT)"),
+        "eulaTitle20":
+            MessageLookupByLibrary.simpleMessage("OUR LEGAL OBLIGATIONS"),
+        "eulaTitle3": MessageLookupByLibrary.simpleMessage(
+            "TERMS AND CONDITIONS OF USE AND DISCLAIMER"),
+        "eulaTitle4": MessageLookupByLibrary.simpleMessage("GENERAL USE"),
+        "eulaTitle5": MessageLookupByLibrary.simpleMessage("MODIFICATIONS"),
+        "eulaTitle6":
+            MessageLookupByLibrary.simpleMessage("LIMITATIONS ON USE"),
+        "eulaTitle7":
+            MessageLookupByLibrary.simpleMessage("ACCOUNTS AND MEMBERSHIP"),
+        "eulaTitle8": MessageLookupByLibrary.simpleMessage("BACKUPS"),
+        "eulaTitle9": MessageLookupByLibrary.simpleMessage("GENERAL WARNING"),
+        "exampleHintSeed": MessageLookupByLibrary.simpleMessage(
+            "Ejemplo: build case level ..."),
+        "exchangeExpedient": MessageLookupByLibrary.simpleMessage("Expediente"),
+        "exchangeExpensive": MessageLookupByLibrary.simpleMessage("Caro"),
+        "exchangeIdentical":
+            MessageLookupByLibrary.simpleMessage("Identico a CEX"),
+        "exchangeRate": MessageLookupByLibrary.simpleMessage("Tipo de cambio:"),
+        "exchangeTitle": MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
+        "exportButton": MessageLookupByLibrary.simpleMessage("Exportar"),
+        "exportContactsTitle":
+            MessageLookupByLibrary.simpleMessage("Contactos"),
+        "exportDesc": MessageLookupByLibrary.simpleMessage(
+            "Seleccione elementos para exportar a un archivo cifrado."),
+        "exportLink": MessageLookupByLibrary.simpleMessage("Exportar"),
+        "exportNotesTitle": MessageLookupByLibrary.simpleMessage("Notas"),
+        "exportSuccessTitle": MessageLookupByLibrary.simpleMessage(
+            "Los elementos se han exportado correctamente:"),
+        "exportSwapsTitle":
+            MessageLookupByLibrary.simpleMessage("Intercambios"),
+        "exportTitle": MessageLookupByLibrary.simpleMessage("Exportar"),
+        "failedToCancelActivation": m48,
+        "fakeBalanceAmt":
+            MessageLookupByLibrary.simpleMessage("Cantidad de saldo falso:"),
+        "faqTitle":
+            MessageLookupByLibrary.simpleMessage("Preguntas frecuentes"),
+        "faucetError": MessageLookupByLibrary.simpleMessage("Error"),
+        "faucetInProgress": m49,
+        "faucetName": MessageLookupByLibrary.simpleMessage("GRIFO"),
+        "faucetSuccess": MessageLookupByLibrary.simpleMessage("Éxito"),
+        "faucetTimedOut":
+            MessageLookupByLibrary.simpleMessage("Tiempo de espera agotado"),
+        "feedNewsTab": MessageLookupByLibrary.simpleMessage("Noticias"),
+        "feedNotFound": MessageLookupByLibrary.simpleMessage("Nada aquí"),
+        "feedNotifTitle": m50,
+        "feedReadMore": MessageLookupByLibrary.simpleMessage("Leer más..."),
+        "feedTab": MessageLookupByLibrary.simpleMessage("Informacion"),
+        "feedTitle": MessageLookupByLibrary.simpleMessage("Noticias"),
+        "feedUnableToProceed": MessageLookupByLibrary.simpleMessage(
+            "No se puede continuar con la actualización de noticias"),
+        "feedUnableToUpdate": MessageLookupByLibrary.simpleMessage(
+            "No se puede obtener la actualización de noticias"),
+        "feedUpToDate":
+            MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
+        "feedUpdated": MessageLookupByLibrary.simpleMessage(
+            "Fuente de noticias actualizada"),
+        "feedback": MessageLookupByLibrary.simpleMessage(
+            "Compartir archivo de registro"),
+        "feesError": m51,
+        "filtersAll": MessageLookupByLibrary.simpleMessage("Todo"),
+        "filtersButton": MessageLookupByLibrary.simpleMessage("Filtro"),
+        "filtersClearAll":
+            MessageLookupByLibrary.simpleMessage("Borrar todos los filtros"),
+        "filtersFailed": MessageLookupByLibrary.simpleMessage("Fallido"),
+        "filtersFrom":
+            MessageLookupByLibrary.simpleMessage("Partir de la fecha"),
+        "filtersMaker": MessageLookupByLibrary.simpleMessage("Vendedor"),
+        "filtersReceive":
+            MessageLookupByLibrary.simpleMessage("Recibir moneda"),
+        "filtersSell": MessageLookupByLibrary.simpleMessage("Vender moneda"),
+        "filtersStatus": MessageLookupByLibrary.simpleMessage("Estado"),
+        "filtersSuccessful": MessageLookupByLibrary.simpleMessage("Exitoso"),
+        "filtersTaker": MessageLookupByLibrary.simpleMessage("Comprador"),
+        "filtersTo": MessageLookupByLibrary.simpleMessage("Hasta la fecha"),
+        "filtersType":
+            MessageLookupByLibrary.simpleMessage("Comprador/Vendedor"),
+        "fingerprint": MessageLookupByLibrary.simpleMessage("Huella dactilar"),
+        "finishingUp": MessageLookupByLibrary.simpleMessage(
+            "Terminando, por favor espera."),
+        "foundQrCode":
+            MessageLookupByLibrary.simpleMessage("Código QR encontrado"),
+        "frenchLanguage": MessageLookupByLibrary.simpleMessage("Francés"),
+        "from": MessageLookupByLibrary.simpleMessage("Desde"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "Sincronizaremos las transacciones futuras realizadas después de la activación asociada con su clave pública. Esta es la opción más rápida y ocupa la menor cantidad de almacenamiento."),
+        "gasFee": m52,
+        "gasLimit": MessageLookupByLibrary.simpleMessage("Limite de Gas"),
+        "gasNotActive": m53,
+        "gasPrice": MessageLookupByLibrary.simpleMessage("Precio de Gas"),
+        "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
+            "La protección general con PIN no está activa.\nEl modo de camuflaje no estará disponible.\nActive la protección con PIN."),
+        "getBackupPhrase": MessageLookupByLibrary.simpleMessage(
+            "Importante: ¡Haz una copia de seguridad de tu frase inicial antes de continuar!"),
+        "gettingTxWait": MessageLookupByLibrary.simpleMessage(
+            "Obteniendo transacción, por favor espere"),
+        "goToPorfolio":
+            MessageLookupByLibrary.simpleMessage("Ir al portafolio"),
+        "helpLink": MessageLookupByLibrary.simpleMessage("Ayuda"),
+        "helpTitle": MessageLookupByLibrary.simpleMessage("Ayuda y apoyo"),
+        "hideBalance": MessageLookupByLibrary.simpleMessage("Ocultar saldos"),
+        "hintConfirmPassword":
+            MessageLookupByLibrary.simpleMessage("Confirmar contraseña"),
+        "hintCreatePassword":
+            MessageLookupByLibrary.simpleMessage("Crear contraseña"),
+        "hintCurrentPassword":
+            MessageLookupByLibrary.simpleMessage("Contraseña actual"),
+        "hintEnterPassword":
+            MessageLookupByLibrary.simpleMessage("Ingresa tu contraseña"),
+        "hintEnterSeedPhrase":
+            MessageLookupByLibrary.simpleMessage("Ingrese su frase inicial"),
+        "hintNameYourWallet":
+            MessageLookupByLibrary.simpleMessage("Nombra tu billetera"),
+        "hintPassword": MessageLookupByLibrary.simpleMessage("Clave"),
+        "history": MessageLookupByLibrary.simpleMessage("historia"),
+        "hours": MessageLookupByLibrary.simpleMessage("h"),
+        "hungarianLanguage": MessageLookupByLibrary.simpleMessage("Húngaro"),
+        "iUnderstand": MessageLookupByLibrary.simpleMessage("Entiendo"),
+        "importButton": MessageLookupByLibrary.simpleMessage("Importar"),
+        "importDecryptError": MessageLookupByLibrary.simpleMessage(
+            "Contraseña no válida o datos dañados"),
+        "importDesc":
+            MessageLookupByLibrary.simpleMessage("Elementos a importar:"),
+        "importFileNotFound":
+            MessageLookupByLibrary.simpleMessage("Archivo no encontrado"),
+        "importInvalidSwapData": MessageLookupByLibrary.simpleMessage(
+            "Datos de intercambio no válidos. Proporcione un archivo JSON de estado de intercambio válido."),
+        "importLink": MessageLookupByLibrary.simpleMessage("Importar"),
+        "importLoadDesc": MessageLookupByLibrary.simpleMessage(
+            "Seleccione el archivo cifrado para importar."),
+        "importLoadSwapDesc": MessageLookupByLibrary.simpleMessage(
+            "Seleccione el archivo de intercambio de texto sin formato para importar."),
+        "importLoading": MessageLookupByLibrary.simpleMessage("Abriendo..."),
+        "importPassCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "importPassOk": MessageLookupByLibrary.simpleMessage("Ok"),
+        "importPassword": MessageLookupByLibrary.simpleMessage("Clave"),
+        "importSingleSwapLink":
+            MessageLookupByLibrary.simpleMessage("Importar un Intercambio"),
+        "importSingleSwapTitle":
+            MessageLookupByLibrary.simpleMessage("Importar Intercambio"),
+        "importSomeItemsSkippedWarning": MessageLookupByLibrary.simpleMessage(
+            "Se han saltado algunos elementos"),
+        "importSuccessTitle": MessageLookupByLibrary.simpleMessage(
+            "Los elementos se han importado correctamente:"),
+        "importSwapFailed": MessageLookupByLibrary.simpleMessage(
+            "No se pudo importar el intercambio"),
+        "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
+            "Error al decodificar el archivo json"),
+        "importTitle": MessageLookupByLibrary.simpleMessage("Importar"),
+        "incomingTransactionsProtectionSettings": m55,
+        "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
+            "Utilice una contraseña segura y no la almacene en el mismo dispositivo"),
+        "infoTrade1": MessageLookupByLibrary.simpleMessage(
+            "¡La solicitud de intercambio no se puede deshacer y es un evento final!"),
+        "infoTrade2": MessageLookupByLibrary.simpleMessage(
+            "El intercambio puede tardar hasta 60 minutos. ¡NO cierres esta aplicación!"),
+        "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
+            "Debe proporcionar una contraseña para el cifrado de la billetera por razones de seguridad."),
+        "insufficientBalanceToPay": m56,
+        "insufficientText": MessageLookupByLibrary.simpleMessage(
+            "El volumen mínimo requerido por este pedido es"),
+        "insufficientTitle":
+            MessageLookupByLibrary.simpleMessage("Volumen insuficiente"),
+        "internetRefreshButton":
+            MessageLookupByLibrary.simpleMessage("Actualizar"),
+        "internetRestored": MessageLookupByLibrary.simpleMessage(
+            "Conexión a Internet restaurada"),
+        "invalidSwap": MessageLookupByLibrary.simpleMessage(
+            "No se puede continuar con el intercambio"),
+        "invalidSwapDetailsLink":
+            MessageLookupByLibrary.simpleMessage("Detalles"),
+        "isUnavailable": m58,
+        "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japonés"),
+        "koreanLanguage": MessageLookupByLibrary.simpleMessage("Coreano"),
+        "language": MessageLookupByLibrary.simpleMessage("Idioma"),
+        "latestTxs":
+            MessageLookupByLibrary.simpleMessage("Últimas transacciones"),
+        "legalTitle": MessageLookupByLibrary.simpleMessage("Legal"),
+        "less": MessageLookupByLibrary.simpleMessage("menos"),
+        "lessThanCaution": m59,
+        "loading": MessageLookupByLibrary.simpleMessage("Cargando..."),
+        "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
+            "Cargando libro de ordenes..."),
+        "lockScreen":
+            MessageLookupByLibrary.simpleMessage("La pantalla está bloqueada"),
+        "lockScreenAuth":
+            MessageLookupByLibrary.simpleMessage("¡Por favor, autentícate!"),
+        "login": MessageLookupByLibrary.simpleMessage("acceso"),
+        "logout": MessageLookupByLibrary.simpleMessage("Cerrar sesión"),
+        "logoutOnExit":
+            MessageLookupByLibrary.simpleMessage("Cerrar sesión al salir"),
+        "logoutWarning": MessageLookupByLibrary.simpleMessage(
+            "¿Estás seguro de que quieres cerrar sesión ahora?"),
+        "logoutsettings": MessageLookupByLibrary.simpleMessage(
+            "Configuración de cierre de sesión"),
+        "longMinutes": MessageLookupByLibrary.simpleMessage("Minutos"),
+        "makeAorder": MessageLookupByLibrary.simpleMessage("hacer un pedido"),
+        "makerDetailsCancel":
+            MessageLookupByLibrary.simpleMessage("Cancelar orden"),
+        "makerDetailsCreated":
+            MessageLookupByLibrary.simpleMessage("Createdo en"),
+        "makerDetailsFor": MessageLookupByLibrary.simpleMessage("Recibir"),
+        "makerDetailsId": MessageLookupByLibrary.simpleMessage("ID de Orden"),
+        "makerDetailsNoSwaps": MessageLookupByLibrary.simpleMessage(
+            "Este pedido no inició intercambios"),
+        "makerDetailsPrice": MessageLookupByLibrary.simpleMessage("Precio"),
+        "makerDetailsSell": MessageLookupByLibrary.simpleMessage("Vender"),
+        "makerDetailsSwaps": MessageLookupByLibrary.simpleMessage(
+            "Intercambios iniciados por este pedido"),
+        "makerDetailsTitle": MessageLookupByLibrary.simpleMessage(
+            "Detalles del pedido del fabricante"),
+        "makerOrder": MessageLookupByLibrary.simpleMessage("Orden de Vendedor"),
+        "marketplace": MessageLookupByLibrary.simpleMessage("Mercado"),
+        "marketsChart": MessageLookupByLibrary.simpleMessage("Gráfico"),
+        "marketsDepth": MessageLookupByLibrary.simpleMessage("Profundidad"),
+        "marketsNoAsks": MessageLookupByLibrary.simpleMessage(
+            "No se encontraron solicitudes"),
+        "marketsNoBids":
+            MessageLookupByLibrary.simpleMessage("No se encontraron ofertas"),
+        "marketsOrderDetails":
+            MessageLookupByLibrary.simpleMessage("Detalles del Pedido"),
+        "marketsOrderbook":
+            MessageLookupByLibrary.simpleMessage("LIBRO DE ORDENES"),
+        "marketsPrice": MessageLookupByLibrary.simpleMessage("PRECIO"),
+        "marketsSelectCoins": MessageLookupByLibrary.simpleMessage(
+            "Por favor seleccione monedas"),
+        "marketsTab": MessageLookupByLibrary.simpleMessage("Mercados"),
+        "marketsTitle": MessageLookupByLibrary.simpleMessage("MERCADOS"),
+        "matchExportPass": MessageLookupByLibrary.simpleMessage(
+            "Las contraseñas deben coincidir"),
+        "matchingCamoChange": MessageLookupByLibrary.simpleMessage("Cambiar"),
+        "matchingCamoPinError": MessageLookupByLibrary.simpleMessage(
+            "Su PIN general y el PIN de camuflaje son los mismos.\nEl modo de camuflaje no estará disponible.\nCambie el PIN de camuflaje."),
+        "matchingCamoTitle":
+            MessageLookupByLibrary.simpleMessage("PIN Invalido"),
+        "max": MessageLookupByLibrary.simpleMessage("MAXIMO"),
+        "maxOrder":
+            MessageLookupByLibrary.simpleMessage("Volumen máximo de pedidos:"),
+        "media": MessageLookupByLibrary.simpleMessage("Noticias"),
+        "mediaBrowse": MessageLookupByLibrary.simpleMessage("NAVEGAR"),
+        "mediaBrowseFeed": MessageLookupByLibrary.simpleMessage("NAVEGAR RSS"),
+        "mediaBy": MessageLookupByLibrary.simpleMessage("By"),
+        "mediaNotSavedDescription": MessageLookupByLibrary.simpleMessage(
+            "NO TIENES ARTÍCULOS GUARDADOS"),
+        "mediaSaved": MessageLookupByLibrary.simpleMessage("GUARDADO"),
+        "memo": MessageLookupByLibrary.simpleMessage("Memorándum"),
+        "merge": MessageLookupByLibrary.simpleMessage("Unir"),
+        "mergedValue": MessageLookupByLibrary.simpleMessage("Valor combinado:"),
+        "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
+        "min": MessageLookupByLibrary.simpleMessage("Min"),
+        "minOrder":
+            MessageLookupByLibrary.simpleMessage("Volumen mínimo de pedido:"),
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
+        "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
+            "Debe ser menor que el monto de venta"),
+        "minVolumeTitle":
+            MessageLookupByLibrary.simpleMessage("Volumen mínimo requerido"),
+        "minVolumeToggle": MessageLookupByLibrary.simpleMessage(
+            "Usar volumen mínimo personalizado"),
+        "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
+            "Advertencia: Minimizar la aplicación en iOS finalizará el proceso de activación."),
+        "minutes": MessageLookupByLibrary.simpleMessage("m"),
+        "mobileDataWarning": m66,
+        "moreInfo": MessageLookupByLibrary.simpleMessage("Más información"),
+        "moreTab": MessageLookupByLibrary.simpleMessage("Mas"),
+        "multiActivateGas": m67,
+        "multiBaseAmtPlaceholder":
+            MessageLookupByLibrary.simpleMessage("Cantidad"),
+        "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Moneda"),
+        "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("Vender"),
+        "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "multiConfirmConfirm":
+            MessageLookupByLibrary.simpleMessage("Confirmar"),
+        "multiConfirmTitle": m68,
+        "multiCreate": MessageLookupByLibrary.simpleMessage("Crear"),
+        "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Orden"),
+        "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Ordenes"),
+        "multiEthFee": MessageLookupByLibrary.simpleMessage("costo"),
+        "multiFiatCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "multiFiatDesc": MessageLookupByLibrary.simpleMessage(
+            "Ingrese la cantidad de dinero para recibir:"),
+        "multiFiatFill": MessageLookupByLibrary.simpleMessage("Autollenarl"),
+        "multiFixErrors": MessageLookupByLibrary.simpleMessage(
+            "Corrija todos los errores antes de continuar"),
+        "multiInvalidAmt":
+            MessageLookupByLibrary.simpleMessage("Monto invalido"),
+        "multiInvalidSellAmt":
+            MessageLookupByLibrary.simpleMessage("Cantidad de venta no válido"),
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
+        "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage(
+            "La cantidad máxima de venta es"),
+        "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
+            "La cantidad mínima recibida es"),
+        "multiMinSellAmt": MessageLookupByLibrary.simpleMessage(
+            "La cantidad mínima de venta es"),
+        "multiReceiveTitle": MessageLookupByLibrary.simpleMessage("Recibir:"),
+        "multiSellTitle": MessageLookupByLibrary.simpleMessage("Vender:"),
+        "multiTab": MessageLookupByLibrary.simpleMessage("Multi"),
+        "multiTableAmt": MessageLookupByLibrary.simpleMessage("Recibir Cntd."),
+        "multiTablePrice": MessageLookupByLibrary.simpleMessage("Precio/CEX"),
+        "networkFee": MessageLookupByLibrary.simpleMessage("Tarifa de red"),
+        "newAccount": MessageLookupByLibrary.simpleMessage("nueva cuenta"),
+        "newAccountUpper": MessageLookupByLibrary.simpleMessage("Nueva Cuenta"),
+        "newValue": MessageLookupByLibrary.simpleMessage("Nuevo valor:"),
+        "newsFeed": MessageLookupByLibrary.simpleMessage("Noticias"),
+        "next": MessageLookupByLibrary.simpleMessage("próximo"),
+        "no": MessageLookupByLibrary.simpleMessage("No"),
+        "noArticles": MessageLookupByLibrary.simpleMessage(
+            "No hay noticias. Vuelva a consultar más tarde."),
+        "noCoinFound": MessageLookupByLibrary.simpleMessage(
+            "No se encontró ninguna moneda"),
+        "noFunds": MessageLookupByLibrary.simpleMessage("Sin Fondos"),
+        "noFundsDetected": MessageLookupByLibrary.simpleMessage(
+            "No hay fondos disponibles, por favor deposite."),
+        "noInternet":
+            MessageLookupByLibrary.simpleMessage("Sin conexión a Internet"),
+        "noItemsToExport": MessageLookupByLibrary.simpleMessage(
+            "No hay artículos seleccionados"),
+        "noItemsToImport": MessageLookupByLibrary.simpleMessage(
+            "No hay artículos seleccionados"),
+        "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
+            "No se encontraron pedidos coincidentes"),
+        "noOrder": m71,
+        "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
+            "Haga clic para crear un pedido"),
+        "noOrders": MessageLookupByLibrary.simpleMessage(
+            "No hay pedidos, por favor vaya al comercio."),
+        "noRewardYet": MessageLookupByLibrary.simpleMessage(
+            "No se puede reclamar ninguna recompensa. Vuelva a intentarlo en 1 hora."),
+        "noRewards": MessageLookupByLibrary.simpleMessage(
+            "No hay recompensas reclamables"),
+        "noSuchCoin": MessageLookupByLibrary.simpleMessage("No hay tal moneda"),
+        "noSwaps": MessageLookupByLibrary.simpleMessage("No historia."),
+        "noTxs": MessageLookupByLibrary.simpleMessage("Sin transacciones"),
+        "nonNumericInput":
+            MessageLookupByLibrary.simpleMessage("El valor debe ser numérico."),
+        "none": MessageLookupByLibrary.simpleMessage("Ninguno"),
+        "notEnoughGas": m72,
+        "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
+            "No hay suficiente saldo para las tarifas: opere con una cantidad menor"),
+        "noteOnOrder": MessageLookupByLibrary.simpleMessage(
+            "Nota: el pedido emparejado no se puede cancelar de nuevo"),
+        "notePlaceholder": MessageLookupByLibrary.simpleMessage("Añadir Nota"),
+        "noteTitle": MessageLookupByLibrary.simpleMessage("Nota"),
+        "nothingFound": MessageLookupByLibrary.simpleMessage("Nada Encontrado"),
+        "notifSwapCompletedText": m73,
+        "notifSwapCompletedTitle":
+            MessageLookupByLibrary.simpleMessage("Intercambio completado"),
+        "notifSwapFailedText": m74,
+        "notifSwapFailedTitle":
+            MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
+        "notifSwapStartedText": m75,
+        "notifSwapStartedTitle":
+            MessageLookupByLibrary.simpleMessage("Nuevo intercambio iniciado"),
+        "notifSwapStatusTitle":
+            MessageLookupByLibrary.simpleMessage("Cambio de estado cambiado"),
+        "notifSwapTimeoutText": m76,
+        "notifSwapTimeoutTitle": MessageLookupByLibrary.simpleMessage(
+            "Se agotó el tiempo de intercambio"),
+        "notifTxText": m77,
+        "notifTxTitle":
+            MessageLookupByLibrary.simpleMessage("Transaccion entrante"),
+        "numberAssets": m78,
+        "officialPressRelease": MessageLookupByLibrary.simpleMessage(
+            "comunicado de prensa oficial"),
+        "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
+        "oldLogsDelete": MessageLookupByLibrary.simpleMessage("Borrar"),
+        "oldLogsTitle":
+            MessageLookupByLibrary.simpleMessage("Registros antiguos"),
+        "oldLogsUsed": MessageLookupByLibrary.simpleMessage("Espacio usado"),
+        "openMessage":
+            MessageLookupByLibrary.simpleMessage("Abrir mensaje de error"),
+        "orderBookLess": MessageLookupByLibrary.simpleMessage("Menos"),
+        "orderBookMore": MessageLookupByLibrary.simpleMessage("Más"),
+        "orderCancel": m79,
+        "orderCreated": MessageLookupByLibrary.simpleMessage("Pedido creado"),
+        "orderCreatedInfo":
+            MessageLookupByLibrary.simpleMessage("Pedido creado con éxito"),
+        "orderDetailsAddress":
+            MessageLookupByLibrary.simpleMessage("Direccion"),
+        "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
+        "orderDetailsFor": MessageLookupByLibrary.simpleMessage("for"),
+        "orderDetailsIdentical":
+            MessageLookupByLibrary.simpleMessage("Idéntico a CEX"),
+        "orderDetailsMin": MessageLookupByLibrary.simpleMessage("min."),
+        "orderDetailsPrice": MessageLookupByLibrary.simpleMessage("Precio"),
+        "orderDetailsReceive": MessageLookupByLibrary.simpleMessage("Recibir"),
+        "orderDetailsSelect":
+            MessageLookupByLibrary.simpleMessage("Seleccione"),
+        "orderDetailsSells": MessageLookupByLibrary.simpleMessage("Ventas"),
+        "orderDetailsSettings": MessageLookupByLibrary.simpleMessage(
+            "Abra detalles con un solo toque y seleccione Ordenar con un toque largo"),
+        "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Gastar"),
+        "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Detalles"),
+        "orderFilled": m82,
+        "orderMatched":
+            MessageLookupByLibrary.simpleMessage("Orden Triangulada"),
+        "orderMatching":
+            MessageLookupByLibrary.simpleMessage("Triangulación de órdenes"),
+        "orderTypePartial": MessageLookupByLibrary.simpleMessage("Orden"),
+        "orderTypeUnknown":
+            MessageLookupByLibrary.simpleMessage("Orden desconocida"),
+        "orders": MessageLookupByLibrary.simpleMessage("ordenes"),
+        "ordersActive": MessageLookupByLibrary.simpleMessage("Activo"),
+        "ordersHistory": MessageLookupByLibrary.simpleMessage("Historial"),
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
+        "overwrite": MessageLookupByLibrary.simpleMessage("Sobrescribir"),
+        "ownOrder":
+            MessageLookupByLibrary.simpleMessage("Esta es tu propia orden!"),
+        "paidFromBalance":
+            MessageLookupByLibrary.simpleMessage("Pagado del saldo:"),
+        "paidFromVolume": MessageLookupByLibrary.simpleMessage(
+            "Pagado del volumen recibido:"),
+        "paidWith": MessageLookupByLibrary.simpleMessage("Pagado con"),
+        "passwordRequirement": MessageLookupByLibrary.simpleMessage(
+            "La contraseña debe contener al menos 12 caracteres, con una minúscula, una mayúscula y un símbolo especial."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "Su billetera mostrará sus transacciones pasadas realizadas después de la fecha especificada."),
+        "paymentUriDetailsAccept":
+            MessageLookupByLibrary.simpleMessage("Pagar"),
+        "paymentUriDetailsAcceptQuestion":
+            MessageLookupByLibrary.simpleMessage("¿Acepta esta transacción?"),
+        "paymentUriDetailsAddressSpan":
+            MessageLookupByLibrary.simpleMessage("A Direccion"),
+        "paymentUriDetailsAmountSpan":
+            MessageLookupByLibrary.simpleMessage("Monto:"),
+        "paymentUriDetailsCoinSpan":
+            MessageLookupByLibrary.simpleMessage("Moneda:"),
+        "paymentUriDetailsDeny":
+            MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "paymentUriDetailsTitle":
+            MessageLookupByLibrary.simpleMessage("Pago solicitado"),
+        "paymentUriInactiveCoin": m86,
+        "placeOrder": MessageLookupByLibrary.simpleMessage("Haga su pedido"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Acepte todas las solicitudes especiales de activación de monedas o anule la selección de las monedas."),
+        "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
+            "Por favor agregue una moneda"),
+        "pleaseRestart": MessageLookupByLibrary.simpleMessage(
+            "Reinicie la aplicación para volver a intentarlo o presione el botón a continuación."),
+        "portfolio": MessageLookupByLibrary.simpleMessage("Portfolio"),
+        "poweredOnKmd":
+            MessageLookupByLibrary.simpleMessage("Desarrollado por Komodo"),
+        "price": MessageLookupByLibrary.simpleMessage("price"),
+        "privateKey": MessageLookupByLibrary.simpleMessage("Llave Privada"),
+        "privateKeys": MessageLookupByLibrary.simpleMessage("Llaves Privadas"),
+        "protectionCtrlConfirmations":
+            MessageLookupByLibrary.simpleMessage("Confirmaciones"),
+        "protectionCtrlCustom": MessageLookupByLibrary.simpleMessage(
+            "Usar configuraciones de protección personalizadas"),
+        "protectionCtrlOff":
+            MessageLookupByLibrary.simpleMessage("DESACTIVADO"),
+        "protectionCtrlOn": MessageLookupByLibrary.simpleMessage("ACTIVADO"),
+        "protectionCtrlWarning": MessageLookupByLibrary.simpleMessage(
+            "Advertencia, este intercambio atómico no está protegido por dPoW."),
+        "pubkey": MessageLookupByLibrary.simpleMessage("Llave Publica"),
+        "qrCodeScanner":
+            MessageLookupByLibrary.simpleMessage("Escáner de código QR"),
+        "question_1": MessageLookupByLibrary.simpleMessage(
+            "¿Guardás mis llaves privadas?"),
+        "question_10": m87,
+        "question_2": m88,
+        "question_3": MessageLookupByLibrary.simpleMessage(
+            "¿Cuánto tiempo toma cada intercambio atómico?"),
+        "question_4": MessageLookupByLibrary.simpleMessage(
+            "¿Necesito estar en línea durante la duración del intercambio?"),
+        "question_5": m89,
+        "question_6": MessageLookupByLibrary.simpleMessage(
+            "¿Ofrecen soporte al usuario?"),
+        "question_7": MessageLookupByLibrary.simpleMessage(
+            "¿Tiene restricciones de país?"),
+        "question_8": m90,
+        "question_9": m91,
+        "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
+            "¡Es una nueva era! Hemos cambiado oficialmente nuestro nombre de \'AtomicDEX\' a \'Komodo Wallet\'"),
+        "receive": MessageLookupByLibrary.simpleMessage("RECIBIR"),
+        "receiveLower": MessageLookupByLibrary.simpleMessage("Recibir"),
+        "recommendSeedMessage": MessageLookupByLibrary.simpleMessage(
+            "Recomendamos almacenarlo fuera de línea."),
+        "remove": MessageLookupByLibrary.simpleMessage("Desactivar"),
+        "requestedTrade":
+            MessageLookupByLibrary.simpleMessage("Comercio solicitado"),
+        "reset": MessageLookupByLibrary.simpleMessage("RESETEAR"),
+        "resetTitle":
+            MessageLookupByLibrary.simpleMessage("Restablecer formulario"),
+        "restoreWallet": MessageLookupByLibrary.simpleMessage("RESTAURAR"),
+        "retryActivating": MessageLookupByLibrary.simpleMessage(
+            "Volviendo a intentar activar todas las monedas..."),
+        "retryAll": MessageLookupByLibrary.simpleMessage(
+            "Vuelva a intentar activar todo"),
+        "rewardsButton":
+            MessageLookupByLibrary.simpleMessage("Reclama tus recompensas"),
+        "rewardsCancel": MessageLookupByLibrary.simpleMessage("Cancelar"),
+        "rewardsError": MessageLookupByLibrary.simpleMessage(
+            "Algo salió mal. Por favor, inténtelo de nuevo más tarde."),
+        "rewardsInProgressLong": MessageLookupByLibrary.simpleMessage(
+            "La transacción está en curso"),
+        "rewardsInProgressShort":
+            MessageLookupByLibrary.simpleMessage("procesando"),
+        "rewardsLowAmountLong": MessageLookupByLibrary.simpleMessage(
+            "Cantidad de UTXO inferior a 10 KMD"),
+        "rewardsLowAmountShort":
+            MessageLookupByLibrary.simpleMessage("<10 KMD"),
+        "rewardsOneHourLong":
+            MessageLookupByLibrary.simpleMessage("Aún no ha pasado una hora"),
+        "rewardsOneHourShort": MessageLookupByLibrary.simpleMessage("<1 hora"),
+        "rewardsPopupOk": MessageLookupByLibrary.simpleMessage("Ok"),
+        "rewardsPopupTitle":
+            MessageLookupByLibrary.simpleMessage("Estado de recompensas:"),
+        "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
+            "Obtenga más información sobre las recompensas para usuarios activos de KMD"),
+        "rewardsReceive": MessageLookupByLibrary.simpleMessage("Recibir"),
+        "rewardsSuccess": m92,
+        "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
+        "rewardsTableRewards":
+            MessageLookupByLibrary.simpleMessage("Recompensas,\nKMD"),
+        "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("Estado"),
+        "rewardsTableTime":
+            MessageLookupByLibrary.simpleMessage("Tiempo\nrestante"),
+        "rewardsTableTitle":
+            MessageLookupByLibrary.simpleMessage("Información de recompensas:"),
+        "rewardsTableUXTO":
+            MessageLookupByLibrary.simpleMessage("UTXO\ncantidad,\nKMD"),
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
+        "rewardsTitle":
+            MessageLookupByLibrary.simpleMessage("Información de recompensas"),
+        "russianLanguage": MessageLookupByLibrary.simpleMessage("Ruso"),
+        "saveMerged": MessageLookupByLibrary.simpleMessage("Guardar combinado"),
+        "scrollToContinue": MessageLookupByLibrary.simpleMessage(
+            "Desplácese hacia abajo para continuar..."),
+        "searchFilterCoin":
+            MessageLookupByLibrary.simpleMessage("Buscar una moneda"),
+        "searchFilterSubtitleAVX": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens de Avax"),
+        "searchFilterSubtitleBEP": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens BEP"),
+        "searchFilterSubtitleCosmos": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todo Cosmos Network"),
+        "searchFilterSubtitleERC": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens ERC"),
+        "searchFilterSubtitleETC": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens ETC"),
+        "searchFilterSubtitleFTM": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todas las fichas de Fantom"),
+        "searchFilterSubtitleHCO": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens de HecoChain"),
+        "searchFilterSubtitleHRC": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todas las fichas de armonía"),
+        "searchFilterSubtitleIris": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todo Iris Network"),
+        "searchFilterSubtitleKRC": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens de Kucoin"),
+        "searchFilterSubtitleMVR": MessageLookupByLibrary.simpleMessage(
+            "Seleccione todas las fichas de Moonriver"),
+        "searchFilterSubtitlePLG": MessageLookupByLibrary.simpleMessage(
+            "Seleccione todas las fichas de polígono"),
+        "searchFilterSubtitleQRC": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens QRC"),
+        "searchFilterSubtitleSBCH": MessageLookupByLibrary.simpleMessage(
+            "Seleccione todos los tokens SmartBCH"),
+        "searchFilterSubtitleSLP": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los tokens SLP"),
+        "searchFilterSubtitleSmartChain": MessageLookupByLibrary.simpleMessage(
+            "Seleccione todos los SmartChains"),
+        "searchFilterSubtitleTestCoins": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todos los activos de prueba"),
+        "searchFilterSubtitleUBQ": MessageLookupByLibrary.simpleMessage(
+            "Seleccionar todas las monedas Ubiq"),
+        "searchFilterSubtitleZHTLC": MessageLookupByLibrary.simpleMessage(
+            "Seleccione todas las monedas ZHTLC"),
+        "searchFilterSubtitleutxo": MessageLookupByLibrary.simpleMessage(
+            "Seleccione todas las monedas UTXO"),
+        "searchForTicker":
+            MessageLookupByLibrary.simpleMessage("Buscar teletipo"),
+        "seconds": MessageLookupByLibrary.simpleMessage("s"),
+        "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
+        "seeOrders": m96,
+        "seeTxHistory": MessageLookupByLibrary.simpleMessage(
+            "Ver historial de transacciones"),
+        "seedPhrase": MessageLookupByLibrary.simpleMessage("Frase Semilla"),
+        "seedPhraseTitle":
+            MessageLookupByLibrary.simpleMessage("Tu nueva frase semilla"),
+        "selectCoin":
+            MessageLookupByLibrary.simpleMessage("Seleccionar moneda"),
+        "selectCoinInfo": MessageLookupByLibrary.simpleMessage(
+            "Seleccione las monedas que desea agregar a su cartera."),
+        "selectCoinTitle":
+            MessageLookupByLibrary.simpleMessage("Activar monedas:"),
+        "selectCoinToBuy": MessageLookupByLibrary.simpleMessage(
+            "Seleccione la moneda que desea COMPRAR"),
+        "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
+            "Seleccione la moneda que desea VENDER"),
+        "selectDate":
+            MessageLookupByLibrary.simpleMessage("Seleccione una fecha"),
+        "selectFileImport":
+            MessageLookupByLibrary.simpleMessage("Seleccione Archivo"),
+        "selectLanguage":
+            MessageLookupByLibrary.simpleMessage("Seleccione el idioma"),
+        "selectPaymentMethod":
+            MessageLookupByLibrary.simpleMessage("Selecciona tu forma de pago"),
+        "selectedOrder":
+            MessageLookupByLibrary.simpleMessage("Orden seleccionado:"),
+        "sell": MessageLookupByLibrary.simpleMessage("Vender"),
+        "sellTestCoinWarning": MessageLookupByLibrary.simpleMessage(
+            "¡Advertencia, estás dispuesto a vender monedas de prueba SIN valor real!"),
+        "send": MessageLookupByLibrary.simpleMessage("ENVIAR"),
+        "setUpPassword":
+            MessageLookupByLibrary.simpleMessage("CONFIGURAR UNA CONTRASEÑA"),
+        "settingDialogSpan1": MessageLookupByLibrary.simpleMessage(
+            "Estás seguro de que quieres eliminar"),
+        "settingDialogSpan2":
+            MessageLookupByLibrary.simpleMessage("billetera?"),
+        "settingDialogSpan3":
+            MessageLookupByLibrary.simpleMessage("Si es así, asegúrese de"),
+        "settingDialogSpan4":
+            MessageLookupByLibrary.simpleMessage("guardar su frase inicial."),
+        "settingDialogSpan5": MessageLookupByLibrary.simpleMessage(
+            "Para restaurar su billetera en el futuro."),
+        "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Idiomas"),
+        "settings": MessageLookupByLibrary.simpleMessage("Ajustes"),
+        "share": MessageLookupByLibrary.simpleMessage("Compartir"),
+        "shareAddress": m97,
+        "showAddress":
+            MessageLookupByLibrary.simpleMessage("Mostrar dirección"),
+        "showDetails": MessageLookupByLibrary.simpleMessage("Mostrar detalles"),
+        "showMyOrders":
+            MessageLookupByLibrary.simpleMessage("Mostrar mis pedidos"),
+        "showingOrders": m99,
+        "signInWithPassword": MessageLookupByLibrary.simpleMessage(
+            "Iniciar sesión con contraseña"),
+        "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
+            "¿Olvidó la contraseña? Restaurar billetera desde semilla"),
+        "simple": MessageLookupByLibrary.simpleMessage("Sencillo"),
+        "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("Activar"),
+        "simpleTradeBuyHint": m100,
+        "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Comprar"),
+        "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Cerrar"),
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
+        "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Recibir"),
+        "simpleTradeSellHint": m103,
+        "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Vender"),
+        "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Enviar"),
+        "simpleTradeShowLess":
+            MessageLookupByLibrary.simpleMessage("Muestra menos"),
+        "simpleTradeShowMore":
+            MessageLookupByLibrary.simpleMessage("Mostrar mas"),
+        "simpleTradeUnableActivate": m104,
+        "skip": MessageLookupByLibrary.simpleMessage("Omitir"),
+        "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Descartar"),
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
+        "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Sonido"),
+        "soundSettingsTitle":
+            MessageLookupByLibrary.simpleMessage("Ajustes de sonido"),
+        "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("Sonidos"),
+        "soundsDoNotShowAgain": MessageLookupByLibrary.simpleMessage(
+            "Entendido, no lo muestres más."),
+        "soundsExplanation": MessageLookupByLibrary.simpleMessage(
+            "Escuchará notificaciones de sonido durante el proceso de intercambio y cuando tenga un pedido de fabricante activo.\nEl protocolo de intercambios atómicos requiere que los participantes estén en línea para un intercambio exitoso, y las notificaciones de sonido ayudan a lograrlo."),
+        "soundsNote": MessageLookupByLibrary.simpleMessage(
+            "Tenga en cuenta que puede configurar sus sonidos personalizados en la configuración de la aplicación."),
+        "spanishLanguage": MessageLookupByLibrary.simpleMessage("Español"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Fecha de inicio"),
+        "startSwap":
+            MessageLookupByLibrary.simpleMessage("Iniciar intercambio"),
+        "step": MessageLookupByLibrary.simpleMessage("Paso"),
+        "success": MessageLookupByLibrary.simpleMessage("¡Éxito!"),
+        "support": MessageLookupByLibrary.simpleMessage("Apoyo"),
+        "supportLinksDesc": m107,
+        "swap": MessageLookupByLibrary.simpleMessage("intercambio"),
+        "swapCurrent": MessageLookupByLibrary.simpleMessage("Actual"),
+        "swapDetailTitle": MessageLookupByLibrary.simpleMessage(
+            "CONFIRMAR DETALLES DE CAMBIO"),
+        "swapEstimated": MessageLookupByLibrary.simpleMessage("Estimado"),
+        "swapFailed":
+            MessageLookupByLibrary.simpleMessage("Intercambio fallido"),
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
+        "swapOngoing":
+            MessageLookupByLibrary.simpleMessage("Intercambio en curso"),
+        "swapProgress":
+            MessageLookupByLibrary.simpleMessage("Detalles del Progreso"),
+        "swapStarted": MessageLookupByLibrary.simpleMessage("Iniciado"),
+        "swapSucceful":
+            MessageLookupByLibrary.simpleMessage("Intercambio exitoso"),
+        "swapTotal": MessageLookupByLibrary.simpleMessage("Total"),
+        "swapUUID": MessageLookupByLibrary.simpleMessage("Intercambiar UUID"),
+        "switchTheme": MessageLookupByLibrary.simpleMessage("Cambiar Tema"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Sincronización desde la fecha especificada"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Sincronización desde la activación del retoño"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Sincronizar nuevas transacciones"),
+        "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
+        "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
+        "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
+        "tagETC": MessageLookupByLibrary.simpleMessage("ETC"),
+        "tagFTM20": MessageLookupByLibrary.simpleMessage("FTM20"),
+        "tagHCO20": MessageLookupByLibrary.simpleMessage("HCO20"),
+        "tagHRC20": MessageLookupByLibrary.simpleMessage("HRC20"),
+        "tagKMD": MessageLookupByLibrary.simpleMessage("KMD"),
+        "tagKRC20": MessageLookupByLibrary.simpleMessage("KRC20"),
+        "tagMVR20": MessageLookupByLibrary.simpleMessage("MVR20"),
+        "tagPLG20": MessageLookupByLibrary.simpleMessage("PLG20"),
+        "tagQRC20": MessageLookupByLibrary.simpleMessage("QRC20"),
+        "tagSBCH": MessageLookupByLibrary.simpleMessage("SBCH"),
+        "tagUBQ": MessageLookupByLibrary.simpleMessage("UBQ"),
+        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ZHTLC"),
+        "takerOrder":
+            MessageLookupByLibrary.simpleMessage("Orden de Comprador"),
+        "timeOut": MessageLookupByLibrary.simpleMessage("Se acabó el tiempo"),
+        "titleCreatePassword":
+            MessageLookupByLibrary.simpleMessage("CREA UNA CONTRASEÑA"),
+        "titleCurrentAsk":
+            MessageLookupByLibrary.simpleMessage("Pedido seleccionado"),
+        "to": MessageLookupByLibrary.simpleMessage("Para"),
+        "toAddress": MessageLookupByLibrary.simpleMessage("Hacia:"),
+        "tooManyAssetsEnabledSpan1":
+            MessageLookupByLibrary.simpleMessage("Tu tienes"),
+        "tooManyAssetsEnabledSpan2": MessageLookupByLibrary.simpleMessage(
+            "activos habilitados. El límite máximo de activos habilitados es"),
+        "tooManyAssetsEnabledSpan3": MessageLookupByLibrary.simpleMessage(
+            ". Desactive algunos antes de agregar otros nuevos."),
+        "tooManyAssetsEnabledTitle": MessageLookupByLibrary.simpleMessage(
+            "Demasiados recursos habilitados"),
+        "totalFees": MessageLookupByLibrary.simpleMessage("Tarifas totales:"),
+        "trade": MessageLookupByLibrary.simpleMessage("INTERCAMBIO"),
+        "tradeCompleted":
+            MessageLookupByLibrary.simpleMessage("¡CAMBIO COMPLETADO!"),
+        "tradeDetail":
+            MessageLookupByLibrary.simpleMessage("DETALLES INTERCAMBIO"),
+        "tradePreimageError": MessageLookupByLibrary.simpleMessage(
+            "Error al calcular las tarifas comerciales"),
+        "tradingFee":
+            MessageLookupByLibrary.simpleMessage("tarifa de negociación:"),
+        "tradingMode":
+            MessageLookupByLibrary.simpleMessage("Modo de comercio:"),
+        "transactionAddress":
+            MessageLookupByLibrary.simpleMessage("Dirección de transacción"),
+        "transactionHidden":
+            MessageLookupByLibrary.simpleMessage("Transacción oculta"),
+        "transactionHiddenPhishing": MessageLookupByLibrary.simpleMessage(
+            "Esta transacción fue ocultada debido a un posible intento de phishing."),
+        "tryRestarting": MessageLookupByLibrary.simpleMessage(
+            "Si aún así algunas monedas aún no están activadas, intente reiniciar la aplicación."),
+        "turkishLanguage": MessageLookupByLibrary.simpleMessage("Turco"),
+        "txBlock": MessageLookupByLibrary.simpleMessage("Bloque"),
+        "txConfirmations":
+            MessageLookupByLibrary.simpleMessage("Confirmaciones"),
+        "txConfirmed": MessageLookupByLibrary.simpleMessage("CONFIRMADO"),
+        "txFee": MessageLookupByLibrary.simpleMessage("Tarifa"),
+        "txFeeTitle":
+            MessageLookupByLibrary.simpleMessage("tarifa de transacción:"),
+        "txHash": MessageLookupByLibrary.simpleMessage("ID de transacción"),
+        "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
+            "Demasiadas solicitudes.\nSe excedió el límite de solicitudes del historial de transacciones.\nVuelva a intentarlo más tarde."),
+        "txNotConfirmed": MessageLookupByLibrary.simpleMessage("INCONFIRMADO"),
+        "txleft": m112,
+        "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ucranio"),
+        "unlock": MessageLookupByLibrary.simpleMessage("desbloquear"),
+        "unlockFunds":
+            MessageLookupByLibrary.simpleMessage("Desbloquear fondos"),
+        "unlockSuccess": m113,
+        "unspendable": MessageLookupByLibrary.simpleMessage("ingastable"),
+        "updatesAvailable":
+            MessageLookupByLibrary.simpleMessage("Nueva versión disponible"),
+        "updatesChecking": MessageLookupByLibrary.simpleMessage(
+            "Comprobando actualizaciones..."),
+        "updatesCurrentVersion": m114,
+        "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
+            "Nueva versión disponible. Por favor actualice."),
+        "updatesNotifAvailableVersion": m115,
+        "updatesNotifTitle":
+            MessageLookupByLibrary.simpleMessage("Actualización disponible"),
+        "updatesSkip": MessageLookupByLibrary.simpleMessage("Saltar por ahora"),
+        "updatesTitle": m116,
+        "updatesUpToDate":
+            MessageLookupByLibrary.simpleMessage("Ya está actualizado"),
+        "updatesUpdate": MessageLookupByLibrary.simpleMessage("Actualizar"),
+        "uriInsufficientBalanceSpan1": MessageLookupByLibrary.simpleMessage(
+            "No hay suficiente saldo para escaneado"),
+        "uriInsufficientBalanceSpan2":
+            MessageLookupByLibrary.simpleMessage("solicitud de pago."),
+        "uriInsufficientBalanceTitle":
+            MessageLookupByLibrary.simpleMessage("Saldo insuficiente"),
+        "value": MessageLookupByLibrary.simpleMessage("Valor:"),
+        "version": MessageLookupByLibrary.simpleMessage("version"),
+        "viewInExplorerButton":
+            MessageLookupByLibrary.simpleMessage("Explorador"),
+        "viewSeedAndKeys":
+            MessageLookupByLibrary.simpleMessage("Semilla y Claves Privadas"),
+        "volumes": MessageLookupByLibrary.simpleMessage("Volumenes"),
+        "walletInUse": MessageLookupByLibrary.simpleMessage(
+            "El nombre de la billetera ya está en uso"),
+        "walletMaxChar": MessageLookupByLibrary.simpleMessage(
+            "El nombre de la billetera debe tener un máximo de 40 caracteres"),
+        "walletOnly": MessageLookupByLibrary.simpleMessage("Solo billetera"),
+        "warning": MessageLookupByLibrary.simpleMessage("¡Advertencia!"),
+        "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
+        "warningShareLogs": MessageLookupByLibrary.simpleMessage(
+            "Advertencia: en casos especiales, estos datos de registro contienen información confidencial que se puede usar para gastar monedas de intercambios fallidos."),
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
+        "welcomeLetSetUp":
+            MessageLookupByLibrary.simpleMessage("¡VAMOS A PREPARARNOS!"),
+        "welcomeTitle": MessageLookupByLibrary.simpleMessage("BIENVENIDO"),
+        "welcomeWallet": MessageLookupByLibrary.simpleMessage("wallet"),
+        "willBeRedirected": MessageLookupByLibrary.simpleMessage(
+            "Se le redirigirá a la página del portafolio al finalizar."),
+        "willTakeTime": MessageLookupByLibrary.simpleMessage(
+            "Esto llevará un tiempo y la aplicación deberá mantenerse en primer plano.\nCerrar la aplicación mientras la activación está en curso podría generar problemas."),
+        "withdraw": MessageLookupByLibrary.simpleMessage("Retirar"),
+        "withdrawCameraAccessText": m120,
+        "withdrawCameraAccessTitle":
+            MessageLookupByLibrary.simpleMessage("Acceso Denegado"),
+        "withdrawConfirm":
+            MessageLookupByLibrary.simpleMessage("Confirmar Retiro"),
+        "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
+            "Algo salió mal. Vuelva a intentarlo más tarde."),
+        "withdrawValue": m121,
+        "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
+            "Está intentando escanear un código QR de pago para"),
+        "wrongCoinSpan2":
+            MessageLookupByLibrary.simpleMessage("pero tu estas en la"),
+        "wrongCoinSpan3":
+            MessageLookupByLibrary.simpleMessage("pantalla de retirar"),
+        "wrongCoinTitle":
+            MessageLookupByLibrary.simpleMessage("Moneda equivocada"),
+        "wrongPassword": MessageLookupByLibrary.simpleMessage(
+            "Las contraseñas no coinciden. Inténtalo de nuevo."),
+        "yes": MessageLookupByLibrary.simpleMessage("Sí"),
+        "you have a fresh order that is trying to match with an existing order":
+            MessageLookupByLibrary.simpleMessage(
+                "tiene un pedido nuevo que está tratando de coincidir con un pedido existente"),
+        "you have an active swap in progress":
+            MessageLookupByLibrary.simpleMessage(
+                "tienes un intercambio activo en curso"),
+        "you have an order that new orders can match with":
+            MessageLookupByLibrary.simpleMessage(
+                "tiene un pedido con el que pueden coincidir nuevos pedidos"),
+        "youAreSending":
+            MessageLookupByLibrary.simpleMessage("Usted está enviando:"),
+        "youWillReceiveClaim": m122,
+        "youWillReceived":
+            MessageLookupByLibrary.simpleMessage("Usted recibirá:"),
+        "yourWallet": MessageLookupByLibrary.simpleMessage("Su billetera")
+      };
 }

--- a/lib/l10n/messages_fr.dart
+++ b/lib/l10n/messages_fr.dart
@@ -159,156 +159,163 @@ class MessageLookup extends MessageLookupByLibrary {
   static m53(abbr) =>
       "${abbr} balance insuffisante pour payer les frais de courtage";
 
-  static m54(coinAbbr) => "${coinAbbr} est indisponible :(";
+  static m54(coin) => "Adresse ${coin} invalide";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} est indisponible :(";
+
+  static m56(coinName) =>
       "❗Attention ! Le marché pour ${coinName} a un volume de transactions inférieur à 10 000 \$ sur 24 heures !";
 
-  static m56(value) => "La limite doit aller jusqu\'à ${value}";
-
-  static m57(coinName, number) =>
-      "Le montant minimum à vendre est ${number} ${coinName}";
+  static m57(value) => "La limite doit aller jusqu\'à ${value}";
 
   static m58(coinName, number) =>
+      "Le montant minimum à vendre est ${number} ${coinName}";
+
+  static m59(coinName, number) =>
       "Le montant minimum à acheter est ${number} ${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "Le montant minimum de la commande est de ${buyAmount}${buyCoin}(${sellAmount}${sellCoin})";
 
-  static m60(coinName, number) =>
+  static m61(coinName, number) =>
       "Le montant minimum à vendre est de ${number}${coinName}";
 
-  static m61(minValue, coin) => "Doit être supérieur à ${minValue} ${coin}";
+  static m62(minValue, coin) => "Doit être supérieur à ${minValue} ${coin}";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "Veuillez noter que vous utilisez maintenant des données cellulaires et que votre participation au réseau ${appName} P2P consomme du trafic Internet. Il est préférable d\'utiliser un réseau WiFi si votre forfait de données cellulaires est coûteux.";
 
-  static m63(coin) => "Activez ${coin} et rechargez d\'abord le solde";
+  static m64(coin) => "Activez ${coin} et rechargez d\'abord le solde";
 
-  static m64(number) => "Créer ${number} Ordre(s):";
+  static m65(number) => "Créer ${number} Ordre(s):";
 
-  static m65(coin) => "La balance ${coin} est trop faible";
+  static m66(coin) => "La balance ${coin} est trop faible";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "Pas assez de ${coin} pour payer les frais. Balance MIN necessaire ${fee} ${coin}";
 
-  static m67(coinName) =>
+  static m68(coinName) =>
       "Aucun ordre ${coinName} disponible - réessayez ultérieurement ou créez un ordre.";
 
-  static m68(coin) => "Pas assez de ${coin} pour la transaction!";
+  static m69(coin) => "Pas assez de ${coin} pour la transaction!";
 
-  static m69(sell, buy) =>
+  static m70(sell, buy) =>
       " L\'échange${sell} / ${buy} s\'est terminé avec succès";
 
-  static m70(sell, buy) => "${sell}/${buy} échange échoué";
+  static m71(sell, buy) => "${sell}/${buy} échange échoué";
 
-  static m71(sell, buy) => "${sell}/${buy} échange démarré";
+  static m72(sell, buy) => "${sell}/${buy} échange démarré";
 
-  static m72(sell, buy) => "${sell}/${buy} délais d\'échange dépassé";
+  static m73(sell, buy) => "${sell}/${buy} délais d\'échange dépassé";
 
-  static m73(coin) => "Vous avez reçu ${coin}  transaction !";
+  static m74(coin) => "Vous avez reçu ${coin}  transaction !";
 
-  static m74(assets) => "${assets} Actifs";
+  static m75(assets) => "${assets} Actifs";
 
-  static m75(coin) => "Tous les ordres ${coin} seront annulés.";
+  static m76(coin) => "Tous les ordres ${coin} seront annulés.";
 
-  static m76(delta) => "Expédient : CEX +${delta} %";
+  static m77(delta) => "Expédient : CEX +${delta} %";
 
-  static m77(delta) => "Cher : CEX ${delta} %";
+  static m78(delta) => "Cher : CEX ${delta} %";
 
-  static m78(fill) => "${fill}% rempli";
+  static m79(fill) => "${fill}% rempli";
 
-  static m79(coin) => "Mnt. (${coin})";
+  static m80(coin) => "Mnt. (${coin})";
 
-  static m80(coin) => "Prix (${coin})";
+  static m81(coin) => "Prix (${coin})";
 
-  static m81(coin) => "Total (${coin})";
+  static m82(coin) => "Total (${coin})";
 
-  static m82(abbr) =>
+  static m83(abbr) =>
       "${abbr} n\'est pas actif. Veuillez activer et réessayer.";
 
-  static m83(appName) =>
+  static m84(appName) =>
       "Quels sont les appareils compatibles avec ${appName}?";
 
-  static m84(appName) =>
+  static m85(appName) =>
       "En quoi le trading sur ${appName} est-il différent du trading sur d\'autres DEX ?";
 
-  static m85(appName) => "Comment sont calculés les frais sur ${appName}  ?";
+  static m86(appName) => "Comment sont calculés les frais sur ${appName}  ?";
 
-  static m86(appName) => "Qui est derrière ${appName}?";
+  static m87(appName) => "Qui est derrière ${appName}?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "Est-il possible de développer mon propre échange en marque blanche sur ${appName} ?";
 
-  static m88(amount) => "Succès! ${amount} KMD reçu.";
+  static m89(amount) => "Succès! ${amount} KMD reçu.";
 
-  static m89(dd) => "${dd} jour(s)";
+  static m90(dd) => "${dd} jour(s)";
 
-  static m90(hh, minutes) => "${hh}h ${minutes}m";
+  static m91(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m91(mm) => "${mm}min";
+  static m92(mm) => "${mm}min";
 
-  static m92(amount) => "Cliquez pour voir ${amount} orders";
+  static m93(amount) => "Cliquez pour voir ${amount} orders";
 
-  static m93(coinName, address) => "Mon adresse ${coinName}:\n${address}";
+  static m94(coinName, address) => "Mon adresse ${coinName}:\n${address}";
 
-  static m94(count, maxCount) =>
+  static m95(coin) => "Rechercher les transactions ${coin} passées ?";
+
+  static m96(count, maxCount) =>
       "Affichage de ${count} commandes sur ${maxCount}.";
 
-  static m95(coin) => "Veuillez entrer le montant de ${coin} à acheter";
+  static m97(coin) => "Veuillez entrer le montant de ${coin} à acheter";
 
-  static m96(maxCoins) =>
+  static m98(maxCoins) =>
       "Le nombre maximum de pièces actives est de ${maxCoins}. Veuillez en désactiver certains.";
 
-  static m97(coin) => "${coin} pas activé!";
+  static m99(coin) => "${coin} pas activé!";
 
-  static m98(coin) => "Veuillez entrer le montant de ${coin} à vendre";
+  static m100(coin) => "Veuillez entrer le montant de ${coin} à vendre";
 
-  static m99(coin) => "Impossible d\'activer ${coin}";
+  static m101(coin) => "Impossible d\'activer ${coin}";
 
-  static m100(description) =>
+  static m102(description) =>
       "Choisissez un fichier mp3 ou wav s\'il vous plaît. Nous y jouerons quand ${description}.";
 
-  static m101(description) => "Joué quand ${description}";
+  static m103(description) => "Joué quand ${description}";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "Si vous avez des questions ou si vous pensez avoir rencontré un problème technique avec l\'application ${appName} , vous pouvez le signaler et obtenir de l\'aide de notre équipe.";
 
-  static m103(coin) =>
+  static m105(coin) =>
       "Veuillez d\'abord activer ${coin} et recharger le solde";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "${coin}  solde insuffisant pour payer les frais de transaction.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "${coin}  solde insuffisant pour payer les frais de transaction. ${coin} ${amount} requis.";
 
-  static m106(left) => "Transactions restantes : ${left}";
+  static m108(name) =>
+      "Quelles transactions ${name} souhaitez-vous synchroniser ?";
 
-  static m107(amnt, hash) =>
+  static m109(left) => "Transactions restantes : ${left}";
+
+  static m110(amnt, hash) =>
       " ${amnt}  fonds ont été débloqués avec succès - TX : ${hash}";
 
-  static m108(version) => "Version ${version} en cours d\'utilisation";
+  static m111(version) => "Version ${version} en cours d\'utilisation";
 
-  static m109(version) =>
+  static m112(version) =>
       "Version ${version} disponible. Veuillez mettre à jour.";
 
-  static m110(appName) => "Mise à jour ${appName}";
+  static m113(appName) => "Mise à jour ${appName}";
 
-  static m111(coinAbbr) => "Activation ${coinAbbr} échoué";
+  static m114(coinAbbr) => "Activation ${coinAbbr} échoué";
 
-  static m112(coinAbbr) =>
+  static m115(coinAbbr) =>
       "Activation ${coinAbbr} échoué.\nVeuillez redémarrer l\'application et réessayer.";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "Komodo Wallet est un portefeuille multi crypto-monnaies de nouvelle génération doté de la fonctionnalité DEX native de troisième génération et encore bien plus.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "Vous avez précédemment refusé à ${appName} l\'accès à la caméra.\nVeuillez modifier manuellement l\'autorisation de l\'appareil photo dans les paramètres de votre téléphone pour procéder à l\'analyse du code QR.";
 
-  static m115(amount, coinName) => "ENVOYER ${amount} ${coinName}";
+  static m118(amount, coinName) => "ENVOYER ${amount} ${coinName}";
 
-  static m116(amount, coin) => "Vous recevrez ${amount} ${coin}";
+  static m119(amount, coin) => "Vous recevrez ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -357,6 +364,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Adresse du destinataire"),
         "advanced": MessageLookupByLibrary.simpleMessage("Avancé"),
         "all": MessageLookupByLibrary.simpleMessage("Tout"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "Votre portefeuille affichera toutes les transactions passées. Cela prendra beaucoup de temps et de stockage car tous les blocs seront téléchargés et analysés."),
         "allowCustomSeed": MessageLookupByLibrary.simpleMessage(
             "Autoriser les passphrases personnalisées"),
         "alreadyExists":
@@ -428,6 +437,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup":
             MessageLookupByLibrary.simpleMessage("Configuration Masque PIN"),
         "cancel": MessageLookupByLibrary.simpleMessage("Annuler"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Annuler l\'activation"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Etes-vous sûr de vouloir annuler l\'activation ?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("Annuler"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("Annuler l\'ordre"),
         "candleChartError": MessageLookupByLibrary.simpleMessage(
@@ -474,6 +487,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Fermer Message d\'Erreur"),
         "closePreview": MessageLookupByLibrary.simpleMessage("Fermer aperçu"),
         "code": MessageLookupByLibrary.simpleMessage("Code:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Etes-vous sûr de vouloir annuler l\'activation ?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Effacer"),
         "coinSelectNotFound": MessageLookupByLibrary.simpleMessage(
             "Aucune crypto-monnaie active"),
@@ -767,6 +782,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("Code QR trouvé"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("Français"),
         "from": MessageLookupByLibrary.simpleMessage("De"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "Nous synchroniserons les futures transactions effectuées après l\'activation associée à votre clé publique. C’est l’option la plus rapide et celle qui nécessite le moins de stockage."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("limite Gas"),
         "gasNotActive": m50,
@@ -849,11 +866,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rafraichir"),
         "internetRestored":
             MessageLookupByLibrary.simpleMessage("Connexion Internet Restauré"),
+        "invalidCoinAddress": m54,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Échange impossible"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Détails"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japonais"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Coréen"),
         "language": MessageLookupByLibrary.simpleMessage("Langue"),
@@ -861,8 +879,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Dernières Transactions"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Légal"),
         "less": MessageLookupByLibrary.simpleMessage("Moins"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Chargement..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Chargement des ordres ..."),
@@ -933,11 +951,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder": MessageLookupByLibrary.simpleMessage("Volume d\'odre Min:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Doit être inférieur au montant de la vente"),
         "minVolumeTitle":
@@ -947,11 +965,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Avertissement : la réduction de l\'application sur iOS mettra fin au processus d\'activation."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo":
             MessageLookupByLibrary.simpleMessage("Plus d\'informations"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Plus"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Montant"),
         "multiBasePlaceholder":
@@ -960,7 +978,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Annuler"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Confirmer"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Créer"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Ordre"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Ordres"),
@@ -976,8 +994,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Montant invalide"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Montant de vente invalide"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Montant de vente Max est"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
@@ -1012,7 +1030,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Pas d\'articles sélectionnés"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Pas d\'ordres compatibles trouvés"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable":
             MessageLookupByLibrary.simpleMessage("Cliquez pour créer un ordre"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1028,7 +1046,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("Entrer une valeur numérique"),
         "none": MessageLookupByLibrary.simpleMessage("Aucun"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Pas assez de solde pour les frais - échangez un montant inférieur"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1037,24 +1055,24 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ajouter une Note"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("Note"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("Pas de résultat"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Échange terminé"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Échange échoué"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Nouvel échange démarré"),
         "notifSwapStatusTitle": MessageLookupByLibrary.simpleMessage(
             "Statut de l\'échange modifié"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Délais d\'échange dépassé"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Transaction entrante"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease": MessageLookupByLibrary.simpleMessage(
             "Communiqué de presse officiel"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -1065,14 +1083,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ouvrir Message d\'Erreur"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Moins"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Plus"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated": MessageLookupByLibrary.simpleMessage("Ordre créée"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Ordre créée avec succès"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Adresses"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Annuler"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("pour"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Identique au CEX"),
@@ -1086,7 +1104,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ouvrez les détails en un seul clic et sélectionnez Commander en appuyant longuement"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Dépenser"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Détails"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Ordre trouvé"),
         "orderMatching":
             MessageLookupByLibrary.simpleMessage("Recherche d\'ordre"),
@@ -1096,9 +1114,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("ordres"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Actif"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Historique"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Écraser"),
         "ownOrder": MessageLookupByLibrary.simpleMessage(
             " Ceci est votre propre commande!"),
@@ -1109,6 +1127,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Payé avec"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "Le mot de passe doit contenir au moins 12 caractères, avec une minuscule, une majuscule et un symbole spécial."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "Votre portefeuille affichera vos transactions passées effectuées après la date spécifiée."),
         "paymentUriDetailsAccept":
             MessageLookupByLibrary.simpleMessage("Payer"),
         "paymentUriDetailsAcceptQuestion": MessageLookupByLibrary.simpleMessage(
@@ -1123,7 +1143,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Annuler"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Paiement demandé"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder":
             MessageLookupByLibrary.simpleMessage("Passer votre ordre"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
@@ -1149,19 +1169,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Scanner de codes QR"),
         "question_1":
             MessageLookupByLibrary.simpleMessage("Stockez-vous ma clé privé?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Combien de temps dure chaque échange atomique ?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Dois-je être en ligne pendant toute la durée de l\'échange ?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Offrez-vous une assistance aux utilisateurs ?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Avez-vous des restrictions par pays ?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "C\'est une nouvelle ère ! Nous avons officiellement changé notre nom de \'AtomicDEX\' en \'Komodo Wallet\'"),
         "receive": MessageLookupByLibrary.simpleMessage("RECEVOIR"),
@@ -1201,7 +1221,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "En savoir plus sur les récompenses des utilisateurs actifs KMD"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Recevoir"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Récompense,\nKMD"),
@@ -1212,9 +1232,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Information récompense:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("mnt UTXO,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Information récompense"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Russe"),
@@ -1268,7 +1288,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rechercher un téléscripteur"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage(
             "Voir l\'historique de transaction"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Passphrases"),
@@ -1284,6 +1304,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Sélectionnez la crypto-monnaie que vous souhaitez acheter"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "Sélectionnez la crypto-monnaie que vous souhaitez vendre"),
+        "selectDate":
+            MessageLookupByLibrary.simpleMessage("Sélectionnez une date"),
         "selectFileImport":
             MessageLookupByLibrary.simpleMessage("Selectionner fichier"),
         "selectLanguage":
@@ -1311,37 +1333,38 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Langues"),
         "settings": MessageLookupByLibrary.simpleMessage("Réglages"),
         "share": MessageLookupByLibrary.simpleMessage("Partager"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress":
             MessageLookupByLibrary.simpleMessage("Afficher l\'adresse"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Afficher Détails"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("MONTRER MES COMMANDES"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword": MessageLookupByLibrary.simpleMessage(
             "Se connecter avec mot de passe"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "Connectez-vous avec la passphrase"),
         "simple": MessageLookupByLibrary.simpleMessage("Facile"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("Activer"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Acheter"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Fermer"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Recevoir"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Vendre"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Envoyer"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Afficher moins"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Afficher plus"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Passer"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Rejeter"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Son"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Paramètres son"),
@@ -1353,12 +1376,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Notez que vous pouvez définir vos sons personnalisés dans les paramètres de l\'application."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("Espagnol"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Date de début"),
         "startSwap":
             MessageLookupByLibrary.simpleMessage("Commencer l\'échange"),
         "step": MessageLookupByLibrary.simpleMessage("Étape"),
         "success": MessageLookupByLibrary.simpleMessage("Succès!"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("échanger"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Actuel"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage(
@@ -1366,9 +1390,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Estimation"),
         "swapFailed":
             MessageLookupByLibrary.simpleMessage("L\'échange a échoué"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Echange en cours"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Détails de la progression"),
@@ -1377,6 +1401,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Total"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("UUID échange"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Changer de thème"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Synchroniser à partir de la date spécifiée"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Synchronisation à partir de l\'activation des jeunes arbres"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Synchroniser les nouvelles transactions"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1441,25 +1472,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Trop de demandes.\nLimite de demandes d\'historique des transactions dépassée.\nVeuillez réessayer plus tard."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("NON CONFIRMÉ"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrainien"),
         "unlock": MessageLookupByLibrary.simpleMessage("ouvrir"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Débloquer Fonds"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("indépensable"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Nouvelle version disponible"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Recherche de mise à jour..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Nouvelle version disponible. Veuillez mettre à jour."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Mise à jour disponible"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Ignorer pour l\'instant"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage("Déjà à jour"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Update"),
         "uriInsufficientBalanceSpan1": MessageLookupByLibrary.simpleMessage(
@@ -1485,9 +1516,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Attention - dans des cas particuliers, ces données de journal contiennent des informations sensibles qui peuvent être utilisées pour dépenser des pièces à partir d\'échanges échoués !"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("CONFIGURONS!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("BIENVENUE"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("portefeuille"),
@@ -1496,14 +1527,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Cela prendra un certain temps et l\'application doit rester au premier plan.\nLa fermeture de l\'application pendant l\'activation est en cours peut entraîner des problèmes."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Envoyer"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Accès refusé"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Confirmer le retrait"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Un problème est survenu. Réessayez plus tard."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Vous essayez de scanner un code QR de paiement pour"),
         "wrongCoinSpan2":
@@ -1525,7 +1556,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "vous avez une commande avec laquelle de nouvelles commandes peuvent correspondre"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Vous envoyez:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("Vous allez recevoir:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("votre portefeuille")

--- a/lib/l10n/messages_fr.dart
+++ b/lib/l10n/messages_fr.dart
@@ -76,246 +76,253 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "Quel est le ${index} mot dans votre passphrase?";
 
-  static m22(protocolName) => "Les pièces ${protocolName} sont activées";
+  static m22(coin) => "Activation de ${coin} annulée";
 
-  static m23(protocolName) => "${protocolName} pièces activées avec succès";
+  static m23(coin) => "${coin} activé avec succès";
 
-  static m24(protocolName) => "Les pièces ${protocolName} ne sont pas activées";
+  static m24(protocolName) => "Les pièces ${protocolName} sont activées";
 
-  static m25(name) => "Voulez-vous supprimer le contact ${name}?";
+  static m25(protocolName) => "${protocolName} pièces activées avec succès";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "Les pièces ${protocolName} ne sont pas activées";
+
+  static m27(name) => "Voulez-vous supprimer le contact ${name}?";
+
+  static m28(iUnderstand) =>
       "Les phrases de départ personnalisées peuvent être moins sécurisées et plus faciles à déchiffrer qu\'une phrase de départ ou une clé privée (WIF) conforme à BIP39. Pour confirmer que vous comprenez le risque et savez ce que vous faites, saisissez \" ${iUnderstand}\" dans la case ci-dessous.";
 
-  static m27(coinName) => "recevez des frais de transaction ${coinName}";
+  static m29(coinName) => "recevez des frais de transaction ${coinName}";
 
-  static m28(coinName) => "envoyer des frais de transaction à ${coinName}";
+  static m30(coinName) => "envoyer des frais de transaction à ${coinName}";
 
-  static m29(abbr) => "Entrez l\'adresse ${abbr} ";
+  static m31(abbr) => "Entrez l\'adresse ${abbr} ";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "Vous pouvez toujours activer ${remains}, Selected : ${selected}";
 
-  static m31(gas) =>
+  static m33(gas) =>
       "Pas assez de gas - veuillez utiliser au moins ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "Envoi de la demande au robinet ${coin} ...";
+  static m48(coinAbbr) =>
+      "Échec de l\'annulation de l\'activation de ${coinAbbr}";
 
-  static m47(appCompanyShort) => "${appCompanyShort} actualités";
+  static m49(coin) => "Envoi de la demande au robinet ${coin} ...";
 
-  static m48(value) => "Les frais doivent être jusqu\'à ${value}";
+  static m50(appCompanyShort) => "${appCompanyShort} actualités";
 
-  static m49(coin) => "${coin} commission";
+  static m51(value) => "Les frais doivent être jusqu\'à ${value}";
 
-  static m50(coin) => "Veuillez activer ${coin}.";
+  static m52(coin) => "${coin} commission";
 
-  static m51(value) => "Gwei doit atteindre ${value}";
+  static m53(coin) => "Veuillez activer ${coin}.";
 
-  static m52(coinName) =>
+  static m54(value) => "Gwei doit atteindre ${value}";
+
+  static m55(coinName) =>
       "Paramètres de protection des transmissions entrantes ${coinName}";
 
-  static m53(abbr) =>
+  static m56(abbr) =>
       "${abbr} balance insuffisante pour payer les frais de courtage";
 
-  static m54(coin) => "Adresse ${coin} invalide";
+  static m57(coin) => "Adresse ${coin} invalide";
 
-  static m55(coinAbbr) => "${coinAbbr} est indisponible :(";
+  static m58(coinAbbr) => "${coinAbbr} est indisponible :(";
 
-  static m56(coinName) =>
+  static m59(coinName) =>
       "❗Attention ! Le marché pour ${coinName} a un volume de transactions inférieur à 10 000 \$ sur 24 heures !";
 
-  static m57(value) => "La limite doit aller jusqu\'à ${value}";
-
-  static m58(coinName, number) =>
-      "Le montant minimum à vendre est ${number} ${coinName}";
-
-  static m59(coinName, number) =>
-      "Le montant minimum à acheter est ${number} ${coinName}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "Le montant minimum de la commande est de ${buyAmount}${buyCoin}(${sellAmount}${sellCoin})";
+  static m60(value) => "La limite doit aller jusqu\'à ${value}";
 
   static m61(coinName, number) =>
+      "Le montant minimum à vendre est ${number} ${coinName}";
+
+  static m62(coinName, number) =>
+      "Le montant minimum à acheter est ${number} ${coinName}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "Le montant minimum de la commande est de ${buyAmount}${buyCoin}(${sellAmount}${sellCoin})";
+
+  static m64(coinName, number) =>
       "Le montant minimum à vendre est de ${number}${coinName}";
 
-  static m62(minValue, coin) => "Doit être supérieur à ${minValue} ${coin}";
+  static m65(minValue, coin) => "Doit être supérieur à ${minValue} ${coin}";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "Veuillez noter que vous utilisez maintenant des données cellulaires et que votre participation au réseau ${appName} P2P consomme du trafic Internet. Il est préférable d\'utiliser un réseau WiFi si votre forfait de données cellulaires est coûteux.";
 
-  static m64(coin) => "Activez ${coin} et rechargez d\'abord le solde";
+  static m67(coin) => "Activez ${coin} et rechargez d\'abord le solde";
 
-  static m65(number) => "Créer ${number} Ordre(s):";
+  static m68(number) => "Créer ${number} Ordre(s):";
 
-  static m66(coin) => "La balance ${coin} est trop faible";
+  static m69(coin) => "La balance ${coin} est trop faible";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "Pas assez de ${coin} pour payer les frais. Balance MIN necessaire ${fee} ${coin}";
 
-  static m68(coinName) =>
+  static m71(coinName) =>
       "Aucun ordre ${coinName} disponible - réessayez ultérieurement ou créez un ordre.";
 
-  static m69(coin) => "Pas assez de ${coin} pour la transaction!";
+  static m72(coin) => "Pas assez de ${coin} pour la transaction!";
 
-  static m70(sell, buy) =>
+  static m73(sell, buy) =>
       " L\'échange${sell} / ${buy} s\'est terminé avec succès";
 
-  static m71(sell, buy) => "${sell}/${buy} échange échoué";
+  static m74(sell, buy) => "${sell}/${buy} échange échoué";
 
-  static m72(sell, buy) => "${sell}/${buy} échange démarré";
+  static m75(sell, buy) => "${sell}/${buy} échange démarré";
 
-  static m73(sell, buy) => "${sell}/${buy} délais d\'échange dépassé";
+  static m76(sell, buy) => "${sell}/${buy} délais d\'échange dépassé";
 
-  static m74(coin) => "Vous avez reçu ${coin}  transaction !";
+  static m77(coin) => "Vous avez reçu ${coin}  transaction !";
 
-  static m75(assets) => "${assets} Actifs";
+  static m78(assets) => "${assets} Actifs";
 
-  static m76(coin) => "Tous les ordres ${coin} seront annulés.";
+  static m79(coin) => "Tous les ordres ${coin} seront annulés.";
 
-  static m77(delta) => "Expédient : CEX +${delta} %";
+  static m80(delta) => "Expédient : CEX +${delta} %";
 
-  static m78(delta) => "Cher : CEX ${delta} %";
+  static m81(delta) => "Cher : CEX ${delta} %";
 
-  static m79(fill) => "${fill}% rempli";
+  static m82(fill) => "${fill}% rempli";
 
-  static m80(coin) => "Mnt. (${coin})";
+  static m83(coin) => "Mnt. (${coin})";
 
-  static m81(coin) => "Prix (${coin})";
+  static m84(coin) => "Prix (${coin})";
 
-  static m82(coin) => "Total (${coin})";
+  static m85(coin) => "Total (${coin})";
 
-  static m83(abbr) =>
+  static m86(abbr) =>
       "${abbr} n\'est pas actif. Veuillez activer et réessayer.";
 
-  static m84(appName) =>
+  static m87(appName) =>
       "Quels sont les appareils compatibles avec ${appName}?";
 
-  static m85(appName) =>
+  static m88(appName) =>
       "En quoi le trading sur ${appName} est-il différent du trading sur d\'autres DEX ?";
 
-  static m86(appName) => "Comment sont calculés les frais sur ${appName}  ?";
+  static m89(appName) => "Comment sont calculés les frais sur ${appName}  ?";
 
-  static m87(appName) => "Qui est derrière ${appName}?";
+  static m90(appName) => "Qui est derrière ${appName}?";
 
-  static m88(appName) =>
+  static m91(appName) =>
       "Est-il possible de développer mon propre échange en marque blanche sur ${appName} ?";
 
-  static m89(amount) => "Succès! ${amount} KMD reçu.";
+  static m92(amount) => "Succès! ${amount} KMD reçu.";
 
-  static m90(dd) => "${dd} jour(s)";
+  static m93(dd) => "${dd} jour(s)";
 
-  static m91(hh, minutes) => "${hh}h ${minutes}m";
+  static m94(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m92(mm) => "${mm}min";
+  static m95(mm) => "${mm}min";
 
-  static m93(amount) => "Cliquez pour voir ${amount} orders";
+  static m96(amount) => "Cliquez pour voir ${amount} orders";
 
-  static m94(coinName, address) => "Mon adresse ${coinName}:\n${address}";
+  static m97(coinName, address) => "Mon adresse ${coinName}:\n${address}";
 
-  static m95(coin) => "Rechercher les transactions ${coin} passées ?";
+  static m98(coin) => "Rechercher les transactions ${coin} passées ?";
 
-  static m96(count, maxCount) =>
+  static m99(count, maxCount) =>
       "Affichage de ${count} commandes sur ${maxCount}.";
 
-  static m97(coin) => "Veuillez entrer le montant de ${coin} à acheter";
+  static m100(coin) => "Veuillez entrer le montant de ${coin} à acheter";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "Le nombre maximum de pièces actives est de ${maxCoins}. Veuillez en désactiver certains.";
 
-  static m99(coin) => "${coin} pas activé!";
+  static m102(coin) => "${coin} pas activé!";
 
-  static m100(coin) => "Veuillez entrer le montant de ${coin} à vendre";
+  static m103(coin) => "Veuillez entrer le montant de ${coin} à vendre";
 
-  static m101(coin) => "Impossible d\'activer ${coin}";
+  static m104(coin) => "Impossible d\'activer ${coin}";
 
-  static m102(description) =>
+  static m105(description) =>
       "Choisissez un fichier mp3 ou wav s\'il vous plaît. Nous y jouerons quand ${description}.";
 
-  static m103(description) => "Joué quand ${description}";
+  static m106(description) => "Joué quand ${description}";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "Si vous avez des questions ou si vous pensez avoir rencontré un problème technique avec l\'application ${appName} , vous pouvez le signaler et obtenir de l\'aide de notre équipe.";
 
-  static m105(coin) =>
+  static m108(coin) =>
       "Veuillez d\'abord activer ${coin} et recharger le solde";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "${coin}  solde insuffisant pour payer les frais de transaction.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "${coin}  solde insuffisant pour payer les frais de transaction. ${coin} ${amount} requis.";
 
-  static m108(name) =>
+  static m111(name) =>
       "Quelles transactions ${name} souhaitez-vous synchroniser ?";
 
-  static m109(left) => "Transactions restantes : ${left}";
+  static m112(left) => "Transactions restantes : ${left}";
 
-  static m110(amnt, hash) =>
+  static m113(amnt, hash) =>
       " ${amnt}  fonds ont été débloqués avec succès - TX : ${hash}";
 
-  static m111(version) => "Version ${version} en cours d\'utilisation";
+  static m114(version) => "Version ${version} en cours d\'utilisation";
 
-  static m112(version) =>
+  static m115(version) =>
       "Version ${version} disponible. Veuillez mettre à jour.";
 
-  static m113(appName) => "Mise à jour ${appName}";
+  static m116(appName) => "Mise à jour ${appName}";
 
-  static m114(coinAbbr) => "Activation ${coinAbbr} échoué";
+  static m117(coinAbbr) => "Activation ${coinAbbr} échoué";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "Activation ${coinAbbr} échoué.\nVeuillez redémarrer l\'application et réessayer.";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "Komodo Wallet est un portefeuille multi crypto-monnaies de nouvelle génération doté de la fonctionnalité DEX native de troisième génération et encore bien plus.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "Vous avez précédemment refusé à ${appName} l\'accès à la caméra.\nVeuillez modifier manuellement l\'autorisation de l\'appareil photo dans les paramètres de votre téléphone pour procéder à l\'analyse du code QR.";
 
-  static m118(amount, coinName) => "ENVOYER ${amount} ${coinName}";
+  static m121(amount, coinName) => "ENVOYER ${amount} ${coinName}";
 
-  static m119(amount, coin) => "Vous recevrez ${amount} ${coin}";
+  static m122(amount, coin) => "Vous recevrez ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -345,6 +352,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled": MessageLookupByLibrary.simpleMessage(
+            "Activation des pièces annulée"),
         "activationInProgress": m3,
         "addCoin":
             MessageLookupByLibrary.simpleMessage("Activer la crypto-monnaie"),
@@ -489,6 +498,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Code:"),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Etes-vous sûr de vouloir annuler l\'activation ?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Effacer"),
         "coinSelectNotFound": MessageLookupByLibrary.simpleMessage(
             "Aucune crypto-monnaie active"),
@@ -496,9 +507,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Choisir crypto-monnaie"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "Vous avez sélectionné le nombre maximum d\'éléments"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("A venir..."),
         "commingsoon":
             MessageLookupByLibrary.simpleMessage("TX détails à venir!"),
@@ -529,7 +540,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactDelete":
             MessageLookupByLibrary.simpleMessage("Supprimer Contact"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Supprimer"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Annuler"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Editer"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Fermer"),
@@ -558,7 +569,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Frais personnalisés"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "N\'utiliser les frais personnalisés que si vous savez ce que vous faite!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo sécurité dPoW"),
         "date": MessageLookupByLibrary.simpleMessage("Date"),
         "decryptingWallet": MessageLookupByLibrary.simpleMessage(
@@ -576,8 +587,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Supprimer le portefeuille"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Supression portefeuille…"),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "envoyer des frais de négociation frais de transaction"),
@@ -602,7 +613,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Je ne veux pas de mot de passe"),
         "duration": MessageLookupByLibrary.simpleMessage("Durée"),
         "editContact": MessageLookupByLibrary.simpleMessage("Editer contact"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "Le mot de passe chiffré ne peut être nul"),
         "emptyImportPass": MessageLookupByLibrary.simpleMessage(
@@ -611,7 +622,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Le nom du contact ne peut être nul"),
         "emptyWallet": MessageLookupByLibrary.simpleMessage(
             "Le nom du portefeuille ne peut être nul"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "Veuillez activer les notifications pour obtenir des mises à jour sur la progression de l\'activation."),
@@ -648,7 +659,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Adresse non valide"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Adresses Segwit non supportées (pour le moment)"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain":
             MessageLookupByLibrary.simpleMessage("Erreur, veuillez réessayer"),
         "errorTryLater": MessageLookupByLibrary.simpleMessage(
@@ -659,32 +670,32 @@ class MessageLookup extends MessageLookupByLibrary {
             "S\'il vous plaît entrer des données"),
         "estimateValue":
             MessageLookupByLibrary.simpleMessage("Valeur totale estimée"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -734,18 +745,19 @@ class MessageLookup extends MessageLookupByLibrary {
             "Les objets ont été exportés avec succès:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Échange"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Exporter"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Montant du faux solde :"),
         "faqTitle": MessageLookupByLibrary.simpleMessage("Foire aux questions"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Erreur"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("FAUCET"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Succès"),
         "faucetTimedOut":
             MessageLookupByLibrary.simpleMessage("La demande a expiré"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("Actualités"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("Rien ici"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("Lire plus..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("Fil"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("Fil d\'Actualités"),
@@ -758,7 +770,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Fil d\'actualité mis à jour"),
         "feedback":
             MessageLookupByLibrary.simpleMessage("Envoyer des commentaires"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("Tout"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Filtrer"),
         "filtersClearAll":
@@ -784,9 +796,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("De"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "Nous synchroniserons les futures transactions effectuées après l\'activation associée à votre clé publique. C’est l’option la plus rapide et celle qui nécessite le moins de stockage."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("limite Gas"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("prix Gas"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "Protection PIN pas activé.\nCamouflage PIN non disponible.\nVeuillez activer la protection PIN."),
@@ -796,7 +808,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "En cours de transaction, veuillez patienter"),
         "goToPorfolio":
             MessageLookupByLibrary.simpleMessage("Ouvrir portfolio"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Aide"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("Aide et Assistance"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("Masquer balances"),
@@ -848,7 +860,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
             "Erreur décodage fichier json"),
         "importTitle": MessageLookupByLibrary.simpleMessage("Importer"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Si vous n\'entrez pas de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille."),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -857,7 +869,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Cette transaction peut prendre jusqu\'à 10 minutes. NE FERMEZ PAS cette application!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "Vous pouvez choisir de chiffrer votre portefeuille avec un mot de passe. Si vous choisissez de ne pas utiliser de mot de passe, vous devrez entrer votre passphrase chaque fois que vous souhaitez accéder à votre portefeuille."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "Le volume minimum requis pour cet ordre est"),
         "insufficientTitle":
@@ -866,12 +878,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rafraichir"),
         "internetRestored":
             MessageLookupByLibrary.simpleMessage("Connexion Internet Restauré"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Échange impossible"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Détails"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japonais"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Coréen"),
         "language": MessageLookupByLibrary.simpleMessage("Langue"),
@@ -879,8 +891,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Dernières Transactions"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Légal"),
         "less": MessageLookupByLibrary.simpleMessage("Moins"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Chargement..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Chargement des ordres ..."),
@@ -951,11 +963,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder": MessageLookupByLibrary.simpleMessage("Volume d\'odre Min:"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Doit être inférieur au montant de la vente"),
         "minVolumeTitle":
@@ -965,11 +977,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Avertissement : la réduction de l\'application sur iOS mettra fin au processus d\'activation."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo":
             MessageLookupByLibrary.simpleMessage("Plus d\'informations"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Plus"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Montant"),
         "multiBasePlaceholder":
@@ -978,7 +990,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Annuler"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Confirmer"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Créer"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Ordre"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Ordres"),
@@ -994,8 +1006,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Montant invalide"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Montant de vente invalide"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Montant de vente Max est"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
@@ -1030,7 +1042,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Pas d\'articles sélectionnés"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Pas d\'ordres compatibles trouvés"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable":
             MessageLookupByLibrary.simpleMessage("Cliquez pour créer un ordre"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1046,7 +1058,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("Entrer une valeur numérique"),
         "none": MessageLookupByLibrary.simpleMessage("Aucun"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Pas assez de solde pour les frais - échangez un montant inférieur"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1055,24 +1067,24 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ajouter une Note"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("Note"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("Pas de résultat"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Échange terminé"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Échange échoué"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Nouvel échange démarré"),
         "notifSwapStatusTitle": MessageLookupByLibrary.simpleMessage(
             "Statut de l\'échange modifié"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Délais d\'échange dépassé"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Transaction entrante"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease": MessageLookupByLibrary.simpleMessage(
             "Communiqué de presse officiel"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -1083,14 +1095,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ouvrir Message d\'Erreur"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Moins"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Plus"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated": MessageLookupByLibrary.simpleMessage("Ordre créée"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Ordre créée avec succès"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Adresses"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Annuler"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("pour"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Identique au CEX"),
@@ -1104,7 +1116,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ouvrez les détails en un seul clic et sélectionnez Commander en appuyant longuement"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Dépenser"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Détails"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Ordre trouvé"),
         "orderMatching":
             MessageLookupByLibrary.simpleMessage("Recherche d\'ordre"),
@@ -1114,9 +1126,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("ordres"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Actif"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Historique"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Écraser"),
         "ownOrder": MessageLookupByLibrary.simpleMessage(
             " Ceci est votre propre commande!"),
@@ -1143,9 +1155,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Annuler"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Paiement demandé"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder":
             MessageLookupByLibrary.simpleMessage("Passer votre ordre"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Veuillez accepter toutes les demandes spéciales d’activation de pièces ou désélectionner les pièces."),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
             "Veuillez ajouter une Crypto-monnaie"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1169,19 +1184,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Scanner de codes QR"),
         "question_1":
             MessageLookupByLibrary.simpleMessage("Stockez-vous ma clé privé?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Combien de temps dure chaque échange atomique ?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Dois-je être en ligne pendant toute la durée de l\'échange ?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Offrez-vous une assistance aux utilisateurs ?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Avez-vous des restrictions par pays ?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "C\'est une nouvelle ère ! Nous avons officiellement changé notre nom de \'AtomicDEX\' en \'Komodo Wallet\'"),
         "receive": MessageLookupByLibrary.simpleMessage("RECEVOIR"),
@@ -1221,7 +1236,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "En savoir plus sur les récompenses des utilisateurs actifs KMD"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Recevoir"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Récompense,\nKMD"),
@@ -1232,9 +1247,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Information récompense:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("mnt UTXO,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Information récompense"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Russe"),
@@ -1288,7 +1303,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rechercher un téléscripteur"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage(
             "Voir l\'historique de transaction"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Passphrases"),
@@ -1333,38 +1348,38 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Langues"),
         "settings": MessageLookupByLibrary.simpleMessage("Réglages"),
         "share": MessageLookupByLibrary.simpleMessage("Partager"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress":
             MessageLookupByLibrary.simpleMessage("Afficher l\'adresse"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Afficher Détails"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("MONTRER MES COMMANDES"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword": MessageLookupByLibrary.simpleMessage(
             "Se connecter avec mot de passe"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "Connectez-vous avec la passphrase"),
         "simple": MessageLookupByLibrary.simpleMessage("Facile"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("Activer"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Acheter"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Fermer"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Recevoir"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Vendre"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Envoyer"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Afficher moins"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Afficher plus"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Passer"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Rejeter"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Son"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Paramètres son"),
@@ -1382,7 +1397,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Étape"),
         "success": MessageLookupByLibrary.simpleMessage("Succès!"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("échanger"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Actuel"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage(
@@ -1390,9 +1405,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Estimation"),
         "swapFailed":
             MessageLookupByLibrary.simpleMessage("L\'échange a échoué"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Echange en cours"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Détails de la progression"),
@@ -1407,7 +1422,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Synchronisation à partir de l\'activation des jeunes arbres"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
             "Synchroniser les nouvelles transactions"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1472,25 +1487,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Trop de demandes.\nLimite de demandes d\'historique des transactions dépassée.\nVeuillez réessayer plus tard."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("NON CONFIRMÉ"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrainien"),
         "unlock": MessageLookupByLibrary.simpleMessage("ouvrir"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Débloquer Fonds"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("indépensable"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Nouvelle version disponible"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Recherche de mise à jour..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Nouvelle version disponible. Veuillez mettre à jour."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Mise à jour disponible"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Ignorer pour l\'instant"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage("Déjà à jour"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Update"),
         "uriInsufficientBalanceSpan1": MessageLookupByLibrary.simpleMessage(
@@ -1516,9 +1531,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Attention - dans des cas particuliers, ces données de journal contiennent des informations sensibles qui peuvent être utilisées pour dépenser des pièces à partir d\'échanges échoués !"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("CONFIGURONS!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("BIENVENUE"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("portefeuille"),
@@ -1527,14 +1542,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Cela prendra un certain temps et l\'application doit rester au premier plan.\nLa fermeture de l\'application pendant l\'activation est en cours peut entraîner des problèmes."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Envoyer"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Accès refusé"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Confirmer le retrait"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Un problème est survenu. Réessayez plus tard."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Vous essayez de scanner un code QR de paiement pour"),
         "wrongCoinSpan2":
@@ -1556,7 +1571,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "vous avez une commande avec laquelle de nouvelles commandes peuvent correspondre"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Vous envoyez:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("Vous allez recevoir:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("votre portefeuille")

--- a/lib/l10n/messages_hu.dart
+++ b/lib/l10n/messages_hu.dart
@@ -77,241 +77,248 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "Mi a ${index}. szó a SEED-ben?";
 
-  static m22(protocolName) => "${protocolName} érme aktiválva van";
+  static m22(coin) => "${coin} aktiválása megszakítva";
 
-  static m23(protocolName) => "${protocolName} érme sikeresen aktiválva";
+  static m23(coin) => "${coin} sikeresen aktiválva";
 
-  static m24(protocolName) => "A(z) ${protocolName} érmék nincsenek aktiválva";
+  static m24(protocolName) => "${protocolName} érme aktiválva van";
 
-  static m25(name) =>
+  static m25(protocolName) => "${protocolName} érme sikeresen aktiválva";
+
+  static m26(protocolName) => "A(z) ${protocolName} érmék nincsenek aktiválva";
+
+  static m27(name) =>
       "Biztos vagy benne, hogy törölni akarod a ${name} kontaktot?";
 
-  static m26(iUnderstand) =>
+  static m28(iUnderstand) =>
       "Az egyéni magvas kifejezések kevésbé biztonságosak és könnyebben feltörhetők, mint egy generált, BIP39 szabványnak megfelelő magvas kifejezés vagy magánkulcs (WIF). Annak megerősítéséhez, hogy tisztában van a kockázattal és tudja, mit csinál, írja be az alábbi mezőbe a \"${iUnderstand}\" szöveget.";
 
-  static m27(coinName) => "megkapja a ${coinName} tranzakciós díjat";
+  static m29(coinName) => "megkapja a ${coinName} tranzakciós díjat";
 
-  static m28(coinName) => "küldje el a ${coinName} tranzakciós díjat";
+  static m30(coinName) => "küldje el a ${coinName} tranzakciós díjat";
 
-  static m29(abbr) => "Bemenet ${abbr} cím";
+  static m31(abbr) => "Bemenet ${abbr} cím";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "Továbbra is engedélyezheti a következőt: ${remains}, Kijelölve: ${selected}";
 
-  static m31(gas) => "Nincs elég gáz - használjon minimum ${gas} Gwei";
+  static m33(gas) => "Nincs elég gáz - használjon minimum ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "Kérelem küldése a ${coin} csaptelephez...";
+  static m48(coinAbbr) =>
+      "Nem sikerült megszakítani a(z) ${coinAbbr} aktiválását";
 
-  static m47(appCompanyShort) => "${appCompanyShort} hírek";
+  static m49(coin) => "Kérelem küldése a ${coin} csaptelephez...";
 
-  static m48(value) => "A díjak legfeljebb ${value}";
+  static m50(appCompanyShort) => "${appCompanyShort} hírek";
 
-  static m49(coin) => "${coin} díj";
+  static m51(value) => "A díjak legfeljebb ${value}";
 
-  static m50(coin) => "Kérjük, aktiválja ${coin}.";
+  static m52(coin) => "${coin} díj";
 
-  static m51(value) =>
+  static m53(coin) => "Kérjük, aktiválja ${coin}.";
+
+  static m54(value) =>
       "A Gwei értékének legfeljebb ${value} értéknek kell lennie";
 
-  static m52(coinName) => "Bejövő ${coinName} txs-védelmi beállítások";
+  static m55(coinName) => "Bejövő ${coinName} txs-védelmi beállítások";
 
-  static m53(abbr) =>
+  static m56(abbr) =>
       "${abbr} az egyenleg nem elegendő a kereskedési díj kifizetéséhez";
 
-  static m54(coin) => "Érvénytelen ${coin} cím";
+  static m57(coin) => "Érvénytelen ${coin} cím";
 
-  static m55(coinAbbr) => "${coinAbbr} nem elérhető :(";
+  static m58(coinAbbr) => "${coinAbbr} nem elérhető :(";
 
-  static m56(coinName) =>
+  static m59(coinName) =>
       "❗Vigyázat! A(z) ${coinName} piacán kevesebb, mint 10 000 USD 24 órás kereskedési volumen van!";
 
-  static m57(value) => "A korlát legfeljebb ${value} lehet";
-
-  static m58(coinName, number) =>
-      "A minimális eladási összeg ${number} ${coinName}";
-
-  static m59(coinName, number) =>
-      "A minimális vásárlási összeg: ${number}${coinName}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "A megbízás minimális összege ${buyAmount} ${buyCoin} (${sellAmount} ${sellCoin})";
+  static m60(value) => "A korlát legfeljebb ${value} lehet";
 
   static m61(coinName, number) =>
+      "A minimális eladási összeg ${number} ${coinName}";
+
+  static m62(coinName, number) =>
+      "A minimális vásárlási összeg: ${number}${coinName}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "A megbízás minimális összege ${buyAmount} ${buyCoin} (${sellAmount} ${sellCoin})";
+
+  static m64(coinName, number) =>
       "Az eladandó minimális összeg ${number} ${coinName}";
 
-  static m62(minValue, coin) =>
+  static m65(minValue, coin) =>
       "Nagyobbnak kell lennie, mint ${minValue} ${coin}";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "Kérjük, vegye figyelembe, hogy most mobiladatokat használ, és az ${appName} P2P-hálózatban való részvétel internetforgalmat fogyaszt. Jobb, ha WiFi hálózatot használsz, ha a mobiladat-előfizetésed drága.";
 
-  static m64(coin) => "Aktiválja a ${coin} és töltse fel először az egyenlegét";
+  static m67(coin) => "Aktiválja a ${coin} és töltse fel először az egyenlegét";
 
-  static m65(number) => "Create ${number} Order(s):";
+  static m68(number) => "Create ${number} Order(s):";
 
-  static m66(coin) => "${coin} egyenleg túl alacsony";
+  static m69(coin) => "${coin} egyenleg túl alacsony";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "Nincs elég ${coin} a díjak kifizetéséhez. MIN egyenleg ${fee} ${coin}";
 
-  static m68(coinName) =>
+  static m71(coinName) =>
       "Nem érhető el ${coinName} rendelés - próbálja újra később, vagy készítsen egy rendelést.";
 
-  static m69(coin) => "Nincs elég ${coin} a tranzakcióhoz!";
+  static m72(coin) => "Nincs elég ${coin} a tranzakcióhoz!";
 
-  static m70(sell, buy) => "Az ${sell}/${buy} swap sikeresen befejeződött.";
+  static m73(sell, buy) => "Az ${sell}/${buy} swap sikeresen befejeződött.";
 
-  static m71(sell, buy) => "${sell}/${buy} csere sikertelen volt";
+  static m74(sell, buy) => "${sell}/${buy} csere sikertelen volt";
 
-  static m72(sell, buy) => "${sell}/${buy} swap elindult";
+  static m75(sell, buy) => "${sell}/${buy} swap elindult";
 
-  static m73(sell, buy) => "${sell}/${buy} swap időzítve volt";
+  static m76(sell, buy) => "${sell}/${buy} swap időzítve volt";
 
-  static m74(coin) => "Ön ${coin} tranzakciót kapott!";
+  static m77(coin) => "Ön ${coin} tranzakciót kapott!";
 
-  static m75(assets) => "${assets} Aktív";
+  static m78(assets) => "${assets} Aktív";
 
-  static m76(coin) => "Minden ${coin} megrendelés törlésre kerül.";
+  static m79(coin) => "Minden ${coin} megrendelés törlésre kerül.";
 
-  static m77(delta) => "Célszerű: CEX +${delta}%";
+  static m80(delta) => "Célszerű: CEX +${delta}%";
 
-  static m78(delta) => "Drága: CEX ${delta}%";
+  static m81(delta) => "Drága: CEX ${delta}%";
 
-  static m79(fill) => "${fill}% betelt";
+  static m82(fill) => "${fill}% betelt";
 
-  static m80(coin) => "Mennyiség. (${coin})";
+  static m83(coin) => "Mennyiség. (${coin})";
 
-  static m81(coin) => "Ár (${coin})";
+  static m84(coin) => "Ár (${coin})";
 
-  static m82(coin) => "Összesen (${coin})";
+  static m85(coin) => "Összesen (${coin})";
 
-  static m83(abbr) => "${abbr} nem aktív. Kérjük, aktiválja és próbálja újra.";
+  static m86(abbr) => "${abbr} nem aktív. Kérjük, aktiválja és próbálja újra.";
 
-  static m84(appName) => "Mely eszközökön használhatom az ${appName}-t?";
-
-  static m85(appName) =>
-      "Miben különbözik a kereskedés az ${appName}-en a más DEX-eken folytatott kereskedéstől?";
-
-  static m86(appName) => "Hogyan számítják ki a díjakat az ${appName}-nél?";
-
-  static m87(appName) => "Ki áll az ${appName} mögött?";
+  static m87(appName) => "Mely eszközökön használhatom az ${appName}-t?";
 
   static m88(appName) =>
+      "Miben különbözik a kereskedés az ${appName}-en a más DEX-eken folytatott kereskedéstől?";
+
+  static m89(appName) => "Hogyan számítják ki a díjakat az ${appName}-nél?";
+
+  static m90(appName) => "Ki áll az ${appName} mögött?";
+
+  static m91(appName) =>
       "Lehetséges saját white-label csereprogramot kialakítani az ${appName} oldalon?";
 
-  static m89(amount) => "Siker! ${amount} KMD kapott.";
+  static m92(amount) => "Siker! ${amount} KMD kapott.";
 
-  static m90(dd) => "${dd} napok";
+  static m93(dd) => "${dd} napok";
 
-  static m91(hh, minutes) => "${hh}h ${minutes}m";
+  static m94(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m92(mm) => "${mm}min";
+  static m95(mm) => "${mm}min";
 
-  static m93(amount) => "Kattintson a megtekintéshez ${amount} rendelések";
+  static m96(amount) => "Kattintson a megtekintéshez ${amount} rendelések";
 
-  static m94(coinName, address) => "Az én ${coinName} címem:\n${address}";
+  static m97(coinName, address) => "Az én ${coinName} címem:\n${address}";
 
-  static m95(coin) => "Keresi a múltbeli ${coin} tranzakciókat?";
+  static m98(coin) => "Keresi a múltbeli ${coin} tranzakciókat?";
 
-  static m96(count, maxCount) => "${count}/${maxCount} rendelés megjelenítése.";
+  static m99(count, maxCount) => "${count}/${maxCount} rendelés megjelenítése.";
 
-  static m97(coin) => "Kérjük, adja meg a ${coin} összeget a vásárláshoz";
+  static m100(coin) => "Kérjük, adja meg a ${coin} összeget a vásárláshoz";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "A maximális aktív érmék száma ${maxCoins}. Kérjük, néhányat deaktiváljon.";
 
-  static m99(coin) => "${coin} nem aktív!";
+  static m102(coin) => "${coin} nem aktív!";
 
-  static m100(coin) => "Kérjük, adja meg az eladni kívánt ${coin} összeget";
+  static m103(coin) => "Kérjük, adja meg az eladni kívánt ${coin} összeget";
 
-  static m101(coin) => "Nem sikerült aktiválni ${coin}";
+  static m104(coin) => "Nem sikerült aktiválni ${coin}";
 
-  static m102(description) =>
+  static m105(description) =>
       "Válasszon egy mp3 vagy wav fájlt, kérem. Akkor fogjuk lejátszani, amikor ${description}.";
 
-  static m103(description) => "Lejátsszuk, amikor ${description}";
+  static m106(description) => "Lejátsszuk, amikor ${description}";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "Ha bármilyen kérdésed van, vagy úgy gondolod, hogy technikai problémát találtál az ${appName} alkalmazással kapcsolatban, akkor jelentheted, és támogatást kaphatsz csapatunktól.";
 
-  static m105(coin) =>
+  static m108(coin) =>
       "Kérjük, először aktiválja ${coin} és töltse fel egyenlegét";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "Az ${coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "${coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez. ${coin} ${amount} szükséges.";
 
-  static m108(name) => "Mely ${name} tranzakciókat szeretné szinkronizálni?";
+  static m111(name) => "Mely ${name} tranzakciókat szeretné szinkronizálni?";
 
-  static m109(left) => "Tranzakciók Balra: ${left}";
+  static m112(left) => "Tranzakciók Balra: ${left}";
 
-  static m110(amnt, hash) =>
+  static m113(amnt, hash) =>
       "Sikeresen feloldotta a ${amnt} pénzeszközöket - TX: ${hash}";
 
-  static m111(version) => "Ön a ${version} verziót használja.";
+  static m114(version) => "Ön a ${version} verziót használja.";
 
-  static m112(version) => "A ${version} verzió elérhető. Kérjük, frissítse.";
+  static m115(version) => "A ${version} verzió elérhető. Kérjük, frissítse.";
 
-  static m113(appName) => "${appName} frissítés";
+  static m116(appName) => "${appName} frissítés";
 
-  static m114(coinAbbr) => "Nem sikerült aktiválni a ${coinAbbr}";
+  static m117(coinAbbr) => "Nem sikerült aktiválni a ${coinAbbr}";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "Nem sikerült aktiválni a ${coinAbbr}.\nKérjük, indítsa újra az alkalmazást, hogy újra megpróbálhassa.";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} mobil egy következő generációs többérmés pénztárca natív harmadik generációs DEX funkcióval és még sokkal több";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "Ön korábban megtagadta a ${appName} hozzáférést a kamerához.\n Kérjük, a QR-kód beolvasásának folytatásához manuálisan módosítsa a kameraengedélyt a telefon beállításaiban.";
 
-  static m118(amount, coinName) => "KIFIZETÉS ${amount} ${coinName}";
+  static m121(amount, coinName) => "KIFIZETÉS ${amount} ${coinName}";
 
-  static m119(amount, coin) => "Kapni fog ${amount} ${coin}";
+  static m122(amount, coin) => "Kapni fog ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -341,6 +348,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled": MessageLookupByLibrary.simpleMessage(
+            "Az érme aktiválása megszakítva"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("Aktív érme"),
         "addingCoinSuccess": m4,
@@ -483,6 +492,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Kód:"),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Biztosan megszakítja az aktiválást?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Tiszta"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Nincsenek aktív érmék"),
@@ -490,9 +501,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Érme kiválasztása"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "Kiválasztotta az eszközök maximális számát"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("Hamarosan..."),
         "commingsoon": MessageLookupByLibrary.simpleMessage(
             "Tranzakció részletek hamarosan!"),
@@ -523,7 +534,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactDelete":
             MessageLookupByLibrary.simpleMessage("Kapcsolat törlése"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("törlése"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Elutasítás"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Szerkesztés"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Kilépés"),
@@ -555,7 +566,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("Egyedi díj"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "Csak akkor használjon egyéni díjakat, ha tudja, mit csinál!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW biztonság"),
         "date": MessageLookupByLibrary.simpleMessage("Dátum"),
         "decryptingWallet":
@@ -573,8 +584,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Pénztárca törlése"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Pénztárca törlése..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "kereskedési díj tranzakciós díj küldése"),
@@ -600,7 +611,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "duration": MessageLookupByLibrary.simpleMessage("Időtartam"),
         "editContact":
             MessageLookupByLibrary.simpleMessage("Kapcsolat szerkesztése"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "A titkosítási jelszó nem lehet üres"),
         "emptyImportPass":
@@ -609,7 +620,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Kapcsolattartó neve nem lehet üres"),
         "emptyWallet":
             MessageLookupByLibrary.simpleMessage("A tárca neve nem lehet üres"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "Kérjük, engedélyezze az értesítéseket, hogy értesüljön az aktiválás folyamatáról."),
@@ -646,7 +657,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Hiba! Helytelen / nem valós cím!"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "A Segwit címek (még) nem támogatottak"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain":
             MessageLookupByLibrary.simpleMessage("Hiba, kérem próbálja újra"),
         "errorTryLater":
@@ -657,32 +668,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Kérjük adjon meg adatokat"),
         "estimateValue":
             MessageLookupByLibrary.simpleMessage("Becsült Teljes Érték"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -733,19 +744,20 @@ class MessageLookup extends MessageLookupByLibrary {
             "A tételek exportálása sikeresen megtörtént:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Cserék"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Exportálás"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Hamis egyenleg összege:"),
         "faqTitle":
             MessageLookupByLibrary.simpleMessage("Gyakran ismételt kérdések"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Hiba"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("FAUCET"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Siker"),
         "faucetTimedOut":
             MessageLookupByLibrary.simpleMessage("A kérés lejárt"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("Hírek"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("Itt nincs semmi"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("Bővebben..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("Feed"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("Hírek"),
@@ -758,7 +770,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Hírfolyam frissítve"),
         "feedback":
             MessageLookupByLibrary.simpleMessage("Visszajelzés küldése"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("Minden"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Szűrő"),
         "filtersClearAll":
@@ -782,9 +794,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("Honnan"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "A jövőbeni tranzakciókat szinkronizálni fogjuk a nyilvános kulcsához társított aktiválás után. Ez a leggyorsabb lehetőség, és a legkevesebb tárhelyet foglalja el."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Benzin limit"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("Gáz ára"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "Az általános PIN-védelem nem aktív.\n Az álcázási mód nem lesz elérhető.\n Kérjük, aktiválja a PIN-védelmet."),
@@ -794,7 +806,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "A tranzakció lebonyolítása, kérjük, várjon"),
         "goToPorfolio":
             MessageLookupByLibrary.simpleMessage("Ugrás a portfólióhoz"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Segítség"),
         "helpTitle":
             MessageLookupByLibrary.simpleMessage("Segítség és támogatás"),
@@ -848,7 +860,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
             "Hiba a json fájl dekódolásában"),
         "importTitle": MessageLookupByLibrary.simpleMessage("Importálás"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Ha nem ad meg jelszót, akkor minden alkalommal be kell írnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához."),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -857,7 +869,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ez a tranzakció akár 10 percet is igénybe vehet - NE zárja be ezt az alkalmazást!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "Dönthet úgy is, hogy jelszóval titkosítja a pénztárcáját. Ha úgy dönt, hogy nem használ jelszót, akkor minden alkalommal meg kell adnia a SEED-jét, amikor hozzáférni szeretne a pénztárcájához."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "A megbízáshoz szükséges minimális mennyiség"),
         "insufficientTitle":
@@ -866,12 +878,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Frissítés"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Internet kapcsolat helyreállt"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap": MessageLookupByLibrary.simpleMessage(
             "Nem lehet folytatni a swapot"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Részletek"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japán"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Koreai"),
         "language": MessageLookupByLibrary.simpleMessage("Nyelv"),
@@ -879,8 +891,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Legutóbbi tranzakciók"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Jogi"),
         "less": MessageLookupByLibrary.simpleMessage("Kevesebb"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Betöltés..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
             "Rendelési könyv betöltése..."),
@@ -955,11 +967,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder": MessageLookupByLibrary.simpleMessage(
             "Minimális rendelési mennyiség:"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Alacsonyabbnak kell lennie, mint az eladási összeg"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -969,10 +981,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Figyelmeztetés: Az alkalmazás iOS rendszeren való minimalizálása leállítja az aktiválási folyamatot."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Több információ"),
         "moreTab": MessageLookupByLibrary.simpleMessage("További"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Összeg"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Érme"),
@@ -980,7 +992,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Megerősítés"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Létrehozása"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Megrendelés"),
         "multiCreateOrders":
@@ -996,8 +1008,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Érvénytelen összeg"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Érvénytelen eladási összeg"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Max eladási összeg"),
         "multiMinReceiveAmt":
@@ -1031,7 +1043,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Nincs kiválasztott tétel"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Nem találtak megfelelő rendelést"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Kattintson a megrendelés létrehozásához"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1046,7 +1058,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput": MessageLookupByLibrary.simpleMessage(
             "Az értéknek numerikusnak kell lennie"),
         "none": MessageLookupByLibrary.simpleMessage("Egyik sem"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Nincs elég egyenlege a jutalékhoz - kereskedjen kisebb mennyiséggel"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1056,24 +1068,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Megjegyzés"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Semmi sem található"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("A csere befejeződött"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("A swap sikertelen"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Új swap indult"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Swap státusz megváltozott"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Swap lejárt"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Bejövő tranzakció"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Hivatalos sajtóközlemény"),
         "okButton": MessageLookupByLibrary.simpleMessage("Oké"),
@@ -1084,15 +1096,15 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Hibaüzenet megnyitása"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Kevésbé"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Több"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Megrendelés létrehozva"),
         "orderCreatedInfo": MessageLookupByLibrary.simpleMessage(
             "Megrendelés sikeresen létrehozva"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Cím:"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("a esetében"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Azonos a CEX-szel"),
@@ -1107,7 +1119,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "orderDetailsSpend":
             MessageLookupByLibrary.simpleMessage("Töltse el a"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Részletek"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched":
             MessageLookupByLibrary.simpleMessage("Rendelés megegyezett"),
         "orderMatching":
@@ -1118,9 +1130,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("rendelések"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Aktív"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Történelem"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Felülírás"),
         "ownOrder":
             MessageLookupByLibrary.simpleMessage("Ez a saját megrendelésed!"),
@@ -1146,8 +1158,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("Cancel"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Kért fizetés"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Rendelés leadása"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Kérjük, fogadjon el minden különleges érmeaktiválási kérést, vagy törölje az érmék kijelölését."),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
             "Kérjük, adjon hozzá egy érmét"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1171,19 +1186,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR Code Scanner"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Tárolja a privát kulcsaimat?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Mennyi ideig tart egy-egy atomi swap?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "A csere időtartama alatt online kell lennem?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Biztosítanak felhasználói támogatást?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Vannak országos korlátozások?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Ez egy új korszak! Hivatalosan megváltoztattuk a nevünket „AtomicDEX”-ről „Komodo Wallet”-ra"),
         "receive": MessageLookupByLibrary.simpleMessage("FOGAD"),
@@ -1223,7 +1238,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "További információ a KMD aktív felhasználó jutalmakról"),
         "rewardsReceive":
             MessageLookupByLibrary.simpleMessage("Kapja meg a címet."),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Utalás"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Jutalmak,\nKMD"),
@@ -1233,9 +1248,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Jutalom információ:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Jutalom információk"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Orosz"),
@@ -1288,7 +1303,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Keresse meg a Tickert"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Biztonság"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage(
             "Tranzakciós előzmények megtekintése"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("SEED kifejezés"),
@@ -1331,15 +1346,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Nyelvek"),
         "settings": MessageLookupByLibrary.simpleMessage("Beállítások"),
         "share": MessageLookupByLibrary.simpleMessage("Megosztás"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress":
             MessageLookupByLibrary.simpleMessage("Cím megjelenítése"),
         "showDetails":
             MessageLookupByLibrary.simpleMessage("Részletek megjelenítése"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("Mutasd a rendeléseimet"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Jelentkezzen be jelszóval"),
         "signInWithSeedPhrase":
@@ -1347,24 +1362,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Egyszerű"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Aktiválja a címet."),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Vásárlás"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Bezárás"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Fogadja"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Eladni"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Küldje el a"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Kevesebb mutatása"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Többet mutasd meg"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Kihagyás"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Dissississ"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Hang"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Hangbeállítások"),
@@ -1382,16 +1397,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Lépés"),
         "success": MessageLookupByLibrary.simpleMessage("Siker!"),
         "support": MessageLookupByLibrary.simpleMessage("Támogatás"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("csere"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Aktuális"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage(
             "Erősitse meg a csere részleteit"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Becslés"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Csere sikertelen"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing":
             MessageLookupByLibrary.simpleMessage("Csere folyamatban"),
         "swapProgress":
@@ -1407,7 +1422,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Szinkronizálás a csemete aktiválásából"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
             "Új tranzakciók szinkronizálása"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1470,25 +1485,25 @@ class MessageLookup extends MessageLookupByLibrary {
             "Túl sok a kérés.\n Tranzakciótörténeti kérések száma túllépte a limitet.\n Kérjük, próbálja meg később újra."),
         "txNotConfirmed":
             MessageLookupByLibrary.simpleMessage("NEM MEGERŐSÍTETT"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrán"),
         "unlock": MessageLookupByLibrary.simpleMessage("kinyit"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Alapok feloldása"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("elkölthetetlen"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Új verzió elérhető"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Frissítések keresése..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Új verzió elérhető. Kérjük, frissítse."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Frissítés elérhető"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Egyelőre kihagyás"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Már naprakész"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Frissítés"),
@@ -1514,9 +1529,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Figyelmeztetés - különleges esetekben ez a naplóadat érzékeny információkat tartalmaz, amelyek felhasználhatók a sikertelen cserékből származó érmék elköltésére!"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("KÉSZÍTSÜK FEL!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("Üdvözöljük"),
@@ -1526,14 +1541,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Ez eltart egy ideig, és az alkalmazást az előtérben kell tartani.\nAz alkalmazás aktiválás közbeni leállítása problémákhoz vezethet."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Kifizetés"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Hozzáférés megtagadva"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Kiutalás megerősítése"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Valami rosszul sült el. Próbálja meg később újra."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Ön megpróbál beolvasni egy fizetési QR-kódot a következőhöz"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("de a"),
@@ -1552,7 +1567,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "van egy megbízása, amellyel az új megbízások összeilleszthetők."),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Ön küld:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("Fog kapni:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("a pénztárcája")
       };

--- a/lib/l10n/messages_hu.dart
+++ b/lib/l10n/messages_hu.dart
@@ -160,152 +160,158 @@ class MessageLookup extends MessageLookupByLibrary {
   static m53(abbr) =>
       "${abbr} az egyenleg nem elegendő a kereskedési díj kifizetéséhez";
 
-  static m54(coinAbbr) => "${coinAbbr} nem elérhető :(";
+  static m54(coin) => "Érvénytelen ${coin} cím";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} nem elérhető :(";
+
+  static m56(coinName) =>
       "❗Vigyázat! A(z) ${coinName} piacán kevesebb, mint 10 000 USD 24 órás kereskedési volumen van!";
 
-  static m56(value) => "A korlát legfeljebb ${value} lehet";
-
-  static m57(coinName, number) =>
-      "A minimális eladási összeg ${number} ${coinName}";
+  static m57(value) => "A korlát legfeljebb ${value} lehet";
 
   static m58(coinName, number) =>
+      "A minimális eladási összeg ${number} ${coinName}";
+
+  static m59(coinName, number) =>
       "A minimális vásárlási összeg: ${number}${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "A megbízás minimális összege ${buyAmount} ${buyCoin} (${sellAmount} ${sellCoin})";
 
-  static m60(coinName, number) =>
+  static m61(coinName, number) =>
       "Az eladandó minimális összeg ${number} ${coinName}";
 
-  static m61(minValue, coin) =>
+  static m62(minValue, coin) =>
       "Nagyobbnak kell lennie, mint ${minValue} ${coin}";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "Kérjük, vegye figyelembe, hogy most mobiladatokat használ, és az ${appName} P2P-hálózatban való részvétel internetforgalmat fogyaszt. Jobb, ha WiFi hálózatot használsz, ha a mobiladat-előfizetésed drága.";
 
-  static m63(coin) => "Aktiválja a ${coin} és töltse fel először az egyenlegét";
+  static m64(coin) => "Aktiválja a ${coin} és töltse fel először az egyenlegét";
 
-  static m64(number) => "Create ${number} Order(s):";
+  static m65(number) => "Create ${number} Order(s):";
 
-  static m65(coin) => "${coin} egyenleg túl alacsony";
+  static m66(coin) => "${coin} egyenleg túl alacsony";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "Nincs elég ${coin} a díjak kifizetéséhez. MIN egyenleg ${fee} ${coin}";
 
-  static m67(coinName) =>
+  static m68(coinName) =>
       "Nem érhető el ${coinName} rendelés - próbálja újra később, vagy készítsen egy rendelést.";
 
-  static m68(coin) => "Nincs elég ${coin} a tranzakcióhoz!";
+  static m69(coin) => "Nincs elég ${coin} a tranzakcióhoz!";
 
-  static m69(sell, buy) => "Az ${sell}/${buy} swap sikeresen befejeződött.";
+  static m70(sell, buy) => "Az ${sell}/${buy} swap sikeresen befejeződött.";
 
-  static m70(sell, buy) => "${sell}/${buy} csere sikertelen volt";
+  static m71(sell, buy) => "${sell}/${buy} csere sikertelen volt";
 
-  static m71(sell, buy) => "${sell}/${buy} swap elindult";
+  static m72(sell, buy) => "${sell}/${buy} swap elindult";
 
-  static m72(sell, buy) => "${sell}/${buy} swap időzítve volt";
+  static m73(sell, buy) => "${sell}/${buy} swap időzítve volt";
 
-  static m73(coin) => "Ön ${coin} tranzakciót kapott!";
+  static m74(coin) => "Ön ${coin} tranzakciót kapott!";
 
-  static m74(assets) => "${assets} Aktív";
+  static m75(assets) => "${assets} Aktív";
 
-  static m75(coin) => "Minden ${coin} megrendelés törlésre kerül.";
+  static m76(coin) => "Minden ${coin} megrendelés törlésre kerül.";
 
-  static m76(delta) => "Célszerű: CEX +${delta}%";
+  static m77(delta) => "Célszerű: CEX +${delta}%";
 
-  static m77(delta) => "Drága: CEX ${delta}%";
+  static m78(delta) => "Drága: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% betelt";
+  static m79(fill) => "${fill}% betelt";
 
-  static m79(coin) => "Mennyiség. (${coin})";
+  static m80(coin) => "Mennyiség. (${coin})";
 
-  static m80(coin) => "Ár (${coin})";
+  static m81(coin) => "Ár (${coin})";
 
-  static m81(coin) => "Összesen (${coin})";
+  static m82(coin) => "Összesen (${coin})";
 
-  static m82(abbr) => "${abbr} nem aktív. Kérjük, aktiválja és próbálja újra.";
+  static m83(abbr) => "${abbr} nem aktív. Kérjük, aktiválja és próbálja újra.";
 
-  static m83(appName) => "Mely eszközökön használhatom az ${appName}-t?";
+  static m84(appName) => "Mely eszközökön használhatom az ${appName}-t?";
 
-  static m84(appName) =>
+  static m85(appName) =>
       "Miben különbözik a kereskedés az ${appName}-en a más DEX-eken folytatott kereskedéstől?";
 
-  static m85(appName) => "Hogyan számítják ki a díjakat az ${appName}-nél?";
+  static m86(appName) => "Hogyan számítják ki a díjakat az ${appName}-nél?";
 
-  static m86(appName) => "Ki áll az ${appName} mögött?";
+  static m87(appName) => "Ki áll az ${appName} mögött?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "Lehetséges saját white-label csereprogramot kialakítani az ${appName} oldalon?";
 
-  static m88(amount) => "Siker! ${amount} KMD kapott.";
+  static m89(amount) => "Siker! ${amount} KMD kapott.";
 
-  static m89(dd) => "${dd} napok";
+  static m90(dd) => "${dd} napok";
 
-  static m90(hh, minutes) => "${hh}h ${minutes}m";
+  static m91(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m91(mm) => "${mm}min";
+  static m92(mm) => "${mm}min";
 
-  static m92(amount) => "Kattintson a megtekintéshez ${amount} rendelések";
+  static m93(amount) => "Kattintson a megtekintéshez ${amount} rendelések";
 
-  static m93(coinName, address) => "Az én ${coinName} címem:\n${address}";
+  static m94(coinName, address) => "Az én ${coinName} címem:\n${address}";
 
-  static m94(count, maxCount) => "${count}/${maxCount} rendelés megjelenítése.";
+  static m95(coin) => "Keresi a múltbeli ${coin} tranzakciókat?";
 
-  static m95(coin) => "Kérjük, adja meg a ${coin} összeget a vásárláshoz";
+  static m96(count, maxCount) => "${count}/${maxCount} rendelés megjelenítése.";
 
-  static m96(maxCoins) =>
+  static m97(coin) => "Kérjük, adja meg a ${coin} összeget a vásárláshoz";
+
+  static m98(maxCoins) =>
       "A maximális aktív érmék száma ${maxCoins}. Kérjük, néhányat deaktiváljon.";
 
-  static m97(coin) => "${coin} nem aktív!";
+  static m99(coin) => "${coin} nem aktív!";
 
-  static m98(coin) => "Kérjük, adja meg az eladni kívánt ${coin} összeget";
+  static m100(coin) => "Kérjük, adja meg az eladni kívánt ${coin} összeget";
 
-  static m99(coin) => "Nem sikerült aktiválni ${coin}";
+  static m101(coin) => "Nem sikerült aktiválni ${coin}";
 
-  static m100(description) =>
+  static m102(description) =>
       "Válasszon egy mp3 vagy wav fájlt, kérem. Akkor fogjuk lejátszani, amikor ${description}.";
 
-  static m101(description) => "Lejátsszuk, amikor ${description}";
+  static m103(description) => "Lejátsszuk, amikor ${description}";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "Ha bármilyen kérdésed van, vagy úgy gondolod, hogy technikai problémát találtál az ${appName} alkalmazással kapcsolatban, akkor jelentheted, és támogatást kaphatsz csapatunktól.";
 
-  static m103(coin) =>
+  static m105(coin) =>
       "Kérjük, először aktiválja ${coin} és töltse fel egyenlegét";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "Az ${coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "${coin} egyenleg nem elegendő a tranzakciós díjak kifizetéséhez. ${coin} ${amount} szükséges.";
 
-  static m106(left) => "Tranzakciók Balra: ${left}";
+  static m108(name) => "Mely ${name} tranzakciókat szeretné szinkronizálni?";
 
-  static m107(amnt, hash) =>
+  static m109(left) => "Tranzakciók Balra: ${left}";
+
+  static m110(amnt, hash) =>
       "Sikeresen feloldotta a ${amnt} pénzeszközöket - TX: ${hash}";
 
-  static m108(version) => "Ön a ${version} verziót használja.";
+  static m111(version) => "Ön a ${version} verziót használja.";
 
-  static m109(version) => "A ${version} verzió elérhető. Kérjük, frissítse.";
+  static m112(version) => "A ${version} verzió elérhető. Kérjük, frissítse.";
 
-  static m110(appName) => "${appName} frissítés";
+  static m113(appName) => "${appName} frissítés";
 
-  static m111(coinAbbr) => "Nem sikerült aktiválni a ${coinAbbr}";
+  static m114(coinAbbr) => "Nem sikerült aktiválni a ${coinAbbr}";
 
-  static m112(coinAbbr) =>
+  static m115(coinAbbr) =>
       "Nem sikerült aktiválni a ${coinAbbr}.\nKérjük, indítsa újra az alkalmazást, hogy újra megpróbálhassa.";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "${appName} mobil egy következő generációs többérmés pénztárca natív harmadik generációs DEX funkcióval és még sokkal több";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "Ön korábban megtagadta a ${appName} hozzáférést a kamerához.\n Kérjük, a QR-kód beolvasásának folytatásához manuálisan módosítsa a kameraengedélyt a telefon beállításaiban.";
 
-  static m115(amount, coinName) => "KIFIZETÉS ${amount} ${coinName}";
+  static m118(amount, coinName) => "KIFIZETÉS ${amount} ${coinName}";
 
-  static m116(amount, coin) => "Kapni fog ${amount} ${coin}";
+  static m119(amount, coin) => "Kapni fog ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -352,6 +358,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("Címzett címe"),
         "advanced": MessageLookupByLibrary.simpleMessage("Haladó"),
         "all": MessageLookupByLibrary.simpleMessage("Minden"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "A pénztárcája minden korábbi tranzakciót mutat. Ez jelentős tárhelyet és időt vesz igénybe, mivel az összes blokkot letölti és átvizsgálja."),
         "allowCustomSeed":
             MessageLookupByLibrary.simpleMessage("Egyedi SEED engedélyezése"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("Már létezik"),
@@ -422,6 +430,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup":
             MessageLookupByLibrary.simpleMessage("Álcázási PIN beállítása"),
         "cancel": MessageLookupByLibrary.simpleMessage("visszamond"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Aktiválás megszakítása"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Biztosan megszakítja az aktiválást?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("Visszavonás"),
         "cancelOrder":
             MessageLookupByLibrary.simpleMessage("Megrendelés visszavonása"),
@@ -469,6 +481,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closePreview":
             MessageLookupByLibrary.simpleMessage("Előnézet bezárása"),
         "code": MessageLookupByLibrary.simpleMessage("Kód:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Biztosan megszakítja az aktiválást?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Tiszta"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Nincsenek aktív érmék"),
@@ -766,6 +780,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("Talált QR kódot"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("Francia"),
         "from": MessageLookupByLibrary.simpleMessage("Honnan"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "A jövőbeni tranzakciókat szinkronizálni fogjuk a nyilvános kulcsához társított aktiválás után. Ez a leggyorsabb lehetőség, és a legkevesebb tárhelyet foglalja el."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Benzin limit"),
         "gasNotActive": m50,
@@ -850,11 +866,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Frissítés"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Internet kapcsolat helyreállt"),
+        "invalidCoinAddress": m54,
         "invalidSwap": MessageLookupByLibrary.simpleMessage(
             "Nem lehet folytatni a swapot"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Részletek"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japán"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Koreai"),
         "language": MessageLookupByLibrary.simpleMessage("Nyelv"),
@@ -862,8 +879,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Legutóbbi tranzakciók"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Jogi"),
         "less": MessageLookupByLibrary.simpleMessage("Kevesebb"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Betöltés..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
             "Rendelési könyv betöltése..."),
@@ -938,11 +955,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder": MessageLookupByLibrary.simpleMessage(
             "Minimális rendelési mennyiség:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Alacsonyabbnak kell lennie, mint az eladási összeg"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -952,10 +969,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Figyelmeztetés: Az alkalmazás iOS rendszeren való minimalizálása leállítja az aktiválási folyamatot."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Több információ"),
         "moreTab": MessageLookupByLibrary.simpleMessage("További"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Összeg"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Érme"),
@@ -963,7 +980,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Megerősítés"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Létrehozása"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Megrendelés"),
         "multiCreateOrders":
@@ -979,8 +996,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Érvénytelen összeg"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Érvénytelen eladási összeg"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Max eladási összeg"),
         "multiMinReceiveAmt":
@@ -1014,7 +1031,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Nincs kiválasztott tétel"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Nem találtak megfelelő rendelést"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Kattintson a megrendelés létrehozásához"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1029,7 +1046,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput": MessageLookupByLibrary.simpleMessage(
             "Az értéknek numerikusnak kell lennie"),
         "none": MessageLookupByLibrary.simpleMessage("Egyik sem"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Nincs elég egyenlege a jutalékhoz - kereskedjen kisebb mennyiséggel"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1039,24 +1056,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Megjegyzés"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Semmi sem található"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("A csere befejeződött"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("A swap sikertelen"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Új swap indult"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Swap státusz megváltozott"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Swap lejárt"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Bejövő tranzakció"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Hivatalos sajtóközlemény"),
         "okButton": MessageLookupByLibrary.simpleMessage("Oké"),
@@ -1067,15 +1084,15 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Hibaüzenet megnyitása"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Kevésbé"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Több"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Megrendelés létrehozva"),
         "orderCreatedInfo": MessageLookupByLibrary.simpleMessage(
             "Megrendelés sikeresen létrehozva"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Cím:"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("a esetében"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Azonos a CEX-szel"),
@@ -1090,7 +1107,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "orderDetailsSpend":
             MessageLookupByLibrary.simpleMessage("Töltse el a"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Részletek"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched":
             MessageLookupByLibrary.simpleMessage("Rendelés megegyezett"),
         "orderMatching":
@@ -1101,9 +1118,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("rendelések"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Aktív"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Történelem"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Felülírás"),
         "ownOrder":
             MessageLookupByLibrary.simpleMessage("Ez a saját megrendelésed!"),
@@ -1114,6 +1131,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Fizetetve"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "A jelszónak legalább 12 karaktert kell tartalmaznia, egy kisbetűt, egy nagybetűt és egy speciális szimbólumot."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "A pénztárcája megmutatja a megadott dátum után végrehajtott korábbi tranzakcióit."),
         "paymentUriDetailsAccept":
             MessageLookupByLibrary.simpleMessage("Fizetés"),
         "paymentUriDetailsAcceptQuestion": MessageLookupByLibrary.simpleMessage(
@@ -1127,7 +1146,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("Cancel"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Kért fizetés"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Rendelés leadása"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage(
             "Kérjük, adjon hozzá egy érmét"),
@@ -1152,19 +1171,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR Code Scanner"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Tárolja a privát kulcsaimat?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Mennyi ideig tart egy-egy atomi swap?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "A csere időtartama alatt online kell lennem?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Biztosítanak felhasználói támogatást?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Vannak országos korlátozások?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Ez egy új korszak! Hivatalosan megváltoztattuk a nevünket „AtomicDEX”-ről „Komodo Wallet”-ra"),
         "receive": MessageLookupByLibrary.simpleMessage("FOGAD"),
@@ -1204,7 +1223,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "További információ a KMD aktív felhasználó jutalmakról"),
         "rewardsReceive":
             MessageLookupByLibrary.simpleMessage("Kapja meg a címet."),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Utalás"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Jutalmak,\nKMD"),
@@ -1214,9 +1233,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Jutalom információ:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Jutalom információk"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Orosz"),
@@ -1269,7 +1288,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Keresse meg a Tickert"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Biztonság"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage(
             "Tranzakciós előzmények megtekintése"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("SEED kifejezés"),
@@ -1283,6 +1302,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Válassza ki az érmét amit VÁSÁROLNI szeretne"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "Válassza ki az érmét amit ELADNI szeretne"),
+        "selectDate":
+            MessageLookupByLibrary.simpleMessage("Válasszon egy dátumot"),
         "selectFileImport":
             MessageLookupByLibrary.simpleMessage("Fájl kiválasztása"),
         "selectLanguage":
@@ -1310,14 +1331,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Nyelvek"),
         "settings": MessageLookupByLibrary.simpleMessage("Beállítások"),
         "share": MessageLookupByLibrary.simpleMessage("Megosztás"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress":
             MessageLookupByLibrary.simpleMessage("Cím megjelenítése"),
         "showDetails":
             MessageLookupByLibrary.simpleMessage("Részletek megjelenítése"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("Mutasd a rendeléseimet"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Jelentkezzen be jelszóval"),
         "signInWithSeedPhrase":
@@ -1325,24 +1347,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Egyszerű"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Aktiválja a címet."),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Vásárlás"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Bezárás"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Fogadja"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Eladni"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Küldje el a"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Kevesebb mutatása"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Többet mutasd meg"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Kihagyás"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Dissississ"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Hang"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Hangbeállítások"),
@@ -1354,21 +1376,22 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Ne feledje, hogy az alkalmazás beállításaiban beállíthatja az egyéni hangokat."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("Spanyol"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Kezdő dátum"),
         "startSwap":
             MessageLookupByLibrary.simpleMessage("Indítsa el a Swapot"),
         "step": MessageLookupByLibrary.simpleMessage("Lépés"),
         "success": MessageLookupByLibrary.simpleMessage("Siker!"),
         "support": MessageLookupByLibrary.simpleMessage("Támogatás"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("csere"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Aktuális"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage(
             "Erősitse meg a csere részleteit"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Becslés"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Csere sikertelen"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing":
             MessageLookupByLibrary.simpleMessage("Csere folyamatban"),
         "swapProgress":
@@ -1378,6 +1401,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Összesen"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("Swap UUID"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Switch téma"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Szinkronizálás a megadott dátumtól"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Szinkronizálás a csemete aktiválásából"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Új tranzakciók szinkronizálása"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1440,25 +1470,25 @@ class MessageLookup extends MessageLookupByLibrary {
             "Túl sok a kérés.\n Tranzakciótörténeti kérések száma túllépte a limitet.\n Kérjük, próbálja meg később újra."),
         "txNotConfirmed":
             MessageLookupByLibrary.simpleMessage("NEM MEGERŐSÍTETT"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrán"),
         "unlock": MessageLookupByLibrary.simpleMessage("kinyit"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Alapok feloldása"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("elkölthetetlen"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Új verzió elérhető"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Frissítések keresése..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Új verzió elérhető. Kérjük, frissítse."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Frissítés elérhető"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Egyelőre kihagyás"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Már naprakész"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Frissítés"),
@@ -1484,9 +1514,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Figyelmeztetés - különleges esetekben ez a naplóadat érzékeny információkat tartalmaz, amelyek felhasználhatók a sikertelen cserékből származó érmék elköltésére!"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("KÉSZÍTSÜK FEL!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("Üdvözöljük"),
@@ -1496,14 +1526,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Ez eltart egy ideig, és az alkalmazást az előtérben kell tartani.\nAz alkalmazás aktiválás közbeni leállítása problémákhoz vezethet."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Kifizetés"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Hozzáférés megtagadva"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Kiutalás megerősítése"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Valami rosszul sült el. Próbálja meg később újra."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Ön megpróbál beolvasni egy fizetési QR-kódot a következőhöz"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("de a"),
@@ -1522,7 +1552,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "van egy megbízása, amellyel az új megbízások összeilleszthetők."),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Ön küld:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("Fog kapni:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("a pénztárcája")
       };

--- a/lib/l10n/messages_ja.dart
+++ b/lib/l10n/messages_ja.dart
@@ -154,139 +154,145 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m53(abbr) => "${abbr} 取引手数料を支払うのに十分な残高がありません";
 
-  static m54(coinAbbr) => "${coinAbbr} は利用できません:(";
+  static m54(coin) => "無効な ${coin} アドレスです";
 
-  static m55(coinName) => "❗注意！ ${coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。";
+  static m55(coinAbbr) => "${coinAbbr} は利用できません:(";
 
-  static m56(value) => "制限は最大 ${value} である必要があります";
+  static m56(coinName) => "❗注意！ ${coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。";
 
-  static m57(coinName, number) => "最低販売額は ${number} ${coinName} です";
+  static m57(value) => "制限は最大 ${value} である必要があります";
 
-  static m58(coinName, number) => "最低購入金額は ${number} ${coinName} です";
+  static m58(coinName, number) => "最低販売額は ${number} ${coinName} です";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m59(coinName, number) => "最低購入金額は ${number} ${coinName} です";
+
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "注文の最小額は ${buyAmount} ${buyCoin} (${sellAmount} ${sellCoin}) です";
 
-  static m60(coinName, number) => "最低販売額は ${number} ${coinName} です";
+  static m61(coinName, number) => "最低販売額は ${number} ${coinName} です";
 
-  static m61(minValue, coin) => "${minValue} ${coin} より大きくなければなりません";
+  static m62(minValue, coin) => "${minValue} ${coin} より大きくなければなりません";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "現在、携帯データ ネットワークを使用しており、${appName} P2P ネットワークに参加すると、インターネット トラフィックが消費されることに注意してください。携帯電話のデータ プランが高額な場合は、WiFi ネットワークを使用することをお勧めします。";
 
-  static m63(coin) => "最初に ${coin} を有効にして、残高をチャージしてください";
+  static m64(coin) => "最初に ${coin} を有効にして、残高をチャージしてください";
 
-  static m64(number) => "${number} オーダーを作成:";
+  static m65(number) => "${number} オーダーを作成:";
 
-  static m65(coin) => "${coin} の残高が少なすぎます";
+  static m66(coin) => "${coin} の残高が少なすぎます";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "料金を支払うのに十分な ${coin} がありません。 MIN 残高は ${fee} ${coin} です";
 
-  static m67(coinName) => "${coinName} の金額を入力してください。";
+  static m68(coinName) => "${coinName} の金額を入力してください。";
 
-  static m68(coin) => "取引に十分な ${coin} がありません!";
+  static m69(coin) => "取引に十分な ${coin} がありません!";
 
-  static m69(sell, buy) => "${sell}/${buy} スワップが正常に完了しました";
+  static m70(sell, buy) => "${sell}/${buy} スワップが正常に完了しました";
 
-  static m70(sell, buy) => "${sell}/${buy} スワップに失敗しました";
+  static m71(sell, buy) => "${sell}/${buy} スワップに失敗しました";
 
-  static m71(sell, buy) => "${sell}/${buy} スワップ開始";
+  static m72(sell, buy) => "${sell}/${buy} スワップ開始";
 
-  static m72(sell, buy) => "${sell}/${buy} スワップがタイムアウトしました";
+  static m73(sell, buy) => "${sell}/${buy} スワップがタイムアウトしました";
 
-  static m73(coin) => "${coin} のトランザクションを受け取りました!";
+  static m74(coin) => "${coin} のトランザクションを受け取りました!";
 
-  static m74(assets) => "${assets} アセット";
+  static m75(assets) => "${assets} アセット";
 
-  static m75(coin) => "${coin} の注文はすべてキャンセルされます。";
+  static m76(coin) => "${coin} の注文はすべてキャンセルされます。";
 
-  static m76(delta) => "便宜: CEX +${delta}%";
+  static m77(delta) => "便宜: CEX +${delta}%";
 
-  static m77(delta) => "高価: CEX ${delta}%";
+  static m78(delta) => "高価: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% 埋められました";
+  static m79(fill) => "${fill}% 埋められました";
 
-  static m79(coin) => "金額 (${coin})";
+  static m80(coin) => "金額 (${coin})";
 
-  static m80(coin) => "価格 (${coin})";
+  static m81(coin) => "価格 (${coin})";
 
-  static m81(coin) => "合計 (${coin})";
+  static m82(coin) => "合計 (${coin})";
 
-  static m82(abbr) => "${abbr} はアクティブではありません。有効にしてからもう一度お試しください。";
+  static m83(abbr) => "${abbr} はアクティブではありません。有効にしてからもう一度お試しください。";
 
-  static m83(appName) => "${appName} を使用できるデバイスはどれですか?";
+  static m84(appName) => "${appName} を使用できるデバイスはどれですか?";
 
-  static m84(appName) => "${appName} での取引は、他の DEX での取引とどう違うのですか?";
+  static m85(appName) => "${appName} での取引は、他の DEX での取引とどう違うのですか?";
 
-  static m85(appName) => "${appName} の料金はどのように計算されますか?";
+  static m86(appName) => "${appName} の料金はどのように計算されますか?";
 
-  static m86(appName) => "${appName} の背後にいるのは誰ですか?";
+  static m87(appName) => "${appName} の背後にいるのは誰ですか?";
 
-  static m87(appName) => "${appName} で独自のホワイトラベル取引所を開発することは可能ですか?";
+  static m88(appName) => "${appName} で独自のホワイトラベル取引所を開発することは可能ですか?";
 
-  static m88(amount) => "成功！ ${amount} KMD を受け取りました。";
+  static m89(amount) => "成功！ ${amount} KMD を受け取りました。";
 
-  static m89(dd) => "${dd} 日";
+  static m90(dd) => "${dd} 日";
 
-  static m90(hh, minutes) => "${hh}時 ${minutes}分";
+  static m91(hh, minutes) => "${hh}時 ${minutes}分";
 
-  static m91(mm) => "${mm}分";
+  static m92(mm) => "${mm}分";
 
-  static m92(amount) => "クリックして ${amount} 件の注文を表示";
+  static m93(amount) => "クリックして ${amount} 件の注文を表示";
 
-  static m93(coinName, address) => "私の ${coinName} アドレス: \n${address}";
+  static m94(coinName, address) => "私の ${coinName} アドレス: \n${address}";
 
-  static m94(count, maxCount) => "${maxCount} 件中 ${count} 件の注文を表示しています。";
+  static m95(coin) => "過去の ${coin} 取引をスキャンしますか?";
 
-  static m95(coin) => "購入する${coin}の金額を入力してください";
+  static m96(count, maxCount) => "${maxCount} 件中 ${count} 件の注文を表示しています。";
 
-  static m96(maxCoins) => "アクティブなコインの最大数は ${maxCoins} です。いくつか無効にしてください。";
+  static m97(coin) => "購入する${coin}の金額を入力してください";
 
-  static m97(coin) => "${coin} はアクティブではありません!";
+  static m98(maxCoins) => "アクティブなコインの最大数は ${maxCoins} です。いくつか無効にしてください。";
 
-  static m98(coin) => "売却する${coin}の金額を入力してください";
+  static m99(coin) => "${coin} はアクティブではありません!";
 
-  static m99(coin) => "${coin} をアクティベートできません";
+  static m100(coin) => "売却する${coin}の金額を入力してください";
 
-  static m100(description) =>
+  static m101(coin) => "${coin} をアクティベートできません";
+
+  static m102(description) =>
       "mp3またはwavファイルを選択してください。 ${description} になったら再生します。";
 
-  static m101(description) => "${description} の場合にプレイ";
+  static m103(description) => "${description} の場合にプレイ";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "ご不明な点がある場合、または ${appName} アプリで技術的な問題を発見したと思われる場合は、報告してチームからサポートを受けることができます。";
 
-  static m103(coin) => "最初に ${coin} を有効にして残高をチャージしてください";
+  static m105(coin) => "最初に ${coin} を有効にして残高をチャージしてください";
 
-  static m104(coin) => "${coin} の残高は、取引手数料を支払うのに十分ではありません。";
+  static m106(coin) => "${coin} の残高は、取引手数料を支払うのに十分ではありません。";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "${coin} の残高は、取引手数料を支払うのに十分ではありません。${coin} ${amount} が必要です。";
 
-  static m106(left) => "残りのトランザクション: ${left}";
+  static m108(name) => "どの ${name} トランザクションを同期しますか?";
 
-  static m107(amnt, hash) => "${amnt} 資金のロックを解除しました - TX: ${hash}";
+  static m109(left) => "残りのトランザクション: ${left}";
 
-  static m108(version) => "バージョン ${version} を使用しています";
+  static m110(amnt, hash) => "${amnt} 資金のロックを解除しました - TX: ${hash}";
 
-  static m109(version) => "バージョン ${version} が利用可能です。更新してください。";
+  static m111(version) => "バージョン ${version} を使用しています";
 
-  static m110(appName) => "${appName} の更新";
+  static m112(version) => "バージョン ${version} が利用可能です。更新してください。";
 
-  static m111(coinAbbr) => "${coinAbbr} をアクティベートできませんでした";
+  static m113(appName) => "${appName} の更新";
 
-  static m112(coinAbbr) => "${coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。";
+  static m114(coinAbbr) => "${coinAbbr} をアクティベートできませんでした";
 
-  static m113(appName) =>
+  static m115(coinAbbr) => "${coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。";
+
+  static m116(appName) =>
       "${appName} モバイルは、ネイティブの第 3 世代 DEX 機能などを備えた次世代のマルチコイン ウォレットです。";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "以前にカメラへの ${appName} アクセスを拒否しました。 QR コードのスキャンを続行するには、電話の設定でカメラの許可を手動で変更してください。";
 
-  static m115(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
+  static m118(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
 
-  static m116(amount, coin) => "${amount} ${coin} を受け取ります";
+  static m119(amount, coin) => "${amount} ${coin} を受け取ります";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -326,6 +332,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("受取人住所"),
         "advanced": MessageLookupByLibrary.simpleMessage("高度"),
         "all": MessageLookupByLibrary.simpleMessage("全て"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "ウォレットには過去の取引が表示されます。すべてのブロックがダウンロードされてスキャンされるため、これにはかなりのストレージと時間がかかります。"),
         "allowCustomSeed":
             MessageLookupByLibrary.simpleMessage("カスタム シードを許可する"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("もう存在している"),
@@ -392,6 +400,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup":
             MessageLookupByLibrary.simpleMessage("カモフラージュ PIN の設定"),
         "cancel": MessageLookupByLibrary.simpleMessage("キャンセル"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("アクティベーションのキャンセル"),
+        "cancelActivationQuestion":
+            MessageLookupByLibrary.simpleMessage("アクティベーションをキャンセルしてもよろしいですか?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("キャンセル"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("注文をキャンセルする"),
         "candleChartError": MessageLookupByLibrary.simpleMessage(
@@ -431,6 +443,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closeMessage": MessageLookupByLibrary.simpleMessage("エラーメッセージを閉じる"),
         "closePreview": MessageLookupByLibrary.simpleMessage("プレビューを閉じる"),
         "code": MessageLookupByLibrary.simpleMessage("コード："),
+        "cofirmCancelActivation":
+            MessageLookupByLibrary.simpleMessage("アクティベーションをキャンセルしてもよろしいですか?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("クリア"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("アクティブなコインはありません"),
@@ -688,6 +702,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("QRコードが見つかりました"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("フランス語"),
         "from": MessageLookupByLibrary.simpleMessage("から"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "公開キーに関連付けられたアクティベーション後に行われる今後のトランザクションは同期されます。これは最も迅速なオプションであり、必要なストレージの量も最小限です。"),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("ガスリミット"),
         "gasNotActive": m50,
@@ -763,17 +779,18 @@ class MessageLookup extends MessageLookupByLibrary {
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("リフレッシュ"),
         "internetRestored":
             MessageLookupByLibrary.simpleMessage("インターネット接続が回復しました"),
+        "invalidCoinAddress": m54,
         "invalidSwap": MessageLookupByLibrary.simpleMessage("スワップを続行できません"),
         "invalidSwapDetailsLink": MessageLookupByLibrary.simpleMessage("詳細"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("日本"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("韓国語"),
         "language": MessageLookupByLibrary.simpleMessage("言語"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("最新の取引"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("法的"),
         "less": MessageLookupByLibrary.simpleMessage("以下"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("読み込んでいます..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("オーダーブックを読み込んでいます..."),
@@ -833,11 +850,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("MS"),
         "min": MessageLookupByLibrary.simpleMessage("最小"),
         "minOrder": MessageLookupByLibrary.simpleMessage("最小注文量:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH":
             MessageLookupByLibrary.simpleMessage("販売額より低くなければなりません"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage("必要な最小ボリューム"),
@@ -846,16 +863,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "警告: iOS でアプリを最小化すると、アクティベーション プロセスが終了します。"),
         "minutes": MessageLookupByLibrary.simpleMessage("メートル"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("より詳しい情報"),
         "moreTab": MessageLookupByLibrary.simpleMessage("もっと"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("額"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("コイン"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("売る"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("キャンセル"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("確認"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("作成"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("注文"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("注文"),
@@ -869,8 +886,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiInvalidAmt": MessageLookupByLibrary.simpleMessage("金額が無効です"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("販売金額が無効です"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage("最大販売額は"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage("最小受け取り金額は"),
         "multiMinSellAmt": MessageLookupByLibrary.simpleMessage("最小販売額は"),
@@ -897,7 +914,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noItemsToImport": MessageLookupByLibrary.simpleMessage("項目が選択されていません"),
         "noMatchingOrders":
             MessageLookupByLibrary.simpleMessage("一致する注文が見つかりません"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage("クリックして注文を作成"),
         "noOrders":
             MessageLookupByLibrary.simpleMessage("注文はありません。取引に行ってください。"),
@@ -910,7 +927,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("値は数値でなければなりません"),
         "none": MessageLookupByLibrary.simpleMessage("なし"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "手数料に十分な残高がありません - 少額で取引してください"),
         "noteOnOrder":
@@ -918,23 +935,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("メモを追加"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("ノート"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("何も見つかりません"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("スワップ完了"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("スワップに失敗しました"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("新しいスワップが開始されました"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("スワップ ステータスが変更されました"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("スワップ タイムアウト"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("着信トランザクション"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("公式プレスリリース"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -944,14 +961,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("エラーメッセージを開く"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("少ない"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("もっと"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated": MessageLookupByLibrary.simpleMessage("オーダーが作成されました"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("注文が正常に作成されました"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("住所"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("キャンセル"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("為に"),
         "orderDetailsIdentical": MessageLookupByLibrary.simpleMessage("CEXと同じ"),
         "orderDetailsMin": MessageLookupByLibrary.simpleMessage("分。"),
@@ -963,7 +980,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "シングルタップで詳細を開き、ロングタップで注文を選択します"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("費やす"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("詳細"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("一致した注文"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("オーダーマッチング"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("注文"),
@@ -971,9 +988,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("注文"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("アクティブ"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("歴史"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("上書き"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("これはあなた自身の注文です！"),
         "paidFromBalance": MessageLookupByLibrary.simpleMessage("残高から支払われる:"),
@@ -982,6 +999,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("で支払った"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "パスワードには、小文字 1 つ、大文字 1 つ、特殊記号 1 つを含む 12 文字以上を含める必要があります。"),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "ウォレットには、指定した日付以降に行われた過去の取引が表示されます。"),
         "paymentUriDetailsAccept": MessageLookupByLibrary.simpleMessage("支払い"),
         "paymentUriDetailsAcceptQuestion":
             MessageLookupByLibrary.simpleMessage("この取引を受け入れますか？"),
@@ -994,7 +1013,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("キャンセル"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("支払いが要求されました"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("ご注文"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage("コインを追加してください"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1015,18 +1034,18 @@ class MessageLookup extends MessageLookupByLibrary {
         "pubkey": MessageLookupByLibrary.simpleMessage("公開鍵"),
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("QRコードスキャナー"),
         "question_1": MessageLookupByLibrary.simpleMessage("私の秘密鍵を保管しますか?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "各アトミック スワップにはどのくらいの時間がかかりますか?"),
         "question_4":
             MessageLookupByLibrary.simpleMessage("スワップ中はオンラインである必要がありますか?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6":
             MessageLookupByLibrary.simpleMessage("ユーザーサポートは提供していますか？"),
         "question_7": MessageLookupByLibrary.simpleMessage("国の制限はありますか？"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "新しい時代です！ 「AtomicDEX」から「Komodo Wallet」に正式に名前を変更しました"),
         "receive": MessageLookupByLibrary.simpleMessage("受け取る"),
@@ -1060,16 +1079,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore":
             MessageLookupByLibrary.simpleMessage("KMDアクティブユーザー特典について詳しく見る"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("受け取る"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("フィアット"),
         "rewardsTableRewards": MessageLookupByLibrary.simpleMessage("リワード、KMD"),
         "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("状態"),
         "rewardsTableTime": MessageLookupByLibrary.simpleMessage("残り時間"),
         "rewardsTableTitle": MessageLookupByLibrary.simpleMessage("特典情報:"),
         "rewardsTableUXTO": MessageLookupByLibrary.simpleMessage("UTXO金額、KMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("特典情報"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("ロシア"),
         "saveMerged": MessageLookupByLibrary.simpleMessage("結合して保存"),
@@ -1119,7 +1138,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("ティッカーを検索"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("安全"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage("取引履歴を見る"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("シードフレーズ"),
         "seedPhraseTitle":
@@ -1130,6 +1149,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectCoinTitle": MessageLookupByLibrary.simpleMessage("コインを有効にする:"),
         "selectCoinToBuy": MessageLookupByLibrary.simpleMessage("購入したいコインを選択"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage("売りたいコインを選択"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("日付を選択してください"),
         "selectFileImport": MessageLookupByLibrary.simpleMessage("ファイルを選ぶ"),
         "selectLanguage": MessageLookupByLibrary.simpleMessage("言語を選択する"),
         "selectPaymentMethod":
@@ -1152,33 +1172,34 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("言語"),
         "settings": MessageLookupByLibrary.simpleMessage("設定"),
         "share": MessageLookupByLibrary.simpleMessage("シェア"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("住所を表示"),
         "showDetails": MessageLookupByLibrary.simpleMessage("詳細を表示"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("私の注文を表示"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("パスワードでサインイン"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "パスワードをお忘れですか？シードからウォレットを復元する"),
         "simple": MessageLookupByLibrary.simpleMessage("単純"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("活性化"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("買う"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("近い"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("受け取る"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("売る"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("送信"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("表示を減らす"),
         "simpleTradeShowMore": MessageLookupByLibrary.simpleMessage("もっと見せる"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("スキップ"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("解散"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("音"),
         "soundSettingsTitle": MessageLookupByLibrary.simpleMessage("サウンド設定"),
         "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("サウンド"),
@@ -1189,19 +1210,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "アプリケーション設定でカスタムサウンドを設定できることに注意してください。"),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("スペイン語"),
+        "startDate": MessageLookupByLibrary.simpleMessage("開始日"),
         "startSwap": MessageLookupByLibrary.simpleMessage("スワップの開始"),
         "step": MessageLookupByLibrary.simpleMessage("ステップ"),
         "success": MessageLookupByLibrary.simpleMessage("成功！"),
         "support": MessageLookupByLibrary.simpleMessage("サポート"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("スワップ"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("現時点の"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage("交換の詳細を確認する"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("見積もり"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("スワップに失敗しました"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("スワップ進行中"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("進捗詳細"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("開始"),
@@ -1209,6 +1231,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("合計"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("UUIDを入れ替える"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("テーマを切り替える"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage("指定した日付から同期"),
+        "syncFromSaplingActivation":
+            MessageLookupByLibrary.simpleMessage("苗木アクティベーションからの同期"),
+        "syncNewTransactions":
+            MessageLookupByLibrary.simpleMessage("新しいトランザクションを同期する"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1263,23 +1291,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "リクエストが多すぎます。トランザクション履歴リクエストの制限を超えました。後でもう一度やり直してください。"),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("未確認"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("ウクライナ語"),
         "unlock": MessageLookupByLibrary.simpleMessage("ロックを解除"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("資金のロックを解除"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("使えない"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("新しいバージョンが利用可能"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage("アップデートの確認..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable":
             MessageLookupByLibrary.simpleMessage("新しいバージョンが利用可能です。更新してください。"),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("利用可能なアップデート"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("今のところスキップ"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage("すでに最新"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("アップデート"),
         "uriInsufficientBalanceSpan1":
@@ -1302,9 +1330,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "警告 - 特殊なケースでは、このログ データには機密情報が含まれており、失敗したスワップからのコインの使用に使用できる可能性があります。"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("セットアップしましょう！"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("ようこそ"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("財布"),
@@ -1313,13 +1341,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "これには時間がかかるため、アプリをフォアグラウンドに維持する必要があります。\nアクティベーションの進行中にアプリを終了すると、問題が発生する可能性があります。"),
         "withdraw": MessageLookupByLibrary.simpleMessage("撤退"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("アクセスが拒否されました"),
         "withdrawConfirm": MessageLookupByLibrary.simpleMessage("出金確認"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "エラーが発生しました。あとでもう一度試してみてください。"),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1":
             MessageLookupByLibrary.simpleMessage("の支払い QR コードをスキャンしようとしています"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("しかし、あなたは上にいます"),
@@ -1335,7 +1363,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "you have an order that new orders can match with":
             MessageLookupByLibrary.simpleMessage("新しい注文と一致する注文があります"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("あなたが送っているもの:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("受け取るもの:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("あなたの財布")
       };

--- a/lib/l10n/messages_ja.dart
+++ b/lib/l10n/messages_ja.dart
@@ -74,225 +74,231 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "シード フレーズの ${index} 単語は何ですか?";
 
-  static m22(protocolName) => "${protocolName} コインが有効化されました";
+  static m22(coin) => "${coin} のアクティベーションがキャンセルされました";
 
-  static m23(protocolName) => "${protocolName} コインが正常に有効化されました";
+  static m23(coin) => "${coin} を正常にアクティブ化しました";
 
-  static m24(protocolName) => "${protocolName} コインは有効化されていません";
+  static m24(protocolName) => "${protocolName} コインが有効化されました";
 
-  static m25(name) => "連絡先 ${name} を削除してもよろしいですか?";
+  static m25(protocolName) => "${protocolName} コインが正常に有効化されました";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "${protocolName} コインは有効化されていません";
+
+  static m27(name) => "連絡先 ${name} を削除してもよろしいですか?";
+
+  static m28(iUnderstand) =>
       "カスタム シード フレーズは、生成された BIP39 準拠のシード フレーズまたは秘密鍵 (WIF) よりも安全性が低く、クラックされやすい可能性があります。リスクを理解し、自分が何をしているかを理解していることを確認するには、下のボックスに「${iUnderstand}」と入力してください。";
 
-  static m27(coinName) => "${coinName} の取引手数料を受け取る";
+  static m29(coinName) => "${coinName} の取引手数料を受け取る";
 
-  static m28(coinName) => "${coinName} の取引手数料を送信します";
+  static m30(coinName) => "${coinName} の取引手数料を送信します";
 
-  static m29(abbr) => "入力 ${abbr} アドレス";
+  static m31(abbr) => "入力 ${abbr} アドレス";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "${remains} を引き続き有効にすることができます。選択済み: ${selected}";
 
-  static m31(gas) => "ガスが不足しています - 少なくとも ${gas} Gwei を使用してください";
+  static m33(gas) => "ガスが不足しています - 少なくとも ${gas} Gwei を使用してください";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "${coin} フォーセットにリクエストを送信しています...";
+  static m48(coinAbbr) => "${coinAbbr} のアクティベーションをキャンセルできませんでした";
 
-  static m47(appCompanyShort) => "${appCompanyShort} ニュース";
+  static m49(coin) => "${coin} フォーセットにリクエストを送信しています...";
 
-  static m48(value) => "料金は ${value} までである必要があります";
+  static m50(appCompanyShort) => "${appCompanyShort} ニュース";
 
-  static m49(coin) => "${coin} 手数料";
+  static m51(value) => "料金は ${value} までである必要があります";
 
-  static m50(coin) => "${coin}をアクティベートしてください。";
+  static m52(coin) => "${coin} 手数料";
 
-  static m51(value) => "グウェイは ${value} までである必要があります";
+  static m53(coin) => "${coin}をアクティベートしてください。";
 
-  static m52(coinName) => "受信 ${coinName} txs 保護設定";
+  static m54(value) => "グウェイは ${value} までである必要があります";
 
-  static m53(abbr) => "${abbr} 取引手数料を支払うのに十分な残高がありません";
+  static m55(coinName) => "受信 ${coinName} txs 保護設定";
 
-  static m54(coin) => "無効な ${coin} アドレスです";
+  static m56(abbr) => "${abbr} 取引手数料を支払うのに十分な残高がありません";
 
-  static m55(coinAbbr) => "${coinAbbr} は利用できません:(";
+  static m57(coin) => "無効な ${coin} アドレスです";
 
-  static m56(coinName) => "❗注意！ ${coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。";
+  static m58(coinAbbr) => "${coinAbbr} は利用できません:(";
 
-  static m57(value) => "制限は最大 ${value} である必要があります";
+  static m59(coinName) => "❗注意！ ${coinName} の市場の 24 時間の取引高は 10,000 ドル未満です。";
 
-  static m58(coinName, number) => "最低販売額は ${number} ${coinName} です";
-
-  static m59(coinName, number) => "最低購入金額は ${number} ${coinName} です";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "注文の最小額は ${buyAmount} ${buyCoin} (${sellAmount} ${sellCoin}) です";
+  static m60(value) => "制限は最大 ${value} である必要があります";
 
   static m61(coinName, number) => "最低販売額は ${number} ${coinName} です";
 
-  static m62(minValue, coin) => "${minValue} ${coin} より大きくなければなりません";
+  static m62(coinName, number) => "最低購入金額は ${number} ${coinName} です";
 
-  static m63(appName) =>
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "注文の最小額は ${buyAmount} ${buyCoin} (${sellAmount} ${sellCoin}) です";
+
+  static m64(coinName, number) => "最低販売額は ${number} ${coinName} です";
+
+  static m65(minValue, coin) => "${minValue} ${coin} より大きくなければなりません";
+
+  static m66(appName) =>
       "現在、携帯データ ネットワークを使用しており、${appName} P2P ネットワークに参加すると、インターネット トラフィックが消費されることに注意してください。携帯電話のデータ プランが高額な場合は、WiFi ネットワークを使用することをお勧めします。";
 
-  static m64(coin) => "最初に ${coin} を有効にして、残高をチャージしてください";
+  static m67(coin) => "最初に ${coin} を有効にして、残高をチャージしてください";
 
-  static m65(number) => "${number} オーダーを作成:";
+  static m68(number) => "${number} オーダーを作成:";
 
-  static m66(coin) => "${coin} の残高が少なすぎます";
+  static m69(coin) => "${coin} の残高が少なすぎます";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "料金を支払うのに十分な ${coin} がありません。 MIN 残高は ${fee} ${coin} です";
 
-  static m68(coinName) => "${coinName} の金額を入力してください。";
+  static m71(coinName) => "${coinName} の金額を入力してください。";
 
-  static m69(coin) => "取引に十分な ${coin} がありません!";
+  static m72(coin) => "取引に十分な ${coin} がありません!";
 
-  static m70(sell, buy) => "${sell}/${buy} スワップが正常に完了しました";
+  static m73(sell, buy) => "${sell}/${buy} スワップが正常に完了しました";
 
-  static m71(sell, buy) => "${sell}/${buy} スワップに失敗しました";
+  static m74(sell, buy) => "${sell}/${buy} スワップに失敗しました";
 
-  static m72(sell, buy) => "${sell}/${buy} スワップ開始";
+  static m75(sell, buy) => "${sell}/${buy} スワップ開始";
 
-  static m73(sell, buy) => "${sell}/${buy} スワップがタイムアウトしました";
+  static m76(sell, buy) => "${sell}/${buy} スワップがタイムアウトしました";
 
-  static m74(coin) => "${coin} のトランザクションを受け取りました!";
+  static m77(coin) => "${coin} のトランザクションを受け取りました!";
 
-  static m75(assets) => "${assets} アセット";
+  static m78(assets) => "${assets} アセット";
 
-  static m76(coin) => "${coin} の注文はすべてキャンセルされます。";
+  static m79(coin) => "${coin} の注文はすべてキャンセルされます。";
 
-  static m77(delta) => "便宜: CEX +${delta}%";
+  static m80(delta) => "便宜: CEX +${delta}%";
 
-  static m78(delta) => "高価: CEX ${delta}%";
+  static m81(delta) => "高価: CEX ${delta}%";
 
-  static m79(fill) => "${fill}% 埋められました";
+  static m82(fill) => "${fill}% 埋められました";
 
-  static m80(coin) => "金額 (${coin})";
+  static m83(coin) => "金額 (${coin})";
 
-  static m81(coin) => "価格 (${coin})";
+  static m84(coin) => "価格 (${coin})";
 
-  static m82(coin) => "合計 (${coin})";
+  static m85(coin) => "合計 (${coin})";
 
-  static m83(abbr) => "${abbr} はアクティブではありません。有効にしてからもう一度お試しください。";
+  static m86(abbr) => "${abbr} はアクティブではありません。有効にしてからもう一度お試しください。";
 
-  static m84(appName) => "${appName} を使用できるデバイスはどれですか?";
+  static m87(appName) => "${appName} を使用できるデバイスはどれですか?";
 
-  static m85(appName) => "${appName} での取引は、他の DEX での取引とどう違うのですか?";
+  static m88(appName) => "${appName} での取引は、他の DEX での取引とどう違うのですか?";
 
-  static m86(appName) => "${appName} の料金はどのように計算されますか?";
+  static m89(appName) => "${appName} の料金はどのように計算されますか?";
 
-  static m87(appName) => "${appName} の背後にいるのは誰ですか?";
+  static m90(appName) => "${appName} の背後にいるのは誰ですか?";
 
-  static m88(appName) => "${appName} で独自のホワイトラベル取引所を開発することは可能ですか?";
+  static m91(appName) => "${appName} で独自のホワイトラベル取引所を開発することは可能ですか?";
 
-  static m89(amount) => "成功！ ${amount} KMD を受け取りました。";
+  static m92(amount) => "成功！ ${amount} KMD を受け取りました。";
 
-  static m90(dd) => "${dd} 日";
+  static m93(dd) => "${dd} 日";
 
-  static m91(hh, minutes) => "${hh}時 ${minutes}分";
+  static m94(hh, minutes) => "${hh}時 ${minutes}分";
 
-  static m92(mm) => "${mm}分";
+  static m95(mm) => "${mm}分";
 
-  static m93(amount) => "クリックして ${amount} 件の注文を表示";
+  static m96(amount) => "クリックして ${amount} 件の注文を表示";
 
-  static m94(coinName, address) => "私の ${coinName} アドレス: \n${address}";
+  static m97(coinName, address) => "私の ${coinName} アドレス: \n${address}";
 
-  static m95(coin) => "過去の ${coin} 取引をスキャンしますか?";
+  static m98(coin) => "過去の ${coin} 取引をスキャンしますか?";
 
-  static m96(count, maxCount) => "${maxCount} 件中 ${count} 件の注文を表示しています。";
+  static m99(count, maxCount) => "${maxCount} 件中 ${count} 件の注文を表示しています。";
 
-  static m97(coin) => "購入する${coin}の金額を入力してください";
+  static m100(coin) => "購入する${coin}の金額を入力してください";
 
-  static m98(maxCoins) => "アクティブなコインの最大数は ${maxCoins} です。いくつか無効にしてください。";
+  static m101(maxCoins) => "アクティブなコインの最大数は ${maxCoins} です。いくつか無効にしてください。";
 
-  static m99(coin) => "${coin} はアクティブではありません!";
+  static m102(coin) => "${coin} はアクティブではありません!";
 
-  static m100(coin) => "売却する${coin}の金額を入力してください";
+  static m103(coin) => "売却する${coin}の金額を入力してください";
 
-  static m101(coin) => "${coin} をアクティベートできません";
+  static m104(coin) => "${coin} をアクティベートできません";
 
-  static m102(description) =>
+  static m105(description) =>
       "mp3またはwavファイルを選択してください。 ${description} になったら再生します。";
 
-  static m103(description) => "${description} の場合にプレイ";
+  static m106(description) => "${description} の場合にプレイ";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "ご不明な点がある場合、または ${appName} アプリで技術的な問題を発見したと思われる場合は、報告してチームからサポートを受けることができます。";
 
-  static m105(coin) => "最初に ${coin} を有効にして残高をチャージしてください";
+  static m108(coin) => "最初に ${coin} を有効にして残高をチャージしてください";
 
-  static m106(coin) => "${coin} の残高は、取引手数料を支払うのに十分ではありません。";
+  static m109(coin) => "${coin} の残高は、取引手数料を支払うのに十分ではありません。";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "${coin} の残高は、取引手数料を支払うのに十分ではありません。${coin} ${amount} が必要です。";
 
-  static m108(name) => "どの ${name} トランザクションを同期しますか?";
+  static m111(name) => "どの ${name} トランザクションを同期しますか?";
 
-  static m109(left) => "残りのトランザクション: ${left}";
+  static m112(left) => "残りのトランザクション: ${left}";
 
-  static m110(amnt, hash) => "${amnt} 資金のロックを解除しました - TX: ${hash}";
+  static m113(amnt, hash) => "${amnt} 資金のロックを解除しました - TX: ${hash}";
 
-  static m111(version) => "バージョン ${version} を使用しています";
+  static m114(version) => "バージョン ${version} を使用しています";
 
-  static m112(version) => "バージョン ${version} が利用可能です。更新してください。";
+  static m115(version) => "バージョン ${version} が利用可能です。更新してください。";
 
-  static m113(appName) => "${appName} の更新";
+  static m116(appName) => "${appName} の更新";
 
-  static m114(coinAbbr) => "${coinAbbr} をアクティベートできませんでした";
+  static m117(coinAbbr) => "${coinAbbr} をアクティベートできませんでした";
 
-  static m115(coinAbbr) => "${coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。";
+  static m118(coinAbbr) => "${coinAbbr} をアクティベートできませんでした。アプリを再起動してもう一度お試しください。";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} モバイルは、ネイティブの第 3 世代 DEX 機能などを備えた次世代のマルチコイン ウォレットです。";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "以前にカメラへの ${appName} アクセスを拒否しました。 QR コードのスキャンを続行するには、電話の設定でカメラの許可を手動で変更してください。";
 
-  static m118(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
+  static m121(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
 
-  static m119(amount, coin) => "${amount} ${coin} を受け取ります";
+  static m122(amount, coin) => "${amount} ${coin} を受け取ります";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -318,6 +324,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled":
+            MessageLookupByLibrary.simpleMessage("コインのアクティベーションがキャンセルされました"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("コインを有効にする"),
         "addingCoinSuccess": m4,
@@ -445,15 +453,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("コード："),
         "cofirmCancelActivation":
             MessageLookupByLibrary.simpleMessage("アクティベーションをキャンセルしてもよろしいですか?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("クリア"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("アクティブなコインはありません"),
         "coinSelectTitle": MessageLookupByLibrary.simpleMessage("コインを選択"),
         "coinsActivatedLimitReached":
             MessageLookupByLibrary.simpleMessage("アセットの最大数を選択しました"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("近日公開..."),
         "commingsoon": MessageLookupByLibrary.simpleMessage("TXの詳細は近日公開！"),
         "commingsoonGeneral": MessageLookupByLibrary.simpleMessage("詳細は近日公開！"),
@@ -477,7 +487,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactCancel": MessageLookupByLibrary.simpleMessage("キャンセル"),
         "contactDelete": MessageLookupByLibrary.simpleMessage("連絡先を削除"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("消去"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("破棄"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("編集"),
         "contactExit": MessageLookupByLibrary.simpleMessage("出口"),
@@ -503,7 +513,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("カスタム料金"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "あなたが何をしているのかを知っている場合にのみ、カスタム料金を使用してください!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW セキュリティ"),
         "date": MessageLookupByLibrary.simpleMessage("日にち"),
         "decryptingWallet": MessageLookupByLibrary.simpleMessage("ウォレットの復号化"),
@@ -516,8 +526,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteWallet": MessageLookupByLibrary.simpleMessage("ウォレットの削除"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("ウォレットを削除しています..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage("送信取引手数料 取引手数料"),
         "detailedFeesTradingFee": MessageLookupByLibrary.simpleMessage("取引手数料"),
@@ -537,7 +547,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "dontWantPassword": MessageLookupByLibrary.simpleMessage("パスワードはいらない"),
         "duration": MessageLookupByLibrary.simpleMessage("間隔"),
         "editContact": MessageLookupByLibrary.simpleMessage("連絡先を編集"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass":
             MessageLookupByLibrary.simpleMessage("暗号化パスワードを空にすることはできません"),
         "emptyImportPass":
@@ -546,7 +556,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("連絡先の名前を空にすることはできません"),
         "emptyWallet":
             MessageLookupByLibrary.simpleMessage("ウォレット名を空にすることはできません"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "アクティベーションの進行状況に関する最新情報を取得するには、通知を有効にしてください。"),
@@ -579,7 +589,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("有効な住所ではありません"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Segwit アドレスはサポートされていません (まだ)"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain":
             MessageLookupByLibrary.simpleMessage("エラーです。もう一度お試しください"),
         "errorTryLater":
@@ -588,32 +598,32 @@ class MessageLookup extends MessageLookupByLibrary {
         "errorValueNotEmpty":
             MessageLookupByLibrary.simpleMessage("データを入力してください"),
         "estimateValue": MessageLookupByLibrary.simpleMessage("推定合計値"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -662,16 +672,17 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("アイテムは正常にエクスポートされました:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("スワップ"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("書き出す"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt": MessageLookupByLibrary.simpleMessage("偽の残高:"),
         "faqTitle": MessageLookupByLibrary.simpleMessage("よくある質問"),
         "faucetError": MessageLookupByLibrary.simpleMessage("エラー"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("蛇口"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("成功"),
         "faucetTimedOut": MessageLookupByLibrary.simpleMessage("要求がタイムアウトしました"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("ニュース"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("ここには何もない"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("続きを読む..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("餌"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("ニュースフィード"),
@@ -682,7 +693,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedUpToDate": MessageLookupByLibrary.simpleMessage("すでに最新"),
         "feedUpdated": MessageLookupByLibrary.simpleMessage("ニュースフィードが更新されました"),
         "feedback": MessageLookupByLibrary.simpleMessage("ログファイルの共有"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("全て"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("フィルター"),
         "filtersClearAll":
@@ -704,9 +715,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("から"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "公開キーに関連付けられたアクティベーション後に行われる今後のトランザクションは同期されます。これは最も迅速なオプションであり、必要なストレージの量も最小限です。"),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("ガスリミット"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("ガス料金"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "一般的な PIN 保護はアクティブではありません。カモフラージュモードは利用できません。 PIN 保護を有効にしてください。"),
@@ -715,7 +726,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "gettingTxWait":
             MessageLookupByLibrary.simpleMessage("トランザクションを取得しています。お待ちください"),
         "goToPorfolio": MessageLookupByLibrary.simpleMessage("ポートフォリオに移動"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("ヘルプ"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("ヘルプとサポート"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("残高を非表示"),
@@ -763,7 +774,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError":
             MessageLookupByLibrary.simpleMessage("json ファイルのデコード中にエラーが発生しました"),
         "importTitle": MessageLookupByLibrary.simpleMessage("輸入"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "安全なパスワードを使用し、同じデバイスに保存しないでください"),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -772,25 +783,25 @@ class MessageLookup extends MessageLookupByLibrary {
             "スワップには最大 60 分かかる場合があります。このアプリケーションを閉じないでください！"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "セキュリティ上の理由から、ウォレット暗号化用のパスワードを提供する必要があります。"),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText":
             MessageLookupByLibrary.simpleMessage("この注文に必要な最小ボリュームは"),
         "insufficientTitle": MessageLookupByLibrary.simpleMessage("ボリューム不足"),
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("リフレッシュ"),
         "internetRestored":
             MessageLookupByLibrary.simpleMessage("インターネット接続が回復しました"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap": MessageLookupByLibrary.simpleMessage("スワップを続行できません"),
         "invalidSwapDetailsLink": MessageLookupByLibrary.simpleMessage("詳細"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("日本"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("韓国語"),
         "language": MessageLookupByLibrary.simpleMessage("言語"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("最新の取引"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("法的"),
         "less": MessageLookupByLibrary.simpleMessage("以下"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("読み込んでいます..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("オーダーブックを読み込んでいます..."),
@@ -850,11 +861,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("MS"),
         "min": MessageLookupByLibrary.simpleMessage("最小"),
         "minOrder": MessageLookupByLibrary.simpleMessage("最小注文量:"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH":
             MessageLookupByLibrary.simpleMessage("販売額より低くなければなりません"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage("必要な最小ボリューム"),
@@ -863,16 +874,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "警告: iOS でアプリを最小化すると、アクティベーション プロセスが終了します。"),
         "minutes": MessageLookupByLibrary.simpleMessage("メートル"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("より詳しい情報"),
         "moreTab": MessageLookupByLibrary.simpleMessage("もっと"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("額"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("コイン"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("売る"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("キャンセル"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("確認"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("作成"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("注文"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("注文"),
@@ -886,8 +897,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiInvalidAmt": MessageLookupByLibrary.simpleMessage("金額が無効です"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("販売金額が無効です"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage("最大販売額は"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage("最小受け取り金額は"),
         "multiMinSellAmt": MessageLookupByLibrary.simpleMessage("最小販売額は"),
@@ -914,7 +925,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noItemsToImport": MessageLookupByLibrary.simpleMessage("項目が選択されていません"),
         "noMatchingOrders":
             MessageLookupByLibrary.simpleMessage("一致する注文が見つかりません"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage("クリックして注文を作成"),
         "noOrders":
             MessageLookupByLibrary.simpleMessage("注文はありません。取引に行ってください。"),
@@ -927,7 +938,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("値は数値でなければなりません"),
         "none": MessageLookupByLibrary.simpleMessage("なし"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "手数料に十分な残高がありません - 少額で取引してください"),
         "noteOnOrder":
@@ -935,23 +946,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("メモを追加"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("ノート"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("何も見つかりません"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("スワップ完了"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("スワップに失敗しました"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("新しいスワップが開始されました"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("スワップ ステータスが変更されました"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("スワップ タイムアウト"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("着信トランザクション"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("公式プレスリリース"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -961,14 +972,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("エラーメッセージを開く"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("少ない"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("もっと"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated": MessageLookupByLibrary.simpleMessage("オーダーが作成されました"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("注文が正常に作成されました"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("住所"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("キャンセル"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("為に"),
         "orderDetailsIdentical": MessageLookupByLibrary.simpleMessage("CEXと同じ"),
         "orderDetailsMin": MessageLookupByLibrary.simpleMessage("分。"),
@@ -980,7 +991,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "シングルタップで詳細を開き、ロングタップで注文を選択します"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("費やす"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("詳細"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("一致した注文"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("オーダーマッチング"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("注文"),
@@ -988,9 +999,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("注文"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("アクティブ"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("歴史"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("上書き"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("これはあなた自身の注文です！"),
         "paidFromBalance": MessageLookupByLibrary.simpleMessage("残高から支払われる:"),
@@ -1013,8 +1024,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("キャンセル"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("支払いが要求されました"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("ご注文"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "特別なコインの有効化リクエストをすべて受け入れるか、コインの選択を解除してください。"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage("コインを追加してください"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
             "アプリを再起動してもう一度試すか、下のボタンを押してください。"),
@@ -1034,18 +1048,18 @@ class MessageLookup extends MessageLookupByLibrary {
         "pubkey": MessageLookupByLibrary.simpleMessage("公開鍵"),
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("QRコードスキャナー"),
         "question_1": MessageLookupByLibrary.simpleMessage("私の秘密鍵を保管しますか?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "各アトミック スワップにはどのくらいの時間がかかりますか?"),
         "question_4":
             MessageLookupByLibrary.simpleMessage("スワップ中はオンラインである必要がありますか?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6":
             MessageLookupByLibrary.simpleMessage("ユーザーサポートは提供していますか？"),
         "question_7": MessageLookupByLibrary.simpleMessage("国の制限はありますか？"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "新しい時代です！ 「AtomicDEX」から「Komodo Wallet」に正式に名前を変更しました"),
         "receive": MessageLookupByLibrary.simpleMessage("受け取る"),
@@ -1079,16 +1093,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore":
             MessageLookupByLibrary.simpleMessage("KMDアクティブユーザー特典について詳しく見る"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("受け取る"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("フィアット"),
         "rewardsTableRewards": MessageLookupByLibrary.simpleMessage("リワード、KMD"),
         "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("状態"),
         "rewardsTableTime": MessageLookupByLibrary.simpleMessage("残り時間"),
         "rewardsTableTitle": MessageLookupByLibrary.simpleMessage("特典情報:"),
         "rewardsTableUXTO": MessageLookupByLibrary.simpleMessage("UTXO金額、KMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("特典情報"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("ロシア"),
         "saveMerged": MessageLookupByLibrary.simpleMessage("結合して保存"),
@@ -1138,7 +1152,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("ティッカーを検索"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("安全"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage("取引履歴を見る"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("シードフレーズ"),
         "seedPhraseTitle":
@@ -1172,34 +1186,34 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("言語"),
         "settings": MessageLookupByLibrary.simpleMessage("設定"),
         "share": MessageLookupByLibrary.simpleMessage("シェア"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("住所を表示"),
         "showDetails": MessageLookupByLibrary.simpleMessage("詳細を表示"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("私の注文を表示"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("パスワードでサインイン"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "パスワードをお忘れですか？シードからウォレットを復元する"),
         "simple": MessageLookupByLibrary.simpleMessage("単純"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("活性化"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("買う"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("近い"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("受け取る"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("売る"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("送信"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("表示を減らす"),
         "simpleTradeShowMore": MessageLookupByLibrary.simpleMessage("もっと見せる"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("スキップ"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("解散"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("音"),
         "soundSettingsTitle": MessageLookupByLibrary.simpleMessage("サウンド設定"),
         "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("サウンド"),
@@ -1215,15 +1229,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("ステップ"),
         "success": MessageLookupByLibrary.simpleMessage("成功！"),
         "support": MessageLookupByLibrary.simpleMessage("サポート"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("スワップ"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("現時点の"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage("交換の詳細を確認する"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("見積もり"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("スワップに失敗しました"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("スワップ進行中"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("進捗詳細"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("開始"),
@@ -1236,7 +1250,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("苗木アクティベーションからの同期"),
         "syncNewTransactions":
             MessageLookupByLibrary.simpleMessage("新しいトランザクションを同期する"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1291,23 +1305,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "リクエストが多すぎます。トランザクション履歴リクエストの制限を超えました。後でもう一度やり直してください。"),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("未確認"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("ウクライナ語"),
         "unlock": MessageLookupByLibrary.simpleMessage("ロックを解除"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("資金のロックを解除"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("使えない"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("新しいバージョンが利用可能"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage("アップデートの確認..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable":
             MessageLookupByLibrary.simpleMessage("新しいバージョンが利用可能です。更新してください。"),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("利用可能なアップデート"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("今のところスキップ"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage("すでに最新"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("アップデート"),
         "uriInsufficientBalanceSpan1":
@@ -1330,9 +1344,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "警告 - 特殊なケースでは、このログ データには機密情報が含まれており、失敗したスワップからのコインの使用に使用できる可能性があります。"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("セットアップしましょう！"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("ようこそ"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("財布"),
@@ -1341,13 +1355,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "これには時間がかかるため、アプリをフォアグラウンドに維持する必要があります。\nアクティベーションの進行中にアプリを終了すると、問題が発生する可能性があります。"),
         "withdraw": MessageLookupByLibrary.simpleMessage("撤退"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("アクセスが拒否されました"),
         "withdrawConfirm": MessageLookupByLibrary.simpleMessage("出金確認"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "エラーが発生しました。あとでもう一度試してみてください。"),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1":
             MessageLookupByLibrary.simpleMessage("の支払い QR コードをスキャンしようとしています"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("しかし、あなたは上にいます"),
@@ -1363,7 +1377,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "you have an order that new orders can match with":
             MessageLookupByLibrary.simpleMessage("新しい注文と一致する注文があります"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("あなたが送っているもの:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("受け取るもの:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("あなたの財布")
       };

--- a/lib/l10n/messages_ko.dart
+++ b/lib/l10n/messages_ko.dart
@@ -155,139 +155,145 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m53(abbr) => "${abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다";
 
-  static m54(coinAbbr) => "${coinAbbr} 이 사용불가합니다 :(";
+  static m54(coin) => "잘못된 ${coin} 주소";
 
-  static m55(coinName) => "❗주의! ${coinName} 시장의 24시간 거래량이 \$10,000 미만입니다!";
+  static m55(coinAbbr) => "${coinAbbr} 이 사용불가합니다 :(";
 
-  static m56(value) => "한도는 최대 ${value}이어야 합니다.";
+  static m56(coinName) => "❗주의! ${coinName} 시장의 24시간 거래량이 \$10,000 미만입니다!";
 
-  static m57(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
+  static m57(value) => "한도는 최대 ${value}이어야 합니다.";
 
-  static m58(coinName, number) => "최소 구매 양은 ${number} ${coinName}입니다";
+  static m58(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m59(coinName, number) => "최소 구매 양은 ${number} ${coinName}입니다";
+
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "최소 주문 양은 ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})입니다";
 
-  static m60(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
+  static m61(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
 
-  static m61(minValue, coin) => "값은 ${minValue} ${coin}보다 커야합니다";
+  static m62(minValue, coin) => "값은 ${minValue} ${coin}보다 커야합니다";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "이제 셀룰러 데이터를 사용하고 ${appName} P2P 네트워크에 참여하여 인터넷 트래픽을 소비합니다. 셀룰러 데이터 요금제가 비싸다면 WiFi 네트워크를 사용하는 것이 좋습니다.";
 
-  static m63(coin) => "${coin} 활성화하고 먼저 가장 높은 잔고로";
+  static m64(coin) => "${coin} 활성화하고 먼저 가장 높은 잔고로";
 
-  static m64(number) => "${number} 주문들 생성:";
+  static m65(number) => "${number} 주문들 생성:";
 
-  static m65(coin) => "${coin} 잔고가 너무 낮습니다";
+  static m66(coin) => "${coin} 잔고가 너무 낮습니다";
 
-  static m66(coin, fee) => "수수료를 지불할 ${coin}이 부족합니다. 최소 잔고는 ${fee} ${coin}입니다";
+  static m67(coin, fee) => "수수료를 지불할 ${coin}이 부족합니다. 최소 잔고는 ${fee} ${coin}입니다";
 
-  static m67(coinName) => "${coinName} 양을 입력해 주세요.";
+  static m68(coinName) => "${coinName} 양을 입력해 주세요.";
 
-  static m68(coin) => "거래를 위한 ${coin} 부족합니다!";
+  static m69(coin) => "거래를 위한 ${coin} 부족합니다!";
 
-  static m69(sell, buy) => "${sell}/${buy} 가 성공적으로 바꿔었습니다";
+  static m70(sell, buy) => "${sell}/${buy} 가 성공적으로 바꿔었습니다";
 
-  static m70(sell, buy) => "${sell}/${buy} 를 바꾸기 실패했습니다";
+  static m71(sell, buy) => "${sell}/${buy} 를 바꾸기 실패했습니다";
 
-  static m71(sell, buy) => "${sell}/${buy} 스와프가 시작되었습니다";
+  static m72(sell, buy) => "${sell}/${buy} 스와프가 시작되었습니다";
 
-  static m72(sell, buy) => "${sell}/${buy} 스왑 시간이 초과되었습니다";
+  static m73(sell, buy) => "${sell}/${buy} 스왑 시간이 초과되었습니다";
 
-  static m73(coin) => "당신은 ${coin} 거래를 받았습니다!";
+  static m74(coin) => "당신은 ${coin} 거래를 받았습니다!";
 
-  static m74(assets) => "${assets} 자산";
+  static m75(assets) => "${assets} 자산";
 
-  static m75(coin) => "모든 ${coin} 주문이 취소될것 입니다.";
+  static m76(coin) => "모든 ${coin} 주문이 취소될것 입니다.";
 
-  static m76(delta) => "편함: CEX +${delta}%";
+  static m77(delta) => "편함: CEX +${delta}%";
 
-  static m77(delta) => "편함: CEX ${delta}%";
+  static m78(delta) => "편함: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% 채워짐";
+  static m79(fill) => "${fill}% 채워짐";
 
-  static m79(coin) => "Amt. (${coin})";
+  static m80(coin) => "Amt. (${coin})";
 
-  static m80(coin) => "가격 (${coin})";
+  static m81(coin) => "가격 (${coin})";
 
-  static m81(coin) => "총값 (${coin})";
+  static m82(coin) => "총값 (${coin})";
 
-  static m82(abbr) => "${abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.";
+  static m83(abbr) => "${abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.";
 
-  static m83(appName) => "어떤 기기에서 ${appName}을 사용할 수 있나요?";
+  static m84(appName) => "어떤 기기에서 ${appName}을 사용할 수 있나요?";
 
-  static m84(appName) => "다른 DEX들에서 거래하는 것 보다 ${appName}에서 하는 것이 무엇이 다른가요?";
+  static m85(appName) => "다른 DEX들에서 거래하는 것 보다 ${appName}에서 하는 것이 무엇이 다른가요?";
 
-  static m85(appName) => "${appName}에서 수수료는 어떻게 계산되나요?";
+  static m86(appName) => "${appName}에서 수수료는 어떻게 계산되나요?";
 
-  static m86(appName) => "${appName} 뒤에는 누가 있나요?";
+  static m87(appName) => "${appName} 뒤에는 누가 있나요?";
 
-  static m87(appName) => "${appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?";
+  static m88(appName) => "${appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?";
 
-  static m88(amount) => "성공! ${amount} KMD를 받았습니다.";
+  static m89(amount) => "성공! ${amount} KMD를 받았습니다.";
 
-  static m89(dd) => "${dd} 날(들)";
+  static m90(dd) => "${dd} 날(들)";
 
-  static m90(hh, minutes) => "${hh}h ${minutes}m";
+  static m91(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m91(mm) => "${mm}분";
+  static m92(mm) => "${mm}분";
 
-  static m92(amount) => "${amount} 주문을 보기 위해 클릭하세요";
+  static m93(amount) => "${amount} 주문을 보기 위해 클릭하세요";
 
-  static m93(coinName, address) => "나의 ${coinName} 주소:\n${address}";
+  static m94(coinName, address) => "나의 ${coinName} 주소:\n${address}";
 
-  static m94(count, maxCount) => "${maxCount}개 주문 중 ${count}개를 표시 중입니다.";
+  static m95(coin) => "과거 ${coin} 거래를 검색하시겠습니까?";
 
-  static m95(coin) => "구매할 ${coin} 양을 입력하세요";
+  static m96(count, maxCount) => "${maxCount}개 주문 중 ${count}개를 표시 중입니다.";
 
-  static m96(maxCoins) => "최대 활성화 코인 양은 ${maxCoins}입니다. 조금 비활성화 해주세요.";
+  static m97(coin) => "구매할 ${coin} 양을 입력하세요";
 
-  static m97(coin) => "${coin}이 활성화 되어 있지 않습니다!";
+  static m98(maxCoins) => "최대 활성화 코인 양은 ${maxCoins}입니다. 조금 비활성화 해주세요.";
 
-  static m98(coin) => "판매 할 ${coin} 양을 입력하세요";
+  static m99(coin) => "${coin}이 활성화 되어 있지 않습니다!";
 
-  static m99(coin) => "${coin}을 활성화 할 수 없습니다";
+  static m100(coin) => "판매 할 ${coin} 양을 입력하세요";
 
-  static m100(description) =>
+  static m101(coin) => "${coin}을 활성화 할 수 없습니다";
+
+  static m102(description) =>
       "mp3 또는 wav 파일을 골라주세요. 저희가 ${description}때 들려드리겠습니다.";
 
-  static m101(description) => "${description}일때 들려주기";
+  static m103(description) => "${description}일때 들려주기";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "궁금한 점이 있거나, ${appName} 앱의 기술적인 문제를 발견하셨다고 생각하시면, 보고하고 팀의 지원을 받으실 수 있습니다.";
 
-  static m103(coin) => "${coin} 활성화와 최고 잔고를 먼저 해주세요";
+  static m105(coin) => "${coin} 활성화와 최고 잔고를 먼저 해주세요";
 
-  static m104(coin) => "${coin} 잔고가 거래 수수료를 지불하기 부족합니다.";
+  static m106(coin) => "${coin} 잔고가 거래 수수료를 지불하기 부족합니다.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "${coin} 잔고가 거래 수수료를 지불하기 부족합니다. ${coin} ${amount}가 필요합니다.";
 
-  static m106(left) => "남은 거래: ${left}";
+  static m108(name) => "어떤 ${name} 거래를 동기화하시겠습니까?";
 
-  static m107(amnt, hash) => "성공적으로 ${amnt} 펀드를 열었습니다 - TX: ${hash}";
+  static m109(left) => "남은 거래: ${left}";
 
-  static m108(version) => "당신은 ${version} 사용 중 입니다";
+  static m110(amnt, hash) => "성공적으로 ${amnt} 펀드를 열었습니다 - TX: ${hash}";
 
-  static m109(version) => "버전 ${version}이 있습니다. 업데이트를 하세요.";
+  static m111(version) => "당신은 ${version} 사용 중 입니다";
 
-  static m110(appName) => "${appName} 업데이트";
+  static m112(version) => "버전 ${version}이 있습니다. 업데이트를 하세요.";
 
-  static m111(coinAbbr) => "저희가 ${coinAbbr}를 활성화 하는 것을 실패했습니다";
+  static m113(appName) => "${appName} 업데이트";
 
-  static m112(coinAbbr) =>
+  static m114(coinAbbr) => "저희가 ${coinAbbr}를 활성화 하는 것을 실패했습니다";
+
+  static m115(coinAbbr) =>
       "저희가 ${coinAbbr}를 활성화 하는 것을 실패했습니다.\n앱을 다시 시작하고 다시 해주세요.";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "${appName} 모바일은 3세대 DEX 기능과 더 많은 기능 등을 탑재한 차세대 멀티코인 지갑입니다.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "카메라에 대한 ${appName} 액세스를 이전에 거부했습니다.\nQR코드 스캔을 실시하려면 전화기의 설정에서 카메라의 허가를 수동으로 변경해 주세요.";
 
-  static m115(amount, coinName) => "${amount} ${coinName} 인출";
+  static m118(amount, coinName) => "${amount} ${coinName} 인출";
 
-  static m116(amount, coin) => "당신은 ${amount} ${coin}을 받습니다";
+  static m119(amount, coin) => "당신은 ${amount} ${coin}을 받습니다";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -329,6 +335,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("수신자 선택"),
         "advanced": MessageLookupByLibrary.simpleMessage("고급"),
         "all": MessageLookupByLibrary.simpleMessage("모두"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "지갑에는 과거 거래가 표시됩니다. 모든 블록이 다운로드되고 스캔되므로 상당한 저장 공간과 시간이 소요됩니다."),
         "allowCustomSeed": MessageLookupByLibrary.simpleMessage("커스텀 시드 허용"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("벌서 존재합니다"),
         "amount": MessageLookupByLibrary.simpleMessage("양"),
@@ -388,6 +396,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "camoSetupTitle": MessageLookupByLibrary.simpleMessage("위장 비밀번호 셋업"),
         "camouflageSetup": MessageLookupByLibrary.simpleMessage("위장 비밀번호 셋업"),
         "cancel": MessageLookupByLibrary.simpleMessage("취소"),
+        "cancelActivation": MessageLookupByLibrary.simpleMessage("활성화 취소"),
+        "cancelActivationQuestion":
+            MessageLookupByLibrary.simpleMessage("활성화를 취소하시겠습니까?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("취소"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("주문 취소"),
         "candleChartError":
@@ -426,6 +437,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closeMessage": MessageLookupByLibrary.simpleMessage("에러 메시지 닫기"),
         "closePreview": MessageLookupByLibrary.simpleMessage("프리뷰 닫기"),
         "code": MessageLookupByLibrary.simpleMessage("코드:"),
+        "cofirmCancelActivation":
+            MessageLookupByLibrary.simpleMessage("활성화를 취소하시겠습니까?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("클리어"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("활성화된 코인 없음"),
@@ -683,6 +696,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("QR코드 발견"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("프랑스 국민"),
         "from": MessageLookupByLibrary.simpleMessage("에서부터"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "공개 키와 관련된 활성화 후 향후 거래가 동기화됩니다. 이는 가장 빠른 옵션이며 저장 공간을 가장 적게 차지합니다."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("가스 제한"),
         "gasNotActive": m50,
@@ -756,17 +771,18 @@ class MessageLookup extends MessageLookupByLibrary {
         "insufficientTitle": MessageLookupByLibrary.simpleMessage("볼륨 부족"),
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("새로 고침"),
         "internetRestored": MessageLookupByLibrary.simpleMessage("인터넷 연결 복구됨"),
+        "invalidCoinAddress": m54,
         "invalidSwap": MessageLookupByLibrary.simpleMessage("스왑 진행 불가능"),
         "invalidSwapDetailsLink": MessageLookupByLibrary.simpleMessage("상세"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("일본어"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("한국인"),
         "language": MessageLookupByLibrary.simpleMessage("언어"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("마지막 거래"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("법적"),
         "less": MessageLookupByLibrary.simpleMessage("덜"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("로딩 중..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage("주문책 로딩 중..."),
         "lockScreen": MessageLookupByLibrary.simpleMessage("스크린이 잠겼습니다"),
@@ -823,11 +839,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("최소"),
         "minOrder": MessageLookupByLibrary.simpleMessage("최소 주문 볼륨"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH":
             MessageLookupByLibrary.simpleMessage("판매 양보다 적어야 합니다"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage("필요된 최소 볼륨"),
@@ -835,16 +851,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "경고: iOS에서 앱을 최소화하면 활성화 프로세스가 종료됩니다."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("더 많은 정보"),
         "moreTab": MessageLookupByLibrary.simpleMessage("더"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("양"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("코인"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("판매"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("취소"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("확인"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("생성"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("주문"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("주문들"),
@@ -857,8 +873,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("계속하기 전에 모든 에러를 고치세요"),
         "multiInvalidAmt": MessageLookupByLibrary.simpleMessage("잘못된 양"),
         "multiInvalidSellAmt": MessageLookupByLibrary.simpleMessage("잘못된 판매 양"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage("최대 판매 양은"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage("최소 받는 양은"),
         "multiMinSellAmt": MessageLookupByLibrary.simpleMessage("최소 판매 양은"),
@@ -884,7 +900,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noItemsToExport": MessageLookupByLibrary.simpleMessage("선택된 아이템 없음"),
         "noItemsToImport": MessageLookupByLibrary.simpleMessage("선택된 아이템 없음"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage("알맞는 주문 없음"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable":
             MessageLookupByLibrary.simpleMessage("주문을 만들기 위해서 눌러주세요"),
         "noOrders": MessageLookupByLibrary.simpleMessage("주문 없음, 가서 거래하세요."),
@@ -896,7 +912,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noTxs": MessageLookupByLibrary.simpleMessage("거래내역 없음"),
         "nonNumericInput": MessageLookupByLibrary.simpleMessage("값은 숫자여야 합니다"),
         "none": MessageLookupByLibrary.simpleMessage("없음"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "수수료를 위한 잔고 부족 - 더 작은 양을 거래하세요"),
         "noteOnOrder":
@@ -904,22 +920,22 @@ class MessageLookup extends MessageLookupByLibrary {
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("노트 추가"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("노트"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("찾을 수 없습니다"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("스와프 완료됨"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle": MessageLookupByLibrary.simpleMessage("스와프 실패됨"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("새로운 스와프가 시작되었습니다"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("스와프 상태가 바꿨습니다"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("스왑 시간 초과됨"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("들어오는 거래"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("공식 보도 자료"),
         "okButton": MessageLookupByLibrary.simpleMessage("네"),
@@ -929,14 +945,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("에러 메세지 열기"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("더 적은"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("더"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated": MessageLookupByLibrary.simpleMessage("주문 생성됨"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("주문이 성공적으로 생성됬습니다"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("주소"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("취소"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("위한"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("똑같은 CEX"),
@@ -949,7 +965,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "한개 탭에서 상세를 열고 긴 탭에서 주문을 선택하세요"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("소비"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("세부 사항"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("주문 매칭됨"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("주문 매칭"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("주문"),
@@ -957,9 +973,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("주문"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("활성화"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("히스토리"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("덮어쓰기"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("이것은 당신만의 주문입니다!"),
         "paidFromBalance": MessageLookupByLibrary.simpleMessage("잔액에서 지불:"),
@@ -967,6 +983,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("으로 지불"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "비밀번호는 최서 12자 이상이어여 하고, 소문자, 대문자 및 특수 기호가 하나씩 있어야합니다."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "귀하의 지갑에는 지정된 날짜 이후에 이루어진 과거 거래가 표시됩니다."),
         "paymentUriDetailsAccept": MessageLookupByLibrary.simpleMessage("지불"),
         "paymentUriDetailsAcceptQuestion":
             MessageLookupByLibrary.simpleMessage("거래를 수락하시겠습니까?"),
@@ -978,7 +996,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("코인:"),
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("취소"),
         "paymentUriDetailsTitle": MessageLookupByLibrary.simpleMessage("지불 요청"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("당신의 주문을 넣으세요"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage("코인을 더해 주세요"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -999,17 +1017,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "pubkey": MessageLookupByLibrary.simpleMessage("펍키"),
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("QR 코드 스캐너"),
         "question_1": MessageLookupByLibrary.simpleMessage("제 개인 키를 보관하나요?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3":
             MessageLookupByLibrary.simpleMessage("각각의 아토믹 스왑을 얼마나 걸리나요?"),
         "question_4":
             MessageLookupByLibrary.simpleMessage("스왑을 하는 동안 온라인에 있어야 하나요?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage("유저 지원을 공급하나요?"),
         "question_7": MessageLookupByLibrary.simpleMessage("나라 제한이 있나요?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "새로운 시대입니다! \'AtomicDEX\'에서 \'Komodo Wallet\'으로 공식 명칭을 변경하였습니다."),
         "receive": MessageLookupByLibrary.simpleMessage("받기"),
@@ -1043,7 +1061,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore":
             MessageLookupByLibrary.simpleMessage("KMD 활성화 유저 보상에 대해서 더 읽어 보기"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("받기"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("피아트"),
         "rewardsTableRewards": MessageLookupByLibrary.simpleMessage("보상,\nKMD"),
         "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("상태"),
@@ -1051,9 +1069,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsTableTitle": MessageLookupByLibrary.simpleMessage("보상 정보:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("보상 정보"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("러시아인"),
         "saveMerged": MessageLookupByLibrary.simpleMessage("병함 저장"),
@@ -1103,7 +1121,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("Ticker 찾기"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("보안"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage("거래 내역 보기"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("시드 문구"),
         "seedPhraseTitle":
@@ -1116,6 +1134,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("구매하고 싶은 코인 선택"),
         "selectCoinToSell":
             MessageLookupByLibrary.simpleMessage("판매하고 싶은 코인 선택"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("날짜를 선택하세요"),
         "selectFileImport": MessageLookupByLibrary.simpleMessage("파일 선택"),
         "selectLanguage": MessageLookupByLibrary.simpleMessage("언어 선택"),
         "selectPaymentMethod": MessageLookupByLibrary.simpleMessage("지불 방법 선택"),
@@ -1137,33 +1156,34 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("언어"),
         "settings": MessageLookupByLibrary.simpleMessage("설정"),
         "share": MessageLookupByLibrary.simpleMessage("공유"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("주소 표시"),
         "showDetails": MessageLookupByLibrary.simpleMessage("상세 보기"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("나의 주문 보기"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("비밀번호로 로그인하기"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "비밀번호를 까먹으셨나요? 지갑을 시드로부터 복구하세요"),
         "simple": MessageLookupByLibrary.simpleMessage("심플"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("활성화"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("구매"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("거이"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("받기"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("판매"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("보내기"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("덜 보기"),
         "simpleTradeShowMore": MessageLookupByLibrary.simpleMessage("더 보기"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("스킵"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("해제"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("소리"),
         "soundSettingsTitle": MessageLookupByLibrary.simpleMessage("소리 성정"),
         "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("소리들"),
@@ -1174,19 +1194,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "앱플리케이션 성정에서 커스텀 소리를 설정 할 수 있다는 것을 알아두세요."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("스페인의"),
+        "startDate": MessageLookupByLibrary.simpleMessage("시작일"),
         "startSwap": MessageLookupByLibrary.simpleMessage("스왑 시작"),
         "step": MessageLookupByLibrary.simpleMessage("방법"),
         "success": MessageLookupByLibrary.simpleMessage("성공!"),
         "support": MessageLookupByLibrary.simpleMessage("지원"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("스왑"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("현재"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage("변환 상세 확인"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("견적"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("스왑 실패"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("스왑이 진행되고 있습니다"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("진행 상세"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("시작됨"),
@@ -1194,6 +1215,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("전체"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("UUID 스왑"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("테마 전환"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage("지정된 날짜부터 동기화"),
+        "syncFromSaplingActivation":
+            MessageLookupByLibrary.simpleMessage("묘목 활성화에서 동기화"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage("새 거래 동기화"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1247,22 +1273,22 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "요청이 너무 많습니다.\n거래 이력 요구 제한을 초과했습니다.\n나중에 다시 시도해주세요."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("미확인"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("우크라이나 인"),
         "unlock": MessageLookupByLibrary.simpleMessage("열기"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("펀드 열기"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("사용 불가능"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("새로운 버전 사용 가능"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage("업데이트 확인중..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable":
             MessageLookupByLibrary.simpleMessage("새로운 버전이 있습니다. 업데이트를 하세요."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle": MessageLookupByLibrary.simpleMessage("업데이트가 있습니다"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("지금은 스킵"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("벌서 업데이트 되어있습니다"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("업데이트"),
@@ -1286,9 +1312,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("네"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "경고 - 특별한 경우 이 로그 데이터에는 스왑에 실패한 코인을 사용하는 데 사용할 수 있는 중요한 정보가 포함되어 있습니다!"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("이걸 준비해 봅시다!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("환영합니다"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("지갑"),
@@ -1297,13 +1323,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "이 작업은 시간이 걸리며 앱이 포그라운드에 유지되어야 합니다.\n활성화가 진행되는 동안 앱을 종료하면 문제가 발생할 수 있습니다."),
         "withdraw": MessageLookupByLibrary.simpleMessage("인출"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("액세스 거부"),
         "withdrawConfirm": MessageLookupByLibrary.simpleMessage("인출 확인"),
         "withdrawConfirmError":
             MessageLookupByLibrary.simpleMessage("무언가 잘못 됬습니다. 나중에 다시 시도하세요."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1":
             MessageLookupByLibrary.simpleMessage("당신은 지불 QR 코드를 스캔 할려고 합니다"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("하지만 당신은"),
@@ -1320,7 +1346,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "you have an order that new orders can match with":
             MessageLookupByLibrary.simpleMessage("당신은 새로운 주문을 맞출수 있는 주문이 있습니다"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("당신은 보냅니다:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("당신은 받습니다:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("당신의 지갑")
       };

--- a/lib/l10n/messages_ko.dart
+++ b/lib/l10n/messages_ko.dart
@@ -75,225 +75,231 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "당신의 시드 문구 안에 있는 ${index} 단어는 무엇입니까?";
 
-  static m22(protocolName) => "${protocolName} 코인이 활성화되었습니다";
+  static m22(coin) => "${coin} 활성화가 취소되었습니다.";
 
-  static m23(protocolName) => "${protocolName} 코인이 성공적으로 활성화되었습니다.";
+  static m23(coin) => "${coin}을(를) 성공적으로 활성화했습니다";
 
-  static m24(protocolName) => "${protocolName} 코인이 활성화되지 않았습니다.";
+  static m24(protocolName) => "${protocolName} 코인이 활성화되었습니다";
 
-  static m25(name) => "${name}을 연락처를 삭제하는 것을 확인하십니까?";
+  static m25(protocolName) => "${protocolName} 코인이 성공적으로 활성화되었습니다.";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "${protocolName} 코인이 활성화되지 않았습니다.";
+
+  static m27(name) => "${name}을 연락처를 삭제하는 것을 확인하십니까?";
+
+  static m28(iUnderstand) =>
       "커스텀 시드 문구는 생성된 BIP39 준거 시드 문구 또는 개인 키(WIF)보다 안전성이 낮고 크랙되기 쉬운 경우가 있습니다. 위험을 이해하고 무엇을 하고 있는지 확인하려면 아래 상자에 \"${iUnderstand}\"라고 입력해주세요.";
 
-  static m27(coinName) => "${coinName} 거래 수수료를 받습니다";
+  static m29(coinName) => "${coinName} 거래 수수료를 받습니다";
 
-  static m28(coinName) => "${coinName} 거래 수수료 보내기";
+  static m30(coinName) => "${coinName} 거래 수수료 보내기";
 
-  static m29(abbr) => "${abbr} 주소 입력";
+  static m31(abbr) => "${abbr} 주소 입력";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "여전히 ${remains}을(를) 활성화할 수 있습니다. 선택됨: ${selected}";
 
-  static m31(gas) => "가스가 충분하지 않습니다 - 최소 ${gas}양의 가스를 사용하세요";
+  static m33(gas) => "가스가 충분하지 않습니다 - 최소 ${gas}양의 가스를 사용하세요";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "${coin} 호수에게 요청 보내는 중...";
+  static m48(coinAbbr) => "${coinAbbr} 활성화를 취소하지 못했습니다.";
 
-  static m47(appCompanyShort) => "${appCompanyShort} 뉴스";
+  static m49(coin) => "${coin} 호수에게 요청 보내는 중...";
 
-  static m48(value) => "수수료는 최대 ${value}이어야 합니다.";
+  static m50(appCompanyShort) => "${appCompanyShort} 뉴스";
 
-  static m49(coin) => "${coin} 수수료";
+  static m51(value) => "수수료는 최대 ${value}이어야 합니다.";
 
-  static m50(coin) => "${coin}을 활성화하세요.";
+  static m52(coin) => "${coin} 수수료";
 
-  static m51(value) => "Gwei는 최대 ${value}이어야 합니다.";
+  static m53(coin) => "${coin}을 활성화하세요.";
 
-  static m52(coinName) => "수신되는 ${coinName} txs 보호 설정";
+  static m54(value) => "Gwei는 최대 ${value}이어야 합니다.";
 
-  static m53(abbr) => "${abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다";
+  static m55(coinName) => "수신되는 ${coinName} txs 보호 설정";
 
-  static m54(coin) => "잘못된 ${coin} 주소";
+  static m56(abbr) => "${abbr} 잔액은 교환 수수료를 지불할 금액보다 부족합니다";
 
-  static m55(coinAbbr) => "${coinAbbr} 이 사용불가합니다 :(";
+  static m57(coin) => "잘못된 ${coin} 주소";
 
-  static m56(coinName) => "❗주의! ${coinName} 시장의 24시간 거래량이 \$10,000 미만입니다!";
+  static m58(coinAbbr) => "${coinAbbr} 이 사용불가합니다 :(";
 
-  static m57(value) => "한도는 최대 ${value}이어야 합니다.";
+  static m59(coinName) => "❗주의! ${coinName} 시장의 24시간 거래량이 \$10,000 미만입니다!";
 
-  static m58(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
-
-  static m59(coinName, number) => "최소 구매 양은 ${number} ${coinName}입니다";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "최소 주문 양은 ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})입니다";
+  static m60(value) => "한도는 최대 ${value}이어야 합니다.";
 
   static m61(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
 
-  static m62(minValue, coin) => "값은 ${minValue} ${coin}보다 커야합니다";
+  static m62(coinName, number) => "최소 구매 양은 ${number} ${coinName}입니다";
 
-  static m63(appName) =>
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "최소 주문 양은 ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})입니다";
+
+  static m64(coinName, number) => "최소 판매 양은 ${number} ${coinName}입니다";
+
+  static m65(minValue, coin) => "값은 ${minValue} ${coin}보다 커야합니다";
+
+  static m66(appName) =>
       "이제 셀룰러 데이터를 사용하고 ${appName} P2P 네트워크에 참여하여 인터넷 트래픽을 소비합니다. 셀룰러 데이터 요금제가 비싸다면 WiFi 네트워크를 사용하는 것이 좋습니다.";
 
-  static m64(coin) => "${coin} 활성화하고 먼저 가장 높은 잔고로";
+  static m67(coin) => "${coin} 활성화하고 먼저 가장 높은 잔고로";
 
-  static m65(number) => "${number} 주문들 생성:";
+  static m68(number) => "${number} 주문들 생성:";
 
-  static m66(coin) => "${coin} 잔고가 너무 낮습니다";
+  static m69(coin) => "${coin} 잔고가 너무 낮습니다";
 
-  static m67(coin, fee) => "수수료를 지불할 ${coin}이 부족합니다. 최소 잔고는 ${fee} ${coin}입니다";
+  static m70(coin, fee) => "수수료를 지불할 ${coin}이 부족합니다. 최소 잔고는 ${fee} ${coin}입니다";
 
-  static m68(coinName) => "${coinName} 양을 입력해 주세요.";
+  static m71(coinName) => "${coinName} 양을 입력해 주세요.";
 
-  static m69(coin) => "거래를 위한 ${coin} 부족합니다!";
+  static m72(coin) => "거래를 위한 ${coin} 부족합니다!";
 
-  static m70(sell, buy) => "${sell}/${buy} 가 성공적으로 바꿔었습니다";
+  static m73(sell, buy) => "${sell}/${buy} 가 성공적으로 바꿔었습니다";
 
-  static m71(sell, buy) => "${sell}/${buy} 를 바꾸기 실패했습니다";
+  static m74(sell, buy) => "${sell}/${buy} 를 바꾸기 실패했습니다";
 
-  static m72(sell, buy) => "${sell}/${buy} 스와프가 시작되었습니다";
+  static m75(sell, buy) => "${sell}/${buy} 스와프가 시작되었습니다";
 
-  static m73(sell, buy) => "${sell}/${buy} 스왑 시간이 초과되었습니다";
+  static m76(sell, buy) => "${sell}/${buy} 스왑 시간이 초과되었습니다";
 
-  static m74(coin) => "당신은 ${coin} 거래를 받았습니다!";
+  static m77(coin) => "당신은 ${coin} 거래를 받았습니다!";
 
-  static m75(assets) => "${assets} 자산";
+  static m78(assets) => "${assets} 자산";
 
-  static m76(coin) => "모든 ${coin} 주문이 취소될것 입니다.";
+  static m79(coin) => "모든 ${coin} 주문이 취소될것 입니다.";
 
-  static m77(delta) => "편함: CEX +${delta}%";
+  static m80(delta) => "편함: CEX +${delta}%";
 
-  static m78(delta) => "편함: CEX ${delta}%";
+  static m81(delta) => "편함: CEX ${delta}%";
 
-  static m79(fill) => "${fill}% 채워짐";
+  static m82(fill) => "${fill}% 채워짐";
 
-  static m80(coin) => "Amt. (${coin})";
+  static m83(coin) => "Amt. (${coin})";
 
-  static m81(coin) => "가격 (${coin})";
+  static m84(coin) => "가격 (${coin})";
 
-  static m82(coin) => "총값 (${coin})";
+  static m85(coin) => "총값 (${coin})";
 
-  static m83(abbr) => "${abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.";
+  static m86(abbr) => "${abbr}가 활성화되어 있지 않습니다. 활성화 후에 다시 시도해주세요.";
 
-  static m84(appName) => "어떤 기기에서 ${appName}을 사용할 수 있나요?";
+  static m87(appName) => "어떤 기기에서 ${appName}을 사용할 수 있나요?";
 
-  static m85(appName) => "다른 DEX들에서 거래하는 것 보다 ${appName}에서 하는 것이 무엇이 다른가요?";
+  static m88(appName) => "다른 DEX들에서 거래하는 것 보다 ${appName}에서 하는 것이 무엇이 다른가요?";
 
-  static m86(appName) => "${appName}에서 수수료는 어떻게 계산되나요?";
+  static m89(appName) => "${appName}에서 수수료는 어떻게 계산되나요?";
 
-  static m87(appName) => "${appName} 뒤에는 누가 있나요?";
+  static m90(appName) => "${appName} 뒤에는 누가 있나요?";
 
-  static m88(appName) => "${appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?";
+  static m91(appName) => "${appName}에서 저의 화이트-레이블 익스체인지를 개발할 수 있나요?";
 
-  static m89(amount) => "성공! ${amount} KMD를 받았습니다.";
+  static m92(amount) => "성공! ${amount} KMD를 받았습니다.";
 
-  static m90(dd) => "${dd} 날(들)";
+  static m93(dd) => "${dd} 날(들)";
 
-  static m91(hh, minutes) => "${hh}h ${minutes}m";
+  static m94(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m92(mm) => "${mm}분";
+  static m95(mm) => "${mm}분";
 
-  static m93(amount) => "${amount} 주문을 보기 위해 클릭하세요";
+  static m96(amount) => "${amount} 주문을 보기 위해 클릭하세요";
 
-  static m94(coinName, address) => "나의 ${coinName} 주소:\n${address}";
+  static m97(coinName, address) => "나의 ${coinName} 주소:\n${address}";
 
-  static m95(coin) => "과거 ${coin} 거래를 검색하시겠습니까?";
+  static m98(coin) => "과거 ${coin} 거래를 검색하시겠습니까?";
 
-  static m96(count, maxCount) => "${maxCount}개 주문 중 ${count}개를 표시 중입니다.";
+  static m99(count, maxCount) => "${maxCount}개 주문 중 ${count}개를 표시 중입니다.";
 
-  static m97(coin) => "구매할 ${coin} 양을 입력하세요";
+  static m100(coin) => "구매할 ${coin} 양을 입력하세요";
 
-  static m98(maxCoins) => "최대 활성화 코인 양은 ${maxCoins}입니다. 조금 비활성화 해주세요.";
+  static m101(maxCoins) => "최대 활성화 코인 양은 ${maxCoins}입니다. 조금 비활성화 해주세요.";
 
-  static m99(coin) => "${coin}이 활성화 되어 있지 않습니다!";
+  static m102(coin) => "${coin}이 활성화 되어 있지 않습니다!";
 
-  static m100(coin) => "판매 할 ${coin} 양을 입력하세요";
+  static m103(coin) => "판매 할 ${coin} 양을 입력하세요";
 
-  static m101(coin) => "${coin}을 활성화 할 수 없습니다";
+  static m104(coin) => "${coin}을 활성화 할 수 없습니다";
 
-  static m102(description) =>
+  static m105(description) =>
       "mp3 또는 wav 파일을 골라주세요. 저희가 ${description}때 들려드리겠습니다.";
 
-  static m103(description) => "${description}일때 들려주기";
+  static m106(description) => "${description}일때 들려주기";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "궁금한 점이 있거나, ${appName} 앱의 기술적인 문제를 발견하셨다고 생각하시면, 보고하고 팀의 지원을 받으실 수 있습니다.";
 
-  static m105(coin) => "${coin} 활성화와 최고 잔고를 먼저 해주세요";
+  static m108(coin) => "${coin} 활성화와 최고 잔고를 먼저 해주세요";
 
-  static m106(coin) => "${coin} 잔고가 거래 수수료를 지불하기 부족합니다.";
+  static m109(coin) => "${coin} 잔고가 거래 수수료를 지불하기 부족합니다.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "${coin} 잔고가 거래 수수료를 지불하기 부족합니다. ${coin} ${amount}가 필요합니다.";
 
-  static m108(name) => "어떤 ${name} 거래를 동기화하시겠습니까?";
+  static m111(name) => "어떤 ${name} 거래를 동기화하시겠습니까?";
 
-  static m109(left) => "남은 거래: ${left}";
+  static m112(left) => "남은 거래: ${left}";
 
-  static m110(amnt, hash) => "성공적으로 ${amnt} 펀드를 열었습니다 - TX: ${hash}";
+  static m113(amnt, hash) => "성공적으로 ${amnt} 펀드를 열었습니다 - TX: ${hash}";
 
-  static m111(version) => "당신은 ${version} 사용 중 입니다";
+  static m114(version) => "당신은 ${version} 사용 중 입니다";
 
-  static m112(version) => "버전 ${version}이 있습니다. 업데이트를 하세요.";
+  static m115(version) => "버전 ${version}이 있습니다. 업데이트를 하세요.";
 
-  static m113(appName) => "${appName} 업데이트";
+  static m116(appName) => "${appName} 업데이트";
 
-  static m114(coinAbbr) => "저희가 ${coinAbbr}를 활성화 하는 것을 실패했습니다";
+  static m117(coinAbbr) => "저희가 ${coinAbbr}를 활성화 하는 것을 실패했습니다";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "저희가 ${coinAbbr}를 활성화 하는 것을 실패했습니다.\n앱을 다시 시작하고 다시 해주세요.";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} 모바일은 3세대 DEX 기능과 더 많은 기능 등을 탑재한 차세대 멀티코인 지갑입니다.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "카메라에 대한 ${appName} 액세스를 이전에 거부했습니다.\nQR코드 스캔을 실시하려면 전화기의 설정에서 카메라의 허가를 수동으로 변경해 주세요.";
 
-  static m118(amount, coinName) => "${amount} ${coinName} 인출";
+  static m121(amount, coinName) => "${amount} ${coinName} 인출";
 
-  static m119(amount, coin) => "당신은 ${amount} ${coin}을 받습니다";
+  static m122(amount, coin) => "당신은 ${amount} ${coin}을 받습니다";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -320,6 +326,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled":
+            MessageLookupByLibrary.simpleMessage("코인 활성화가 취소되었습니다."),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("코인 활성화"),
         "addingCoinSuccess": m4,
@@ -439,15 +447,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("코드:"),
         "cofirmCancelActivation":
             MessageLookupByLibrary.simpleMessage("활성화를 취소하시겠습니까?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("클리어"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("활성화된 코인 없음"),
         "coinSelectTitle": MessageLookupByLibrary.simpleMessage("코인 선택"),
         "coinsActivatedLimitReached":
             MessageLookupByLibrary.simpleMessage("최대 저작물 수를 선택했습니다."),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("곳 옵니다..."),
         "commingsoon": MessageLookupByLibrary.simpleMessage("TX 디테일이 곳 옵니다!"),
         "commingsoonGeneral":
@@ -472,7 +482,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactCancel": MessageLookupByLibrary.simpleMessage("취소"),
         "contactDelete": MessageLookupByLibrary.simpleMessage("연락처 삭제"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("삭제"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("버리기"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("편집"),
         "contactExit": MessageLookupByLibrary.simpleMessage("종료"),
@@ -499,7 +509,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("통관 수수료"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "당신이 무엇을 하고 있는지 알고 있는 경우에만 관세비용을 사용하세요!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW 보안"),
         "date": MessageLookupByLibrary.simpleMessage("날짜"),
         "decryptingWallet": MessageLookupByLibrary.simpleMessage("지갑 해석 중"),
@@ -511,8 +521,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteSpan3": MessageLookupByLibrary.simpleMessage(" 비활성화도 됩니다"),
         "deleteWallet": MessageLookupByLibrary.simpleMessage("지갑 삭제"),
         "deletingWallet": MessageLookupByLibrary.simpleMessage("지갑 삭제 중..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage("거래 수수료 거래 수수료 보내기"),
         "detailedFeesTradingFee":
@@ -534,7 +544,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("전 비밀번호를 원지 않습니다"),
         "duration": MessageLookupByLibrary.simpleMessage("지속시간"),
         "editContact": MessageLookupByLibrary.simpleMessage("연락처 편집"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass":
             MessageLookupByLibrary.simpleMessage("암호화 암호는 공백으로 둘 수 없습니다"),
         "emptyImportPass":
@@ -543,7 +553,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("연락처 이름은 공백으로 둘 수 없습니다"),
         "emptyWallet":
             MessageLookupByLibrary.simpleMessage("지갑 이름은 절대로 공백으로 둘 수 없습니다"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "활성화 진행 상황에 대한 업데이트를 받으려면 알림을 활성화하세요."),
@@ -574,7 +584,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("유효한 주소가 없습니다"),
         "errorNotAValidAddressSegWit":
             MessageLookupByLibrary.simpleMessage("세그윗 주소가 (아직) 지원되지 않습니다"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain": MessageLookupByLibrary.simpleMessage("에러, 다시 하세요"),
         "errorTryLater": MessageLookupByLibrary.simpleMessage("에러, 나중에 다시 하세요"),
         "errorValueEmpty":
@@ -582,32 +592,32 @@ class MessageLookup extends MessageLookupByLibrary {
         "errorValueNotEmpty":
             MessageLookupByLibrary.simpleMessage("데이터를 입력해주세요"),
         "estimateValue": MessageLookupByLibrary.simpleMessage("예상된 합계치"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -656,16 +666,17 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("아이템이 성공적으로 내보냈습니다:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("바꾸기"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("수출"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt": MessageLookupByLibrary.simpleMessage("가짜 잔고 잔액:"),
         "faqTitle": MessageLookupByLibrary.simpleMessage("자주 묻는 질문들"),
         "faucetError": MessageLookupByLibrary.simpleMessage("에러"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("호수"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("성공"),
         "faucetTimedOut": MessageLookupByLibrary.simpleMessage("요청 시간 초과"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("뉴스"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("아무것도 없습니다"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("더 읽기..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("피드"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("뉴스 피드"),
@@ -676,7 +687,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedUpToDate": MessageLookupByLibrary.simpleMessage("벌서 최신화 되어 있습니다"),
         "feedUpdated": MessageLookupByLibrary.simpleMessage("뉴스 피드가 업데이트 됬습니다"),
         "feedback": MessageLookupByLibrary.simpleMessage("로그 파일 공유"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("모두"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("필터"),
         "filtersClearAll": MessageLookupByLibrary.simpleMessage("모든 필터 지우기"),
@@ -698,9 +709,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("에서부터"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "공개 키와 관련된 활성화 후 향후 거래가 동기화됩니다. 이는 가장 빠른 옵션이며 저장 공간을 가장 적게 차지합니다."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("가스 제한"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("가스 가격"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "일반 핀 보호가 활성화되어 있지 않습니다.\n위장 모드를 사용 할 수 없습니다.\n핀 보호를 활성화 시켜주세요."),
@@ -709,7 +720,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "gettingTxWait":
             MessageLookupByLibrary.simpleMessage("거래를 받는 중입니다. 잠시 기다려 주세요."),
         "goToPorfolio": MessageLookupByLibrary.simpleMessage("포티폴리오로 가기"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("도움"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("도움 및 서포트"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("잔고 숨기기"),
@@ -756,7 +767,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError":
             MessageLookupByLibrary.simpleMessage("json파일 읽기에 에러가 났습니다"),
         "importTitle": MessageLookupByLibrary.simpleMessage("불러오기"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "보안 비밀번호를 사용하고 똑같은 장치에 저장해두지 마세요"),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -765,24 +776,24 @@ class MessageLookup extends MessageLookupByLibrary {
             "스왑은 60분까지 걸릴 수 있습니다. 이 앱플리케이션을 종료하지 마세요!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "보안 이유상 지갑 암호활를 위해 비밀번호를 입력해야 합니다"),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText":
             MessageLookupByLibrary.simpleMessage("이 주문을 하기 위한 최소 볼륨은"),
         "insufficientTitle": MessageLookupByLibrary.simpleMessage("볼륨 부족"),
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("새로 고침"),
         "internetRestored": MessageLookupByLibrary.simpleMessage("인터넷 연결 복구됨"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap": MessageLookupByLibrary.simpleMessage("스왑 진행 불가능"),
         "invalidSwapDetailsLink": MessageLookupByLibrary.simpleMessage("상세"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("일본어"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("한국인"),
         "language": MessageLookupByLibrary.simpleMessage("언어"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("마지막 거래"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("법적"),
         "less": MessageLookupByLibrary.simpleMessage("덜"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("로딩 중..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage("주문책 로딩 중..."),
         "lockScreen": MessageLookupByLibrary.simpleMessage("스크린이 잠겼습니다"),
@@ -839,11 +850,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("최소"),
         "minOrder": MessageLookupByLibrary.simpleMessage("최소 주문 볼륨"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH":
             MessageLookupByLibrary.simpleMessage("판매 양보다 적어야 합니다"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage("필요된 최소 볼륨"),
@@ -851,16 +862,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "경고: iOS에서 앱을 최소화하면 활성화 프로세스가 종료됩니다."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("더 많은 정보"),
         "moreTab": MessageLookupByLibrary.simpleMessage("더"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("양"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("코인"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("판매"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("취소"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("확인"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("생성"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("주문"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("주문들"),
@@ -873,8 +884,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("계속하기 전에 모든 에러를 고치세요"),
         "multiInvalidAmt": MessageLookupByLibrary.simpleMessage("잘못된 양"),
         "multiInvalidSellAmt": MessageLookupByLibrary.simpleMessage("잘못된 판매 양"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage("최대 판매 양은"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage("최소 받는 양은"),
         "multiMinSellAmt": MessageLookupByLibrary.simpleMessage("최소 판매 양은"),
@@ -900,7 +911,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noItemsToExport": MessageLookupByLibrary.simpleMessage("선택된 아이템 없음"),
         "noItemsToImport": MessageLookupByLibrary.simpleMessage("선택된 아이템 없음"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage("알맞는 주문 없음"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable":
             MessageLookupByLibrary.simpleMessage("주문을 만들기 위해서 눌러주세요"),
         "noOrders": MessageLookupByLibrary.simpleMessage("주문 없음, 가서 거래하세요."),
@@ -912,7 +923,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noTxs": MessageLookupByLibrary.simpleMessage("거래내역 없음"),
         "nonNumericInput": MessageLookupByLibrary.simpleMessage("값은 숫자여야 합니다"),
         "none": MessageLookupByLibrary.simpleMessage("없음"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "수수료를 위한 잔고 부족 - 더 작은 양을 거래하세요"),
         "noteOnOrder":
@@ -920,22 +931,22 @@ class MessageLookup extends MessageLookupByLibrary {
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("노트 추가"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("노트"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("찾을 수 없습니다"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("스와프 완료됨"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle": MessageLookupByLibrary.simpleMessage("스와프 실패됨"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("새로운 스와프가 시작되었습니다"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("스와프 상태가 바꿨습니다"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("스왑 시간 초과됨"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("들어오는 거래"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("공식 보도 자료"),
         "okButton": MessageLookupByLibrary.simpleMessage("네"),
@@ -945,14 +956,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("에러 메세지 열기"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("더 적은"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("더"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated": MessageLookupByLibrary.simpleMessage("주문 생성됨"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("주문이 성공적으로 생성됬습니다"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("주소"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("취소"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("위한"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("똑같은 CEX"),
@@ -965,7 +976,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "한개 탭에서 상세를 열고 긴 탭에서 주문을 선택하세요"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("소비"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("세부 사항"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("주문 매칭됨"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("주문 매칭"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("주문"),
@@ -973,9 +984,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("주문"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("활성화"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("히스토리"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("덮어쓰기"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("이것은 당신만의 주문입니다!"),
         "paidFromBalance": MessageLookupByLibrary.simpleMessage("잔액에서 지불:"),
@@ -996,8 +1007,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("코인:"),
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("취소"),
         "paymentUriDetailsTitle": MessageLookupByLibrary.simpleMessage("지불 요청"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("당신의 주문을 넣으세요"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "모든 특별 코인 활성화 요청을 수락하거나 코인 선택을 취소하세요."),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage("코인을 더해 주세요"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
             "다시하기 위해서 앱을 다시 시작하거나, 밑에 버튼을 눌러 주세요."),
@@ -1017,17 +1031,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "pubkey": MessageLookupByLibrary.simpleMessage("펍키"),
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("QR 코드 스캐너"),
         "question_1": MessageLookupByLibrary.simpleMessage("제 개인 키를 보관하나요?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3":
             MessageLookupByLibrary.simpleMessage("각각의 아토믹 스왑을 얼마나 걸리나요?"),
         "question_4":
             MessageLookupByLibrary.simpleMessage("스왑을 하는 동안 온라인에 있어야 하나요?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage("유저 지원을 공급하나요?"),
         "question_7": MessageLookupByLibrary.simpleMessage("나라 제한이 있나요?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "새로운 시대입니다! \'AtomicDEX\'에서 \'Komodo Wallet\'으로 공식 명칭을 변경하였습니다."),
         "receive": MessageLookupByLibrary.simpleMessage("받기"),
@@ -1061,7 +1075,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore":
             MessageLookupByLibrary.simpleMessage("KMD 활성화 유저 보상에 대해서 더 읽어 보기"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("받기"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("피아트"),
         "rewardsTableRewards": MessageLookupByLibrary.simpleMessage("보상,\nKMD"),
         "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("상태"),
@@ -1069,9 +1083,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsTableTitle": MessageLookupByLibrary.simpleMessage("보상 정보:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("보상 정보"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("러시아인"),
         "saveMerged": MessageLookupByLibrary.simpleMessage("병함 저장"),
@@ -1121,7 +1135,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("Ticker 찾기"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("보안"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage("거래 내역 보기"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("시드 문구"),
         "seedPhraseTitle":
@@ -1156,34 +1170,34 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("언어"),
         "settings": MessageLookupByLibrary.simpleMessage("설정"),
         "share": MessageLookupByLibrary.simpleMessage("공유"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("주소 표시"),
         "showDetails": MessageLookupByLibrary.simpleMessage("상세 보기"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("나의 주문 보기"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("비밀번호로 로그인하기"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "비밀번호를 까먹으셨나요? 지갑을 시드로부터 복구하세요"),
         "simple": MessageLookupByLibrary.simpleMessage("심플"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("활성화"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("구매"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("거이"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("받기"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("판매"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("보내기"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("덜 보기"),
         "simpleTradeShowMore": MessageLookupByLibrary.simpleMessage("더 보기"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("스킵"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("해제"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("소리"),
         "soundSettingsTitle": MessageLookupByLibrary.simpleMessage("소리 성정"),
         "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("소리들"),
@@ -1199,15 +1213,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("방법"),
         "success": MessageLookupByLibrary.simpleMessage("성공!"),
         "support": MessageLookupByLibrary.simpleMessage("지원"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("스왑"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("현재"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage("변환 상세 확인"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("견적"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("스왑 실패"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("스왑이 진행되고 있습니다"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("진행 상세"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("시작됨"),
@@ -1219,7 +1233,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "syncFromSaplingActivation":
             MessageLookupByLibrary.simpleMessage("묘목 활성화에서 동기화"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage("새 거래 동기화"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1273,22 +1287,22 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "요청이 너무 많습니다.\n거래 이력 요구 제한을 초과했습니다.\n나중에 다시 시도해주세요."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("미확인"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("우크라이나 인"),
         "unlock": MessageLookupByLibrary.simpleMessage("열기"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("펀드 열기"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("사용 불가능"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("새로운 버전 사용 가능"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage("업데이트 확인중..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable":
             MessageLookupByLibrary.simpleMessage("새로운 버전이 있습니다. 업데이트를 하세요."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle": MessageLookupByLibrary.simpleMessage("업데이트가 있습니다"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("지금은 스킵"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("벌서 업데이트 되어있습니다"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("업데이트"),
@@ -1312,9 +1326,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("네"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "경고 - 특별한 경우 이 로그 데이터에는 스왑에 실패한 코인을 사용하는 데 사용할 수 있는 중요한 정보가 포함되어 있습니다!"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("이걸 준비해 봅시다!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("환영합니다"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("지갑"),
@@ -1323,13 +1337,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "이 작업은 시간이 걸리며 앱이 포그라운드에 유지되어야 합니다.\n활성화가 진행되는 동안 앱을 종료하면 문제가 발생할 수 있습니다."),
         "withdraw": MessageLookupByLibrary.simpleMessage("인출"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("액세스 거부"),
         "withdrawConfirm": MessageLookupByLibrary.simpleMessage("인출 확인"),
         "withdrawConfirmError":
             MessageLookupByLibrary.simpleMessage("무언가 잘못 됬습니다. 나중에 다시 시도하세요."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1":
             MessageLookupByLibrary.simpleMessage("당신은 지불 QR 코드를 스캔 할려고 합니다"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("하지만 당신은"),
@@ -1346,7 +1360,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "you have an order that new orders can match with":
             MessageLookupByLibrary.simpleMessage("당신은 새로운 주문을 맞출수 있는 주문이 있습니다"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("당신은 보냅니다:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("당신은 받습니다:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("당신의 지갑")
       };

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -75,235 +75,241 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "What is the ${index} word in your seed phrase?";
 
-  static m22(protocolName) => "${protocolName} coins are activated";
+  static m22(coin) => "${coin} activation cancelled";
 
-  static m23(protocolName) => "${protocolName} coins activated successfully";
+  static m23(coin) => "Successfully activated ${coin}";
 
-  static m24(protocolName) => "${protocolName} coins are not activated";
+  static m24(protocolName) => "${protocolName} coins are activated";
 
-  static m25(name) => "Are you sure you want to delete contact ${name}?";
+  static m25(protocolName) => "${protocolName} coins activated successfully";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "${protocolName} coins are not activated";
+
+  static m27(name) => "Are you sure you want to delete contact ${name}?";
+
+  static m28(iUnderstand) =>
       "Custom seed phrases might be less secure and easier to crack than a generated BIP39 compliant seed phrase or private key (WIF). To confirm you understand the risk and know what you are doing, type \"${iUnderstand}\" in the box below.";
 
-  static m27(coinName) => "receive ${coinName} transaction fee";
+  static m29(coinName) => "receive ${coinName} transaction fee";
 
-  static m28(coinName) => "send ${coinName} transaction fee";
+  static m30(coinName) => "send ${coinName} transaction fee";
 
-  static m29(abbr) => "Input ${abbr} address";
+  static m31(abbr) => "Input ${abbr} address";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "You can still enable ${remains}, Selected: ${selected}";
 
-  static m31(gas) => "Not enough gas - use at least ${gas} Gwei";
+  static m33(gas) => "Not enough gas - use at least ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020\n\n";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to: \n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors; \n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions; \n(c) the unavailability of the application or any portion of it; \n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application. \n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}. \nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.\n\n";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. \n\n";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020\n\n";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms. \nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam. \nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile";
 
-  static m46(coin) => "Sending request to ${coin} faucet...";
+  static m48(coinAbbr) => "Failed to cancel activation of ${coinAbbr}";
 
-  static m47(appCompanyShort) => "${appCompanyShort} news";
+  static m49(coin) => "Sending request to ${coin} faucet...";
 
-  static m48(value) => "Fees must be up to ${value}";
+  static m50(appCompanyShort) => "${appCompanyShort} news";
 
-  static m49(coin) => "${coin} fee";
+  static m51(value) => "Fees must be up to ${value}";
 
-  static m50(coin) => "Please activate ${coin}.";
+  static m52(coin) => "${coin} fee";
 
-  static m51(value) => "Gwei must be up to ${value}";
+  static m53(coin) => "Please activate ${coin}.";
 
-  static m52(coinName) => "Incoming  ${coinName} txs protection settings";
+  static m54(value) => "Gwei must be up to ${value}";
 
-  static m53(abbr) => "${abbr} balance not sufficient to pay trading fee";
+  static m55(coinName) => "Incoming  ${coinName} txs protection settings";
 
-  static m54(coin) => "Invalid ${coin} address";
+  static m56(abbr) => "${abbr} balance not sufficient to pay trading fee";
 
-  static m55(coinAbbr) => "${coinAbbr} is unavailable :(";
+  static m57(coin) => "Invalid ${coin} address";
 
-  static m56(coinName) =>
+  static m58(coinAbbr) => "${coinAbbr} is unavailable :(";
+
+  static m59(coinName) =>
       "❗Caution! Market for ${coinName} has less than \$10k 24h trading-volume!";
 
-  static m57(value) => "Limit must be up to ${value}";
-
-  static m58(coinName, number) =>
-      "The minimum amount to sell is ${number} ${coinName}";
-
-  static m59(coinName, number) =>
-      "The minimum amount to buy is ${number} ${coinName}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "Order minimum amount is ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+  static m60(value) => "Limit must be up to ${value}";
 
   static m61(coinName, number) =>
+      "The minimum amount to sell is ${number} ${coinName}";
+
+  static m62(coinName, number) =>
+      "The minimum amount to buy is ${number} ${coinName}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "Order minimum amount is ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+
+  static m64(coinName, number) =>
       "The minimum amount to sell is ${number} ${coinName}";
 
-  static m62(minValue, coin) => "Must be greater than ${minValue} ${coin}";
+  static m65(minValue, coin) => "Must be greater than ${minValue} ${coin}";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "Please note that now you\'re using cellular data and participation in ${appName} P2P network consume internet traffic. It\'s better to use a WiFi network if your cellular data plan is costly.";
 
-  static m64(coin) => "Activate ${coin} and top-up balance first";
+  static m67(coin) => "Activate ${coin} and top-up balance first";
 
-  static m65(number) => "Create ${number} Order(s):";
+  static m68(number) => "Create ${number} Order(s):";
 
-  static m66(coin) => "${coin} balance is too low";
+  static m69(coin) => "${coin} balance is too low";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "Not enough ${coin} to pay fees. MIN balance is ${fee} ${coin}";
 
-  static m68(coinName) => "Please enter the ${coinName} amount.";
+  static m71(coinName) => "Please enter the ${coinName} amount.";
 
-  static m69(coin) => "Not enough ${coin} for transaction!";
+  static m72(coin) => "Not enough ${coin} for transaction!";
 
-  static m70(sell, buy) => "${sell}/${buy} swap was completed successfully";
+  static m73(sell, buy) => "${sell}/${buy} swap was completed successfully";
 
-  static m71(sell, buy) => "${sell}/${buy} swap failed";
+  static m74(sell, buy) => "${sell}/${buy} swap failed";
 
-  static m72(sell, buy) => "${sell}/${buy} swap started";
+  static m75(sell, buy) => "${sell}/${buy} swap started";
 
-  static m73(sell, buy) => "${sell}/${buy} swap was timed out";
+  static m76(sell, buy) => "${sell}/${buy} swap was timed out";
 
-  static m74(coin) => "You have received ${coin} transaction!";
+  static m77(coin) => "You have received ${coin} transaction!";
 
-  static m75(assets) => "${assets} Assets";
+  static m78(assets) => "${assets} Assets";
 
-  static m76(coin) => "All ${coin} orders will be canceled.";
+  static m79(coin) => "All ${coin} orders will be canceled.";
 
-  static m77(delta) => "Expedient: CEX +${delta}%";
+  static m80(delta) => "Expedient: CEX +${delta}%";
 
-  static m78(delta) => "Expensive: CEX ${delta}%";
+  static m81(delta) => "Expensive: CEX ${delta}%";
 
-  static m79(fill) => "${fill}% filled";
+  static m82(fill) => "${fill}% filled";
 
-  static m80(coin) => "Amt. (${coin})";
+  static m83(coin) => "Amt. (${coin})";
 
-  static m81(coin) => "Price (${coin})";
+  static m84(coin) => "Price (${coin})";
 
-  static m82(coin) => "Total (${coin})";
+  static m85(coin) => "Total (${coin})";
 
-  static m83(abbr) => "${abbr} is not active. Please activate and try again.";
+  static m86(abbr) => "${abbr} is not active. Please activate and try again.";
 
-  static m84(appName) => "Which devices can I use ${appName} on?";
-
-  static m85(appName) =>
-      "How is trading on ${appName} different from trading on other DEXs?";
-
-  static m86(appName) => "How are the fees on ${appName} calculated?";
-
-  static m87(appName) => "Who is behind ${appName}?";
+  static m87(appName) => "Which devices can I use ${appName} on?";
 
   static m88(appName) =>
+      "How is trading on ${appName} different from trading on other DEXs?";
+
+  static m89(appName) => "How are the fees on ${appName} calculated?";
+
+  static m90(appName) => "Who is behind ${appName}?";
+
+  static m91(appName) =>
       "Is it possible to develop my own white-label exchange on ${appName}?";
 
-  static m89(amount) => "Success! ${amount} KMD received.";
+  static m92(amount) => "Success! ${amount} KMD received.";
 
-  static m90(dd) => "${dd} day(s)";
+  static m93(dd) => "${dd} day(s)";
 
-  static m91(hh, minutes) => "${hh}h ${minutes}m";
+  static m94(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m92(mm) => "${mm}min";
+  static m95(mm) => "${mm}min";
 
-  static m93(amount) => "Click to see ${amount} orders";
+  static m96(amount) => "Click to see ${amount} orders";
 
-  static m94(coinName, address) => "My ${coinName} address: \n${address}";
+  static m97(coinName, address) => "My ${coinName} address: \n${address}";
 
-  static m95(coin) => "Scan for past ${coin} transactions?";
+  static m98(coin) => "Scan for past ${coin} transactions?";
 
-  static m96(count, maxCount) => "Showing ${count} of ${maxCount} orders. ";
+  static m99(count, maxCount) => "Showing ${count} of ${maxCount} orders. ";
 
-  static m97(coin) => "Please enter ${coin} amount to buy";
+  static m100(coin) => "Please enter ${coin} amount to buy";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "Max active coins number is ${maxCoins}. Please deactivate some.";
 
-  static m99(coin) => "${coin} is not active!";
+  static m102(coin) => "${coin} is not active!";
 
-  static m100(coin) => "Please enter ${coin} amount to sell";
+  static m103(coin) => "Please enter ${coin} amount to sell";
 
-  static m101(coin) => "Unable to activate ${coin}";
+  static m104(coin) => "Unable to activate ${coin}";
 
-  static m102(description) =>
+  static m105(description) =>
       "Pick an mp3 or wav file please. We\'ll play it when ${description}.";
 
-  static m103(description) => "Played when ${description}";
+  static m106(description) => "Played when ${description}";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "If you have any questions, or think you\'ve found a technical problem with the ${appName} app, you can report it and get support from our team.";
 
-  static m105(coin) => "Please activate ${coin} and top-up balance first";
+  static m108(coin) => "Please activate ${coin} and top-up balance first";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "${coin} balance not sufficient to pay transaction fees.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "${coin} balance not sufficient to pay transaction fees. ${coin} ${amount} required.";
 
-  static m108(name) => "Which ${name} transactions would you like to sync?";
+  static m111(name) => "Which ${name} transactions would you like to sync?";
 
-  static m109(left) => "Transactions Left: ${left}";
+  static m112(left) => "Transactions Left: ${left}";
 
-  static m110(amnt, hash) =>
+  static m113(amnt, hash) =>
       "Successfully unlocked ${amnt} funds - TX: ${hash}";
 
-  static m111(version) => "You are using version ${version}";
+  static m114(version) => "You are using version ${version}";
 
-  static m112(version) => "Version ${version} available. Please update.";
+  static m115(version) => "Version ${version} available. Please update.";
 
-  static m113(appName) => "${appName} update";
+  static m116(appName) => "${appName} update";
 
-  static m114(coinAbbr) => "We failed to activate ${coinAbbr}";
+  static m117(coinAbbr) => "We failed to activate ${coinAbbr}";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "We failed to activate ${coinAbbr}.\nPlease restart the app to try again.";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} mobile is a next generation multi-coin wallet with native third generation DEX functionality and more.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "You have previously denied ${appName} access to the camera.\nPlease manually change camera permission in your phone settings to proceed with the QR code scan.";
 
-  static m118(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
+  static m121(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
 
-  static m119(amount, coin) => "You will receive ${amount} ${coin}";
+  static m122(amount, coin) => "You will receive ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -331,6 +337,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled":
+            MessageLookupByLibrary.simpleMessage("Coin activation cancelled"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("Add Coin"),
         "addingCoinSuccess": m4,
@@ -471,15 +479,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Code: "),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Are you sure you want to cancel activation?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Clear"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("No active coins"),
         "coinSelectTitle": MessageLookupByLibrary.simpleMessage("Select Coin"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "You have selected the max number of assets"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("Coming soon..."),
         "commingsoon":
             MessageLookupByLibrary.simpleMessage("TX details coming soon!"),
@@ -508,7 +518,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
         "contactDelete": MessageLookupByLibrary.simpleMessage("Delete Contact"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Delete"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Discard"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Edit"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Exit"),
@@ -536,7 +546,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("Custom fee"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "Only use custom fees if you know what you are doing!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW security"),
         "date": MessageLookupByLibrary.simpleMessage("Date"),
         "decryptingWallet":
@@ -553,8 +563,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteWallet": MessageLookupByLibrary.simpleMessage("Delete Wallet"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Deleting wallet..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "send trading fee transaction fee"),
@@ -578,7 +588,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("I don\'t want a password"),
         "duration": MessageLookupByLibrary.simpleMessage("Duration"),
         "editContact": MessageLookupByLibrary.simpleMessage("Edit Contact"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "Encryption password can\'t be empty"),
         "emptyImportPass":
@@ -587,7 +597,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Contact name cannot be empty"),
         "emptyWallet": MessageLookupByLibrary.simpleMessage(
             "Wallet name must not be empty"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "Please enable notifications to get updates on the activation progress."),
@@ -624,7 +634,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Not a valid address"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Segwit addresses are not supported (yet)"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain":
             MessageLookupByLibrary.simpleMessage("Error, please try again"),
         "errorTryLater":
@@ -635,32 +645,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Please input data"),
         "estimateValue":
             MessageLookupByLibrary.simpleMessage("Estimated Total Value"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n"),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time. \n\n"),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n"),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n"),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n"),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). \n\n"),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY\n\n"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -712,19 +722,20 @@ class MessageLookup extends MessageLookupByLibrary {
             "Items have been successfully exported:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Swaps"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Export"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Fake balance amount:"),
         "faqTitle":
             MessageLookupByLibrary.simpleMessage("Frequently Asked Questions"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Error"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("FAUCET"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Success"),
         "faucetTimedOut":
             MessageLookupByLibrary.simpleMessage("Request timed out"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("News"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("Nothing here"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("Read more..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("Feed"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("News Feed"),
@@ -737,7 +748,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedUpdated":
             MessageLookupByLibrary.simpleMessage("News feed updated"),
         "feedback": MessageLookupByLibrary.simpleMessage("Share Log File"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("All"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Filter"),
         "filtersClearAll":
@@ -760,9 +771,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("From"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "We will sync future transactions made after activation associated with your public key. This is the quickest option and takes up the least amount of storage."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Gas limit"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("Gas price"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "General PIN protection is not active.\nCamouflage mode will not be available.\nPlease activate PIN protection."),
@@ -771,7 +782,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "gettingTxWait": MessageLookupByLibrary.simpleMessage(
             "Getting transaction, please wait"),
         "goToPorfolio": MessageLookupByLibrary.simpleMessage("Go to portfolio"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Help"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("Help and Support"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("Hide balances"),
@@ -823,7 +834,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError":
             MessageLookupByLibrary.simpleMessage("Error decoding json file"),
         "importTitle": MessageLookupByLibrary.simpleMessage("Import"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Use a secure password and do not store it on the same device"),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -832,7 +843,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "The swap can take up to 60 minutes. DONT close this application!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "You have to provide a password for the wallet encryption due to security reasons."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "Minumum volume required by this order is"),
         "insufficientTitle":
@@ -841,12 +852,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Refresh"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Internet Connection Restored"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Unable to proceed swap"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Details"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japanese"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Korean"),
         "language": MessageLookupByLibrary.simpleMessage("Language"),
@@ -854,8 +865,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Latest Transactions"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Legal"),
         "less": MessageLookupByLibrary.simpleMessage("Less"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Loading..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Loading orderbook..."),
@@ -921,11 +932,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder": MessageLookupByLibrary.simpleMessage("Min order volume:"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Must be lower than sell amount"),
         "minVolumeTitle":
@@ -935,17 +946,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Warning: Minimizing the app on iOS will terminate the activation process."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("More Info"),
         "moreTab": MessageLookupByLibrary.simpleMessage("More"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Amount"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Coin"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("Sell"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("Confirm"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Create"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Order"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Orders"),
@@ -960,8 +971,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Invalid amount"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Invalid sell amount"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Max sell amount is"),
         "multiMinReceiveAmt":
@@ -994,7 +1005,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("No items selected"),
         "noMatchingOrders":
             MessageLookupByLibrary.simpleMessage("No matching orders found"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable":
             MessageLookupByLibrary.simpleMessage("Click to create an order"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1009,7 +1020,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("The value must be numeric"),
         "none": MessageLookupByLibrary.simpleMessage("None"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Not enough balance for fees - trade a smaller amount"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1017,24 +1028,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("Add a Note"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("Note"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("Nothing found"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Swap completed"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Swap failed"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("New swap started"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Swap status changed"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Swap timed out"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Incoming transaction"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Official press release"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -1045,14 +1056,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Open Error Message"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Less"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("More"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated": MessageLookupByLibrary.simpleMessage("Order created"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Order successfully created"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Address"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("for"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Identical to CEX"),
@@ -1065,7 +1076,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Open Details on single tap and select Order by long tap"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Spend"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Details"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Order matched"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("Order matching"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage(" Order"),
@@ -1074,9 +1085,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("orders"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Active"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("History"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Overwrite"),
         "ownOrder":
             MessageLookupByLibrary.simpleMessage(" This is your own order!"),
@@ -1101,8 +1112,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("Cancel"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Payment Requested"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Place your order"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Please accept all special coin activation requests or deselect the coins."),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Please Add A Coin"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1126,19 +1140,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR Code Scanner"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Do you store my private keys?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "How long does each atomic swap take?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Do I need to be online for the duration of the swap?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Do you provide user support?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Do you have country restrictions?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "It\'s a new era! We have officially rebranded from \'AtomicDEX\' to \'Komodo Wallet\'"),
         "receive": MessageLookupByLibrary.simpleMessage("RECEIVE"),
@@ -1177,7 +1191,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Read more about KMD active user rewards"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Receive"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Rewards,\nKMD"),
@@ -1187,9 +1201,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rewards information:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Rewards information"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Russian"),
@@ -1242,7 +1256,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Search for Ticker"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Security"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("View Transaction History"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Seed Phrase"),
@@ -1284,36 +1298,36 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Languages"),
         "settings": MessageLookupByLibrary.simpleMessage("Settings"),
         "share": MessageLookupByLibrary.simpleMessage("Share"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("Show Address"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Show Details"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("Show My Orders"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Sign in with password"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "Forgot the password? Restore wallet from seed"),
         "simple": MessageLookupByLibrary.simpleMessage("Simple"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("Activate"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Buy"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Close"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Receive"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Sell"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Send"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Show less"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Show more"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Skip"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Dismiss"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Sound"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Sound settings"),
@@ -1330,16 +1344,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Step"),
         "success": MessageLookupByLibrary.simpleMessage("Success!"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("swap"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Current"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("CONFIRM EXCHANGE DETAILS"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Estimate"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Swap failed"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Swap ongoing"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Progress details"),
@@ -1354,7 +1368,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Sync from sapling activation"),
         "syncNewTransactions":
             MessageLookupByLibrary.simpleMessage("Sync new transactions"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1414,24 +1428,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Too many requests.\nTransactions history requests limit exceeded.\nPlease try again later."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("UNCONFIRMED"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrainian"),
         "unlock": MessageLookupByLibrary.simpleMessage("unlock"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Unlock Funds"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("unspendable"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("New version available"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Checking for updates..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "New version available. Please update."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Update available"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("Skip for now"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Already up to date"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Update"),
@@ -1457,9 +1471,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Warning - in special cases this log data contains sensitive information that can be used to spend coins from failed swaps!"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("LET\'S GET SET UP!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("WELCOME"),
@@ -1469,14 +1483,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "This will take a while and the app must be kept in the foreground.\nTerminating the app while activation is in progress could lead to issues."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Withdraw"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Access Denied"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Confirm Withdrawal"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Something went wrong. Try again later."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "You are trying to scan a payment QR code for "),
         "wrongCoinSpan2":
@@ -1498,7 +1512,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "you have an order that new orders can match with"),
         "youAreSending":
             MessageLookupByLibrary.simpleMessage("You are sending:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("You will receive: "),
         "yourWallet": MessageLookupByLibrary.simpleMessage("your wallet")

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -155,149 +155,155 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m53(abbr) => "${abbr} balance not sufficient to pay trading fee";
 
-  static m54(coinAbbr) => "${coinAbbr} is unavailable :(";
+  static m54(coin) => "Invalid ${coin} address";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} is unavailable :(";
+
+  static m56(coinName) =>
       "❗Caution! Market for ${coinName} has less than \$10k 24h trading-volume!";
 
-  static m56(value) => "Limit must be up to ${value}";
-
-  static m57(coinName, number) =>
-      "The minimum amount to sell is ${number} ${coinName}";
+  static m57(value) => "Limit must be up to ${value}";
 
   static m58(coinName, number) =>
+      "The minimum amount to sell is ${number} ${coinName}";
+
+  static m59(coinName, number) =>
       "The minimum amount to buy is ${number} ${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "Order minimum amount is ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
 
-  static m60(coinName, number) =>
+  static m61(coinName, number) =>
       "The minimum amount to sell is ${number} ${coinName}";
 
-  static m61(minValue, coin) => "Must be greater than ${minValue} ${coin}";
+  static m62(minValue, coin) => "Must be greater than ${minValue} ${coin}";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "Please note that now you\'re using cellular data and participation in ${appName} P2P network consume internet traffic. It\'s better to use a WiFi network if your cellular data plan is costly.";
 
-  static m63(coin) => "Activate ${coin} and top-up balance first";
+  static m64(coin) => "Activate ${coin} and top-up balance first";
 
-  static m64(number) => "Create ${number} Order(s):";
+  static m65(number) => "Create ${number} Order(s):";
 
-  static m65(coin) => "${coin} balance is too low";
+  static m66(coin) => "${coin} balance is too low";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "Not enough ${coin} to pay fees. MIN balance is ${fee} ${coin}";
 
-  static m67(coinName) => "Please enter the ${coinName} amount.";
+  static m68(coinName) => "Please enter the ${coinName} amount.";
 
-  static m68(coin) => "Not enough ${coin} for transaction!";
+  static m69(coin) => "Not enough ${coin} for transaction!";
 
-  static m69(sell, buy) => "${sell}/${buy} swap was completed successfully";
+  static m70(sell, buy) => "${sell}/${buy} swap was completed successfully";
 
-  static m70(sell, buy) => "${sell}/${buy} swap failed";
+  static m71(sell, buy) => "${sell}/${buy} swap failed";
 
-  static m71(sell, buy) => "${sell}/${buy} swap started";
+  static m72(sell, buy) => "${sell}/${buy} swap started";
 
-  static m72(sell, buy) => "${sell}/${buy} swap was timed out";
+  static m73(sell, buy) => "${sell}/${buy} swap was timed out";
 
-  static m73(coin) => "You have received ${coin} transaction!";
+  static m74(coin) => "You have received ${coin} transaction!";
 
-  static m74(assets) => "${assets} Assets";
+  static m75(assets) => "${assets} Assets";
 
-  static m75(coin) => "All ${coin} orders will be canceled.";
+  static m76(coin) => "All ${coin} orders will be canceled.";
 
-  static m76(delta) => "Expedient: CEX +${delta}%";
+  static m77(delta) => "Expedient: CEX +${delta}%";
 
-  static m77(delta) => "Expensive: CEX ${delta}%";
+  static m78(delta) => "Expensive: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% filled";
+  static m79(fill) => "${fill}% filled";
 
-  static m79(coin) => "Amt. (${coin})";
+  static m80(coin) => "Amt. (${coin})";
 
-  static m80(coin) => "Price (${coin})";
+  static m81(coin) => "Price (${coin})";
 
-  static m81(coin) => "Total (${coin})";
+  static m82(coin) => "Total (${coin})";
 
-  static m82(abbr) => "${abbr} is not active. Please activate and try again.";
+  static m83(abbr) => "${abbr} is not active. Please activate and try again.";
 
-  static m83(appName) => "Which devices can I use ${appName} on?";
+  static m84(appName) => "Which devices can I use ${appName} on?";
 
-  static m84(appName) =>
+  static m85(appName) =>
       "How is trading on ${appName} different from trading on other DEXs?";
 
-  static m85(appName) => "How are the fees on ${appName} calculated?";
+  static m86(appName) => "How are the fees on ${appName} calculated?";
 
-  static m86(appName) => "Who is behind ${appName}?";
+  static m87(appName) => "Who is behind ${appName}?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "Is it possible to develop my own white-label exchange on ${appName}?";
 
-  static m88(amount) => "Success! ${amount} KMD received.";
+  static m89(amount) => "Success! ${amount} KMD received.";
 
-  static m89(dd) => "${dd} day(s)";
+  static m90(dd) => "${dd} day(s)";
 
-  static m90(hh, minutes) => "${hh}h ${minutes}m";
+  static m91(hh, minutes) => "${hh}h ${minutes}m";
 
-  static m91(mm) => "${mm}min";
+  static m92(mm) => "${mm}min";
 
-  static m92(amount) => "Click to see ${amount} orders";
+  static m93(amount) => "Click to see ${amount} orders";
 
-  static m93(coinName, address) => "My ${coinName} address: \n${address}";
+  static m94(coinName, address) => "My ${coinName} address: \n${address}";
 
-  static m94(count, maxCount) => "Showing ${count} of ${maxCount} orders. ";
+  static m95(coin) => "Scan for past ${coin} transactions?";
 
-  static m95(coin) => "Please enter ${coin} amount to buy";
+  static m96(count, maxCount) => "Showing ${count} of ${maxCount} orders. ";
 
-  static m96(maxCoins) =>
+  static m97(coin) => "Please enter ${coin} amount to buy";
+
+  static m98(maxCoins) =>
       "Max active coins number is ${maxCoins}. Please deactivate some.";
 
-  static m97(coin) => "${coin} is not active!";
+  static m99(coin) => "${coin} is not active!";
 
-  static m98(coin) => "Please enter ${coin} amount to sell";
+  static m100(coin) => "Please enter ${coin} amount to sell";
 
-  static m99(coin) => "Unable to activate ${coin}";
+  static m101(coin) => "Unable to activate ${coin}";
 
-  static m100(description) =>
+  static m102(description) =>
       "Pick an mp3 or wav file please. We\'ll play it when ${description}.";
 
-  static m101(description) => "Played when ${description}";
+  static m103(description) => "Played when ${description}";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "If you have any questions, or think you\'ve found a technical problem with the ${appName} app, you can report it and get support from our team.";
 
-  static m103(coin) => "Please activate ${coin} and top-up balance first";
+  static m105(coin) => "Please activate ${coin} and top-up balance first";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "${coin} balance not sufficient to pay transaction fees.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "${coin} balance not sufficient to pay transaction fees. ${coin} ${amount} required.";
 
-  static m106(left) => "Transactions Left: ${left}";
+  static m108(name) => "Which ${name} transactions would you like to sync?";
 
-  static m107(amnt, hash) =>
+  static m109(left) => "Transactions Left: ${left}";
+
+  static m110(amnt, hash) =>
       "Successfully unlocked ${amnt} funds - TX: ${hash}";
 
-  static m108(version) => "You are using version ${version}";
+  static m111(version) => "You are using version ${version}";
 
-  static m109(version) => "Version ${version} available. Please update.";
+  static m112(version) => "Version ${version} available. Please update.";
 
-  static m110(appName) => "${appName} update";
+  static m113(appName) => "${appName} update";
 
-  static m111(coinAbbr) => "We failed to activate ${coinAbbr}";
+  static m114(coinAbbr) => "We failed to activate ${coinAbbr}";
 
-  static m112(coinAbbr) =>
+  static m115(coinAbbr) =>
       "We failed to activate ${coinAbbr}.\nPlease restart the app to try again.";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "${appName} mobile is a next generation multi-coin wallet with native third generation DEX functionality and more.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "You have previously denied ${appName} access to the camera.\nPlease manually change camera permission in your phone settings to proceed with the QR code scan.";
 
-  static m115(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
+  static m118(amount, coinName) => "WITHDRAW ${amount} ${coinName}";
 
-  static m116(amount, coin) => "You will receive ${amount} ${coin}";
+  static m119(amount, coin) => "You will receive ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -344,6 +350,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Recipients address"),
         "advanced": MessageLookupByLibrary.simpleMessage("Advanced"),
         "all": MessageLookupByLibrary.simpleMessage("All"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "Your wallet will show any past transactions. This will take significant storage and time as all blocks will be downloaded and scanned."),
         "allowCustomSeed":
             MessageLookupByLibrary.simpleMessage("Allow custom seed"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("Already exists"),
@@ -412,6 +420,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup":
             MessageLookupByLibrary.simpleMessage("Camouflage PIN Setup"),
         "cancel": MessageLookupByLibrary.simpleMessage("Cancel"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Cancel Activation"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Are you sure you want to cancel activation?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("Cancel"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("Cancel Order"),
         "candleChartError": MessageLookupByLibrary.simpleMessage(
@@ -457,6 +469,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Close Error Message"),
         "closePreview": MessageLookupByLibrary.simpleMessage("Close preview"),
         "code": MessageLookupByLibrary.simpleMessage("Code: "),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Are you sure you want to cancel activation?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Clear"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("No active coins"),
@@ -744,6 +758,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("Found QR Code"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("French"),
         "from": MessageLookupByLibrary.simpleMessage("From"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "We will sync future transactions made after activation associated with your public key. This is the quickest option and takes up the least amount of storage."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Gas limit"),
         "gasNotActive": m50,
@@ -825,11 +841,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Refresh"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Internet Connection Restored"),
+        "invalidCoinAddress": m54,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Unable to proceed swap"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Details"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japanese"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Korean"),
         "language": MessageLookupByLibrary.simpleMessage("Language"),
@@ -837,8 +854,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Latest Transactions"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Legal"),
         "less": MessageLookupByLibrary.simpleMessage("Less"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Loading..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Loading orderbook..."),
@@ -904,11 +921,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("MIN"),
         "minOrder": MessageLookupByLibrary.simpleMessage("Min order volume:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Must be lower than sell amount"),
         "minVolumeTitle":
@@ -918,17 +935,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Warning: Minimizing the app on iOS will terminate the activation process."),
         "minutes": MessageLookupByLibrary.simpleMessage("m"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("More Info"),
         "moreTab": MessageLookupByLibrary.simpleMessage("More"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Amount"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Coin"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("Sell"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("Confirm"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Create"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Order"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Orders"),
@@ -943,8 +960,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Invalid amount"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Invalid sell amount"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Max sell amount is"),
         "multiMinReceiveAmt":
@@ -977,7 +994,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("No items selected"),
         "noMatchingOrders":
             MessageLookupByLibrary.simpleMessage("No matching orders found"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable":
             MessageLookupByLibrary.simpleMessage("Click to create an order"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -992,7 +1009,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("The value must be numeric"),
         "none": MessageLookupByLibrary.simpleMessage("None"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Not enough balance for fees - trade a smaller amount"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1000,24 +1017,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("Add a Note"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("Note"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("Nothing found"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Swap completed"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Swap failed"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("New swap started"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Swap status changed"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Swap timed out"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Incoming transaction"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Official press release"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ok"),
@@ -1028,14 +1045,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Open Error Message"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Less"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("More"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated": MessageLookupByLibrary.simpleMessage("Order created"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Order successfully created"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Address"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Cancel"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("for"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Identical to CEX"),
@@ -1048,7 +1065,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Open Details on single tap and select Order by long tap"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Spend"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Details"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Order matched"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("Order matching"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage(" Order"),
@@ -1057,9 +1074,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("orders"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Active"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("History"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Overwrite"),
         "ownOrder":
             MessageLookupByLibrary.simpleMessage(" This is your own order!"),
@@ -1070,6 +1087,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Paid with "),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "Password must contain at least 12 characters, with one lower-case, one upper-case and one special symbol."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "Your wallet will show your past transactions made after the specified date."),
         "paymentUriDetailsAccept": MessageLookupByLibrary.simpleMessage("Pay"),
         "paymentUriDetailsAcceptQuestion": MessageLookupByLibrary.simpleMessage(
             "Do you accept this transaction?"),
@@ -1082,7 +1101,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("Cancel"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Payment Requested"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Place your order"),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Please Add A Coin"),
@@ -1107,21 +1126,21 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR Code Scanner"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Do you store my private keys?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "How long does each atomic swap take?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Do I need to be online for the duration of the swap?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Do you provide user support?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Do you have country restrictions?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
-            "It\'s a new era! We have officially changed our name from \'AtomicDEX\' to \'Komodo Wallet\'"),
+            "It\'s a new era! We have officially rebranded from \'AtomicDEX\' to \'Komodo Wallet\'"),
         "receive": MessageLookupByLibrary.simpleMessage("RECEIVE"),
         "receiveLower": MessageLookupByLibrary.simpleMessage("Receive"),
         "recommendSeedMessage": MessageLookupByLibrary.simpleMessage(
@@ -1158,7 +1177,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Read more about KMD active user rewards"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Receive"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Fiat"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Rewards,\nKMD"),
@@ -1168,9 +1187,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rewards information:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Rewards information"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Russian"),
@@ -1223,7 +1242,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Search for Ticker"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Security"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("View Transaction History"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Seed Phrase"),
@@ -1238,6 +1257,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Select the coin you want to BUY"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "Select the coin you want to SELL"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("Select a Date"),
         "selectFileImport": MessageLookupByLibrary.simpleMessage("Select file"),
         "selectLanguage":
             MessageLookupByLibrary.simpleMessage("Select Language"),
@@ -1264,35 +1284,36 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Languages"),
         "settings": MessageLookupByLibrary.simpleMessage("Settings"),
         "share": MessageLookupByLibrary.simpleMessage("Share"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("Show Address"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Show Details"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("Show My Orders"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Sign in with password"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
             "Forgot the password? Restore wallet from seed"),
         "simple": MessageLookupByLibrary.simpleMessage("Simple"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("Activate"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Buy"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Close"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Receive"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Sell"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Send"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Show less"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Show more"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Skip"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Dismiss"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Sound"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Sound settings"),
@@ -1304,20 +1325,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Note that you can set your custom sounds in application settings."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("Spanish"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Start Date"),
         "startSwap": MessageLookupByLibrary.simpleMessage("Start Swap"),
         "step": MessageLookupByLibrary.simpleMessage("Step"),
         "success": MessageLookupByLibrary.simpleMessage("Success!"),
         "support": MessageLookupByLibrary.simpleMessage("Support"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("swap"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Current"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("CONFIRM EXCHANGE DETAILS"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Estimate"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Swap failed"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Swap ongoing"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Progress details"),
@@ -1326,6 +1348,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Total"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("Swap UUID"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Switch Theme"),
+        "syncFromDate":
+            MessageLookupByLibrary.simpleMessage("Sync from specified date"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Sync from sapling activation"),
+        "syncNewTransactions":
+            MessageLookupByLibrary.simpleMessage("Sync new transactions"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1385,24 +1414,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Too many requests.\nTransactions history requests limit exceeded.\nPlease try again later."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("UNCONFIRMED"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrainian"),
         "unlock": MessageLookupByLibrary.simpleMessage("unlock"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Unlock Funds"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("unspendable"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("New version available"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Checking for updates..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "New version available. Please update."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Update available"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("Skip for now"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Already up to date"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Update"),
@@ -1428,9 +1457,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ok"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Warning - in special cases this log data contains sensitive information that can be used to spend coins from failed swaps!"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("LET\'S GET SET UP!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("WELCOME"),
@@ -1440,14 +1469,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "This will take a while and the app must be kept in the foreground.\nTerminating the app while activation is in progress could lead to issues."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Withdraw"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Access Denied"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Confirm Withdrawal"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Something went wrong. Try again later."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "You are trying to scan a payment QR code for "),
         "wrongCoinSpan2":
@@ -1469,7 +1498,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "you have an order that new orders can match with"),
         "youAreSending":
             MessageLookupByLibrary.simpleMessage("You are sending:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("You will receive: "),
         "yourWallet": MessageLookupByLibrary.simpleMessage("your wallet")

--- a/lib/l10n/messages_ru.dart
+++ b/lib/l10n/messages_ru.dart
@@ -155,151 +155,157 @@ class MessageLookup extends MessageLookupByLibrary {
   static m53(abbr) =>
       "${abbr} недостаточно баланса чтобы оплатить торговую комиссию";
 
-  static m54(coinAbbr) => "${coinAbbr} недоступен :(";
+  static m54(coin) => "Неверный адрес ${coin}";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} недоступен :(";
+
+  static m56(coinName) =>
       "❗Осторожно! Объем торгов на рынке ${coinName} за 24 часа составляет менее 10 000 долларов!";
 
-  static m56(value) => "Лимит должен быть до ${value}";
-
-  static m57(coinName, number) =>
-      "Минимальная сумма продажи составляет ${number} ${coinName}.";
+  static m57(value) => "Лимит должен быть до ${value}";
 
   static m58(coinName, number) =>
+      "Минимальная сумма продажи составляет ${number} ${coinName}.";
+
+  static m59(coinName, number) =>
       "Минимальная сумма покупки: ${number} ${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "Минимальная сумма ордера ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
 
-  static m60(coinName, number) =>
+  static m61(coinName, number) =>
       "Минимальная сумма на продажу ${number} ${coinName}";
 
-  static m61(minValue, coin) => "Должно быть больше чем ${minValue} ${coin}";
+  static m62(minValue, coin) => "Должно быть больше чем ${minValue} ${coin}";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "Обратите внимание, что теперь вы используете сотовые данные, а участие в P2P-сети ${appName} потребляет интернет-трафик. Лучше использовать сеть Wi-Fi, если ваш тарифный план сотовой связи является дорогостоящим.";
 
-  static m63(coin) => "Активируйте ${coin} и пополните баланс";
+  static m64(coin) => "Активируйте ${coin} и пополните баланс";
 
-  static m64(number) => "Создать ${number} ордер(ов):";
+  static m65(number) => "Создать ${number} ордер(ов):";
 
-  static m65(coin) => "${coin} баланс очень низкий";
+  static m66(coin) => "${coin} баланс очень низкий";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "Недостаточно ${coin} чтобы оплатить налог. МИН баланс ${fee} ${coin}";
 
-  static m67(coinName) => "Пожалуйста, введите сумму ${coinName}.";
+  static m68(coinName) => "Пожалуйста, введите сумму ${coinName}.";
 
-  static m68(coin) => "Не достаточно ${coin} для транзакции!";
+  static m69(coin) => "Не достаточно ${coin} для транзакции!";
 
-  static m69(sell, buy) => "Своп ${sell}/${buy} успешно завершен";
+  static m70(sell, buy) => "Своп ${sell}/${buy} успешно завершен";
 
-  static m70(sell, buy) => "Своп ${sell}/${buy} не прошел";
+  static m71(sell, buy) => "Своп ${sell}/${buy} не прошел";
 
-  static m71(sell, buy) => "Своп ${sell}/${buy} начат";
+  static m72(sell, buy) => "Своп ${sell}/${buy} начат";
 
-  static m72(sell, buy) => "Превышен тайм-аут свопа ${sell}/${buy}";
+  static m73(sell, buy) => "Превышен тайм-аут свопа ${sell}/${buy}";
 
-  static m73(coin) => "Вы получили ${coin} транзакцию";
+  static m74(coin) => "Вы получили ${coin} транзакцию";
 
-  static m74(assets) => "${assets} Активов";
+  static m75(assets) => "${assets} Активов";
 
-  static m75(coin) => "Все ${coin} ордеры будут отменены.";
+  static m76(coin) => "Все ${coin} ордеры будут отменены.";
 
-  static m76(delta) => "На -${delta}% ниже цен CEX";
+  static m77(delta) => "На -${delta}% ниже цен CEX";
 
-  static m77(delta) => "На +${delta}% выше цен CEX";
+  static m78(delta) => "На +${delta}% выше цен CEX";
 
-  static m78(fill) => "${fill}% заполнено";
+  static m79(fill) => "${fill}% заполнено";
 
-  static m79(coin) => "Сумма (${coin})";
+  static m80(coin) => "Сумма (${coin})";
 
-  static m80(coin) => "Цена (${coin})";
+  static m81(coin) => "Цена (${coin})";
 
-  static m81(coin) => "Всего (${coin})";
+  static m82(coin) => "Всего (${coin})";
 
-  static m82(abbr) =>
+  static m83(abbr) =>
       "${abbr} не активен. Пожалуйста активируйте и попробуйте снова.";
 
-  static m83(appName) => "На каких устройствах я могу использовать ${appName}?";
+  static m84(appName) => "На каких устройствах я могу использовать ${appName}?";
 
-  static m84(appName) =>
+  static m85(appName) =>
       "Чем торговля на ${appName} отличается от торговли на других DEX?";
 
-  static m85(appName) => "Как рассчитываются комиссии на ${appName}?";
+  static m86(appName) => "Как рассчитываются комиссии на ${appName}?";
 
-  static m86(appName) => "Кто стоит за ${appName}?";
+  static m87(appName) => "Кто стоит за ${appName}?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "Можно ли разработать собственную white-label биржу на технологии ${appName}?";
 
-  static m88(amount) => "Получено ${amount} KMD.";
+  static m89(amount) => "Получено ${amount} KMD.";
 
-  static m89(dd) => "${dd} дней}";
+  static m90(dd) => "${dd} дней}";
 
-  static m90(hh, minutes) => "${hh}ч ${minutes}мин";
+  static m91(hh, minutes) => "${hh}ч ${minutes}мин";
 
-  static m91(mm) => "мин ${mm}";
+  static m92(mm) => "мин ${mm}";
 
-  static m92(amount) => "Нажмите, чтобы увидеть ${amount} ордеров";
+  static m93(amount) => "Нажмите, чтобы увидеть ${amount} ордеров";
 
-  static m93(coinName, address) => "Мой ${coinName} адрес:\n${address}";
+  static m94(coinName, address) => "Мой ${coinName} адрес:\n${address}";
 
-  static m94(count, maxCount) => "Показано ${count} из ${maxCount} заказов.";
+  static m95(coin) => "Сканировать прошлые транзакции с ${coin}?";
 
-  static m95(coin) => "Пожалуйста введите сумму ${coin} для покупки";
+  static m96(count, maxCount) => "Показано ${count} из ${maxCount} заказов.";
 
-  static m96(maxCoins) =>
+  static m97(coin) => "Пожалуйста введите сумму ${coin} для покупки";
+
+  static m98(maxCoins) =>
       "Максимальное количество активных монет: ${maxCoins}. Пожалуйста деактивируйте некоторые из них.";
 
-  static m97(coin) => "${coin} не активна";
+  static m99(coin) => "${coin} не активна";
 
-  static m98(coin) => "Пожалуйста введите сумму ${coin} для продажи";
+  static m100(coin) => "Пожалуйста введите сумму ${coin} для продажи";
 
-  static m99(coin) => "Не удалось активировать ${coin}";
+  static m101(coin) => "Не удалось активировать ${coin}";
 
-  static m100(description) =>
+  static m102(description) =>
       "Выберите файл в формате mp3 или wav. Воспроизводится, когда ${description}.";
 
-  static m101(description) => "Воспроизводится, когда ${description}";
+  static m103(description) => "Воспроизводится, когда ${description}";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "Если у вас есть какие-либо вопросы или вы считаете, что обнаружили техническую проблему с приложением ${appName}, вы можете сообщить об этом и получить поддержку от нашей команды.";
 
-  static m103(coin) =>
+  static m105(coin) =>
       "Пожалуйста сначала активируйте ${coin} и пополните баланс";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "Баланс ${coin} недостаточен для оплаты комиссии за транзакцию.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "Баланс ${coin} недостаточен для оплаты комиссии за транзакцию. ${coin} ${amount} требуется.";
 
-  static m106(left) => "Осталось транзакций: ${left}";
+  static m108(name) => "Какие транзакции ${name} вы хотите синхронизировать?";
 
-  static m107(amnt, hash) =>
+  static m109(left) => "Осталось транзакций: ${left}";
+
+  static m110(amnt, hash) =>
       "Успешно разблокировано ${amnt} средств - TX: ${hash}";
 
-  static m108(version) => "Установлена версия ${version}";
+  static m111(version) => "Установлена версия ${version}";
 
-  static m109(version) => "Доступна версия ${version}. Пожалуйста, обновитесь.";
+  static m112(version) => "Доступна версия ${version}. Пожалуйста, обновитесь.";
 
-  static m110(appName) => "Обновление ${appName}";
+  static m113(appName) => "Обновление ${appName}";
 
-  static m111(coinAbbr) => "Ошибка активации ${coinAbbr}";
+  static m114(coinAbbr) => "Ошибка активации ${coinAbbr}";
 
-  static m112(coinAbbr) =>
+  static m115(coinAbbr) =>
       "Ошибка активации ${coinAbbr}\nПожалуйста перезапустите приложение и попробуйте снова";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "${appName} mobile - это мульти-монетный кошелек с функциональностью DEX третьего поколения и многим другим.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "Ранее вы запретили ${appName} доступ к камере.\nВручную измените разрешения для камеры в настройках телефона, чтобы продолжить сканирование QR-кода.";
 
-  static m115(amount, coinName) => "ВЫВЕСТИ ${amount} ${coinName}";
+  static m118(amount, coinName) => "ВЫВЕСТИ ${amount} ${coinName}";
 
-  static m116(amount, coin) => "Вы получите ${amount} ${coin}";
+  static m119(amount, coin) => "Вы получите ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -345,6 +351,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("Адрес получателя"),
         "advanced": MessageLookupByLibrary.simpleMessage("Расширенные"),
         "all": MessageLookupByLibrary.simpleMessage("Все"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "Ваш кошелек покажет все прошлые транзакции. Это потребует значительного объема памяти и времени, поскольку все блоки будут загружены и отсканированы."),
         "allowCustomSeed": MessageLookupByLibrary.simpleMessage(
             "Разрешить произвольный seed-ключ"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("Уже существует"),
@@ -418,6 +426,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup": MessageLookupByLibrary.simpleMessage(
             "Установить маскировочный PIN"),
         "cancel": MessageLookupByLibrary.simpleMessage("отменить"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Отменить активацию"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Вы уверены, что хотите отменить активацию?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("отменить"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("Отменить Ордер"),
         "candleChartError": MessageLookupByLibrary.simpleMessage(
@@ -463,6 +475,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closePreview":
             MessageLookupByLibrary.simpleMessage("Закрыть предпросмотр"),
         "code": MessageLookupByLibrary.simpleMessage("Код:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Вы уверены, что хотите отменить активацию?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Очистить"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Нет активных монет"),
@@ -759,6 +773,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("Найден QR-код"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("Французский"),
         "from": MessageLookupByLibrary.simpleMessage("Из"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "Мы будем синхронизировать будущие транзакции, совершенные после активации, связанные с вашим открытым ключом. Это самый быстрый вариант и занимает меньше всего места."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Лимит газа"),
         "gasNotActive": m50,
@@ -841,11 +857,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Обновить"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Соединение с интернетом восстановлено"),
+        "invalidCoinAddress": m54,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Невозможно продолжить своп"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Подробнее"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Японский"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Корейский"),
         "language": MessageLookupByLibrary.simpleMessage("Язык"),
@@ -853,8 +870,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Последние Транзакции"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Легальные аспекты"),
         "less": MessageLookupByLibrary.simpleMessage("Меньше"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Загрузка..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Загрузка книги ордеров..."),
@@ -926,11 +943,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("МИН"),
         "minOrder":
             MessageLookupByLibrary.simpleMessage("Минимальные объем ордера"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Должно быть меньше чем сумма продажи"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -940,10 +957,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Предупреждение: сворачивание приложения на iOS приведет к прекращению процесса активации."),
         "minutes": MessageLookupByLibrary.simpleMessage("мин"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Больше информации"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Ещё"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Сумма"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Монета"),
@@ -951,7 +968,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Отменить"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Подтвердить"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Создать"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Ордер"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Ордеры"),
@@ -966,8 +983,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Некорректная сумма"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Неверная сумма продажи"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Макс сумма к продаже"),
         "multiMinReceiveAmt":
@@ -1002,7 +1019,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ничего не выбрано"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Совпадающих ордеров не найдено"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Нажмите, чтобы создать ордер"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1017,7 +1034,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput": MessageLookupByLibrary.simpleMessage(
             "Значение должно быть указано в цифрах"),
         "none": MessageLookupByLibrary.simpleMessage("Никто"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Недостаточно баланса для комиссий - выполните сделку на меньшую сумму"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1027,24 +1044,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Заметка"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Ничего не найдено"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Своп завершен"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Своп не был завершен"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Новый своп начался"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Статус свопа изменен"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Превышен тайм-аут свопа"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Входящая транзакция"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Официальный пресс-релиз"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ок"),
@@ -1056,14 +1073,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Открыть сообщение об ошибке"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Меньше"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Более"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated": MessageLookupByLibrary.simpleMessage("Ордер создан"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Ордер успешно создан"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Адрес"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Отменить"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("на"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Совпадает с СЕХ"),
@@ -1078,7 +1095,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Отправьте"),
         "orderDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Подробности"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Сделка найдена"),
         "orderMatching":
             MessageLookupByLibrary.simpleMessage("Поиск сделки в процессе"),
@@ -1088,9 +1105,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("ордера"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Активные"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("История"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Перезаписать"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("Это ваш ордер!"),
         "paidFromBalance":
@@ -1100,6 +1117,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Оплачено c"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "Пароль должен содержать не менее 12 символов, включая один строчный, один заглавный и один специальный символ."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "Ваш кошелек покажет ваши прошлые транзакции, совершенные после указанной даты."),
         "paymentUriDetailsAccept":
             MessageLookupByLibrary.simpleMessage("Оплата"),
         "paymentUriDetailsAcceptQuestion": MessageLookupByLibrary.simpleMessage(
@@ -1114,7 +1133,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Отмена:"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Оплата запрошена"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Разместить ордер"),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Пожалуйста добавьте монету"),
@@ -1138,19 +1157,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("Сканер QR-кода"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Вы храните мои приватные ключи?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Сколько времени занимает каждый атомарный своп?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Необходимо ли мне быть в сети во время свопа?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Предоставляете ли вы поддержку пользователей?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Есть ли у вас какие-либо географические ограничения?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Это новая эра! Мы официально изменили наше название с «AtomicDEX» на «Komodo Wallet»."),
         "receive": MessageLookupByLibrary.simpleMessage("ПОЛУЧИТЬ"),
@@ -1190,7 +1209,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Узнать больше о KMD вознаграждениях"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Получить"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Фиат"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Вознаграждений\nKMD"),
@@ -1199,9 +1218,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsTableTitle":
             MessageLookupByLibrary.simpleMessage("Инфо о вознаграждениях:"),
         "rewardsTableUXTO": MessageLookupByLibrary.simpleMessage("UTXO,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Инфо о вознаграждениях:"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Русский"),
@@ -1254,7 +1273,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("Найти Тикер"),
         "seconds": MessageLookupByLibrary.simpleMessage("сек"),
         "security": MessageLookupByLibrary.simpleMessage("Безопасность"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("Показать историю транзакций"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Seed Фраза"),
@@ -1269,6 +1288,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Выберите монету, которую хотите купить"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "Выберите монету, которую хотите продать"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("Выберите дату"),
         "selectFileImport":
             MessageLookupByLibrary.simpleMessage("Выбрать файл"),
         "selectLanguage": MessageLookupByLibrary.simpleMessage("Выбрать Язык"),
@@ -1294,12 +1314,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Языки"),
         "settings": MessageLookupByLibrary.simpleMessage("Настройки"),
         "share": MessageLookupByLibrary.simpleMessage("ПОДЕЛИТЬСЯ"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("Показать адрес"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Показать детали"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("ПОКАЗАТЬ МОИ ОРДЕРЫ"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Войти с паролем"),
         "signInWithSeedPhrase":
@@ -1307,23 +1328,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Просто"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Активировать"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Купить"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Закрыть"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Получить"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Продать"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Отправить"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("Скрыть"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Показать больше"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Пропустить"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Убрать"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Звук"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Настройки звука"),
@@ -1335,20 +1356,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Обратите внимание что вы можете установить свои собственные звуки в настройках приложения."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("Испанский"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Дата начала"),
         "startSwap": MessageLookupByLibrary.simpleMessage("Начать обмен"),
         "step": MessageLookupByLibrary.simpleMessage("Шаг"),
         "success": MessageLookupByLibrary.simpleMessage("Успех!"),
         "support": MessageLookupByLibrary.simpleMessage("Поддержка"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("обмен"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Текущий"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("ПОДТВЕРДИТЕ ДЕТАЛИ ОБМЕНА"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("прибл"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Обмен не удался"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Обмен в процессе"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Детали прогресса"),
@@ -1357,6 +1379,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Всего"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("UUID обмена"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Переключить тему"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Синхронизировать с указанной даты"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Синхронизация с активацией саженца"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Синхронизировать новые транзакции"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1371,7 +1400,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "tagQRC20": MessageLookupByLibrary.simpleMessage("QRC20"),
         "tagSBCH": MessageLookupByLibrary.simpleMessage("SBCH"),
         "tagUBQ": MessageLookupByLibrary.simpleMessage("UBQ"),
-        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ЖТЛК"),
+        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ZHTLC"),
         "takerOrder": MessageLookupByLibrary.simpleMessage("Ордер Тейкера"),
         "timeOut": MessageLookupByLibrary.simpleMessage("Таймаут"),
         "titleCreatePassword":
@@ -1417,26 +1446,26 @@ class MessageLookup extends MessageLookupByLibrary {
             "Слишком много запросов.\nПревышен лимит запросов истории транзакций.\nПовторите попытку позже."),
         "txNotConfirmed":
             MessageLookupByLibrary.simpleMessage("НЕПОДТВЕРЖДЕНА"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Украинский"),
         "unlock": MessageLookupByLibrary.simpleMessage("разблокировать"),
         "unlockFunds":
             MessageLookupByLibrary.simpleMessage("Разблокировать средства"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable":
             MessageLookupByLibrary.simpleMessage("неизрасходованный"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Доступна новая версия"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Проверка обновлений..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Доступна новая версия. Пожалуйста, обновитесь."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Доступно обновление"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("Пропустить"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage(
             "Установлена последняя версия"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Обновление"),
@@ -1462,9 +1491,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("OK"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Предупреждение - в особых случаях логи могут содержать конфиденциальную информацию, которую можно использовать для доступа к монетам из незавершенных свопов!"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("ДАВАЙТЕ ВСЕ НАСТРОИМ!"),
         "welcomeTitle":
@@ -1475,14 +1504,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Это займет некоторое время, и приложение должно оставаться на переднем плане.\nЗакрытие приложения во время активации может привести к проблемам."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Вывести"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Доступ запрещен"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Подтвердите вывод"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Что-то пошло не так. Попробуйте позже."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Вы пытаетесь сканировать QR code для оплаты"),
         "wrongCoinSpan2":
@@ -1505,7 +1534,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "у вас есть ордер, которому могут соответствовать новые ордеры"),
         "youAreSending":
             MessageLookupByLibrary.simpleMessage("Вы отправляете:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("Вы получите:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("ваш кошелек")
       };

--- a/lib/l10n/messages_ru.dart
+++ b/lib/l10n/messages_ru.dart
@@ -76,236 +76,242 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "Какое ${index} слово в вашем seed-ключе?";
 
-  static m22(protocolName) => "Монеты ${protocolName} активированы";
+  static m22(coin) => "Активация ${coin} отменена";
 
-  static m23(protocolName) => "Монеты ${protocolName} успешно активированы";
+  static m23(coin) => "Успешно активирована ${coin}";
 
-  static m24(protocolName) => "Монеты ${protocolName} не активированы";
+  static m24(protocolName) => "Монеты ${protocolName} активированы";
 
-  static m25(name) => "Вы уверены, что хотите удалить ${name}?";
+  static m25(protocolName) => "Монеты ${protocolName} успешно активированы";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "Монеты ${protocolName} не активированы";
+
+  static m27(name) => "Вы уверены, что хотите удалить ${name}?";
+
+  static m28(iUnderstand) =>
       "Пользовательские исходные фразы могут быть менее безопасными и их легче взломать, чем сгенерированные исходные фразы или закрытый ключ (WIF), совместимые с BIP39. Чтобы подтвердить, что вы понимаете риск и знаете, что делаете, введите \"${iUnderstand}\" в поле ниже.";
 
-  static m27(coinName) => "получить комиссию за транзакцию ${coinName}";
+  static m29(coinName) => "получить комиссию за транзакцию ${coinName}";
 
-  static m28(coinName) => "отправить комиссию за транзакцию ${coinName}";
+  static m30(coinName) => "отправить комиссию за транзакцию ${coinName}";
 
-  static m29(abbr) => "Введите ${abbr} адрес";
+  static m31(abbr) => "Введите ${abbr} адрес";
 
-  static m31(gas) => "Не достаточно газа - используйте минимум ${gas} Gwei";
+  static m33(gas) => "Не достаточно газа - используйте минимум ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "Отправка запроса на кран ${coin}";
+  static m48(coinAbbr) => "Не удалось отменить активацию ${coinAbbr}.";
 
-  static m47(appCompanyShort) => "Новости Комодо";
+  static m49(coin) => "Отправка запроса на кран ${coin}";
 
-  static m48(value) => "Комиссия должна быть не более ${value}";
+  static m50(appCompanyShort) => "Новости Комодо";
 
-  static m49(coin) => "${coin} комиссия";
+  static m51(value) => "Комиссия должна быть не более ${value}";
 
-  static m50(coin) => "Пожалуйста активируйте ${coin}";
+  static m52(coin) => "${coin} комиссия";
 
-  static m51(value) => "Значение Gwei должно быть до ${value}.";
+  static m53(coin) => "Пожалуйста активируйте ${coin}";
 
-  static m52(coinName) =>
+  static m54(value) => "Значение Gwei должно быть до ${value}.";
+
+  static m55(coinName) =>
       "Настройки защиты входящих txs-транзакций ${coinName}";
 
-  static m53(abbr) =>
+  static m56(abbr) =>
       "${abbr} недостаточно баланса чтобы оплатить торговую комиссию";
 
-  static m54(coin) => "Неверный адрес ${coin}";
+  static m57(coin) => "Неверный адрес ${coin}";
 
-  static m55(coinAbbr) => "${coinAbbr} недоступен :(";
+  static m58(coinAbbr) => "${coinAbbr} недоступен :(";
 
-  static m56(coinName) =>
+  static m59(coinName) =>
       "❗Осторожно! Объем торгов на рынке ${coinName} за 24 часа составляет менее 10 000 долларов!";
 
-  static m57(value) => "Лимит должен быть до ${value}";
-
-  static m58(coinName, number) =>
-      "Минимальная сумма продажи составляет ${number} ${coinName}.";
-
-  static m59(coinName, number) =>
-      "Минимальная сумма покупки: ${number} ${coinName}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "Минимальная сумма ордера ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+  static m60(value) => "Лимит должен быть до ${value}";
 
   static m61(coinName, number) =>
+      "Минимальная сумма продажи составляет ${number} ${coinName}.";
+
+  static m62(coinName, number) =>
+      "Минимальная сумма покупки: ${number} ${coinName}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "Минимальная сумма ордера ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
+
+  static m64(coinName, number) =>
       "Минимальная сумма на продажу ${number} ${coinName}";
 
-  static m62(minValue, coin) => "Должно быть больше чем ${minValue} ${coin}";
+  static m65(minValue, coin) => "Должно быть больше чем ${minValue} ${coin}";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "Обратите внимание, что теперь вы используете сотовые данные, а участие в P2P-сети ${appName} потребляет интернет-трафик. Лучше использовать сеть Wi-Fi, если ваш тарифный план сотовой связи является дорогостоящим.";
 
-  static m64(coin) => "Активируйте ${coin} и пополните баланс";
+  static m67(coin) => "Активируйте ${coin} и пополните баланс";
 
-  static m65(number) => "Создать ${number} ордер(ов):";
+  static m68(number) => "Создать ${number} ордер(ов):";
 
-  static m66(coin) => "${coin} баланс очень низкий";
+  static m69(coin) => "${coin} баланс очень низкий";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "Недостаточно ${coin} чтобы оплатить налог. МИН баланс ${fee} ${coin}";
 
-  static m68(coinName) => "Пожалуйста, введите сумму ${coinName}.";
+  static m71(coinName) => "Пожалуйста, введите сумму ${coinName}.";
 
-  static m69(coin) => "Не достаточно ${coin} для транзакции!";
+  static m72(coin) => "Не достаточно ${coin} для транзакции!";
 
-  static m70(sell, buy) => "Своп ${sell}/${buy} успешно завершен";
+  static m73(sell, buy) => "Своп ${sell}/${buy} успешно завершен";
 
-  static m71(sell, buy) => "Своп ${sell}/${buy} не прошел";
+  static m74(sell, buy) => "Своп ${sell}/${buy} не прошел";
 
-  static m72(sell, buy) => "Своп ${sell}/${buy} начат";
+  static m75(sell, buy) => "Своп ${sell}/${buy} начат";
 
-  static m73(sell, buy) => "Превышен тайм-аут свопа ${sell}/${buy}";
+  static m76(sell, buy) => "Превышен тайм-аут свопа ${sell}/${buy}";
 
-  static m74(coin) => "Вы получили ${coin} транзакцию";
+  static m77(coin) => "Вы получили ${coin} транзакцию";
 
-  static m75(assets) => "${assets} Активов";
+  static m78(assets) => "${assets} Активов";
 
-  static m76(coin) => "Все ${coin} ордеры будут отменены.";
+  static m79(coin) => "Все ${coin} ордеры будут отменены.";
 
-  static m77(delta) => "На -${delta}% ниже цен CEX";
+  static m80(delta) => "На -${delta}% ниже цен CEX";
 
-  static m78(delta) => "На +${delta}% выше цен CEX";
+  static m81(delta) => "На +${delta}% выше цен CEX";
 
-  static m79(fill) => "${fill}% заполнено";
+  static m82(fill) => "${fill}% заполнено";
 
-  static m80(coin) => "Сумма (${coin})";
+  static m83(coin) => "Сумма (${coin})";
 
-  static m81(coin) => "Цена (${coin})";
+  static m84(coin) => "Цена (${coin})";
 
-  static m82(coin) => "Всего (${coin})";
+  static m85(coin) => "Всего (${coin})";
 
-  static m83(abbr) =>
+  static m86(abbr) =>
       "${abbr} не активен. Пожалуйста активируйте и попробуйте снова.";
 
-  static m84(appName) => "На каких устройствах я могу использовать ${appName}?";
-
-  static m85(appName) =>
-      "Чем торговля на ${appName} отличается от торговли на других DEX?";
-
-  static m86(appName) => "Как рассчитываются комиссии на ${appName}?";
-
-  static m87(appName) => "Кто стоит за ${appName}?";
+  static m87(appName) => "На каких устройствах я могу использовать ${appName}?";
 
   static m88(appName) =>
+      "Чем торговля на ${appName} отличается от торговли на других DEX?";
+
+  static m89(appName) => "Как рассчитываются комиссии на ${appName}?";
+
+  static m90(appName) => "Кто стоит за ${appName}?";
+
+  static m91(appName) =>
       "Можно ли разработать собственную white-label биржу на технологии ${appName}?";
 
-  static m89(amount) => "Получено ${amount} KMD.";
+  static m92(amount) => "Получено ${amount} KMD.";
 
-  static m90(dd) => "${dd} дней}";
+  static m93(dd) => "${dd} дней}";
 
-  static m91(hh, minutes) => "${hh}ч ${minutes}мин";
+  static m94(hh, minutes) => "${hh}ч ${minutes}мин";
 
-  static m92(mm) => "мин ${mm}";
+  static m95(mm) => "мин ${mm}";
 
-  static m93(amount) => "Нажмите, чтобы увидеть ${amount} ордеров";
+  static m96(amount) => "Нажмите, чтобы увидеть ${amount} ордеров";
 
-  static m94(coinName, address) => "Мой ${coinName} адрес:\n${address}";
+  static m97(coinName, address) => "Мой ${coinName} адрес:\n${address}";
 
-  static m95(coin) => "Сканировать прошлые транзакции с ${coin}?";
+  static m98(coin) => "Сканировать прошлые транзакции с ${coin}?";
 
-  static m96(count, maxCount) => "Показано ${count} из ${maxCount} заказов.";
+  static m99(count, maxCount) => "Показано ${count} из ${maxCount} заказов.";
 
-  static m97(coin) => "Пожалуйста введите сумму ${coin} для покупки";
+  static m100(coin) => "Пожалуйста введите сумму ${coin} для покупки";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "Максимальное количество активных монет: ${maxCoins}. Пожалуйста деактивируйте некоторые из них.";
 
-  static m99(coin) => "${coin} не активна";
+  static m102(coin) => "${coin} не активна";
 
-  static m100(coin) => "Пожалуйста введите сумму ${coin} для продажи";
+  static m103(coin) => "Пожалуйста введите сумму ${coin} для продажи";
 
-  static m101(coin) => "Не удалось активировать ${coin}";
+  static m104(coin) => "Не удалось активировать ${coin}";
 
-  static m102(description) =>
+  static m105(description) =>
       "Выберите файл в формате mp3 или wav. Воспроизводится, когда ${description}.";
 
-  static m103(description) => "Воспроизводится, когда ${description}";
+  static m106(description) => "Воспроизводится, когда ${description}";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "Если у вас есть какие-либо вопросы или вы считаете, что обнаружили техническую проблему с приложением ${appName}, вы можете сообщить об этом и получить поддержку от нашей команды.";
 
-  static m105(coin) =>
+  static m108(coin) =>
       "Пожалуйста сначала активируйте ${coin} и пополните баланс";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "Баланс ${coin} недостаточен для оплаты комиссии за транзакцию.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "Баланс ${coin} недостаточен для оплаты комиссии за транзакцию. ${coin} ${amount} требуется.";
 
-  static m108(name) => "Какие транзакции ${name} вы хотите синхронизировать?";
+  static m111(name) => "Какие транзакции ${name} вы хотите синхронизировать?";
 
-  static m109(left) => "Осталось транзакций: ${left}";
+  static m112(left) => "Осталось транзакций: ${left}";
 
-  static m110(amnt, hash) =>
+  static m113(amnt, hash) =>
       "Успешно разблокировано ${amnt} средств - TX: ${hash}";
 
-  static m111(version) => "Установлена версия ${version}";
+  static m114(version) => "Установлена версия ${version}";
 
-  static m112(version) => "Доступна версия ${version}. Пожалуйста, обновитесь.";
+  static m115(version) => "Доступна версия ${version}. Пожалуйста, обновитесь.";
 
-  static m113(appName) => "Обновление ${appName}";
+  static m116(appName) => "Обновление ${appName}";
 
-  static m114(coinAbbr) => "Ошибка активации ${coinAbbr}";
+  static m117(coinAbbr) => "Ошибка активации ${coinAbbr}";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "Ошибка активации ${coinAbbr}\nПожалуйста перезапустите приложение и попробуйте снова";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} mobile - это мульти-монетный кошелек с функциональностью DEX третьего поколения и многим другим.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "Ранее вы запретили ${appName} доступ к камере.\nВручную измените разрешения для камеры в настройках телефона, чтобы продолжить сканирование QR-кода.";
 
-  static m118(amount, coinName) => "ВЫВЕСТИ ${amount} ${coinName}";
+  static m121(amount, coinName) => "ВЫВЕСТИ ${amount} ${coinName}";
 
-  static m119(amount, coin) => "Вы получите ${amount} ${coin}";
+  static m122(amount, coin) => "Вы получите ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -334,6 +340,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled":
+            MessageLookupByLibrary.simpleMessage("Активация монеты отменена"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("Активировать монету"),
         "addingCoinSuccess": m4,
@@ -477,6 +485,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Код:"),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Вы уверены, что хотите отменить активацию?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Очистить"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Нет активных монет"),
@@ -484,9 +494,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Выбрать монету"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "Вы выбрали максимальное количество активов"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("Скоро будет..."),
         "commingsoon": MessageLookupByLibrary.simpleMessage(
             "Детали TX скоро будут добавлены!"),
@@ -517,7 +527,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactDelete":
             MessageLookupByLibrary.simpleMessage("Удалить контакт"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Удалить"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Сбросить"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Изменить"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Выйти"),
@@ -548,7 +558,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("Настроить комиссию"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "Используйте настраиваемые комиссии только если знаете, что делаете!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Защита Komodo dPoW"),
         "date": MessageLookupByLibrary.simpleMessage("Дата"),
         "decryptingWallet":
@@ -565,8 +575,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteWallet": MessageLookupByLibrary.simpleMessage("Удалить кошелек"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Удаляю кошелек"),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "отправить торговую комиссию комиссию за транзакцию"),
@@ -591,7 +601,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Я не хочу использовать пароль"),
         "duration": MessageLookupByLibrary.simpleMessage("Продолжительность"),
         "editContact": MessageLookupByLibrary.simpleMessage("Редактировать"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "Зашифрованный пароль не может быть пустым"),
         "emptyImportPass":
@@ -636,7 +646,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Невалидный адрес"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Segwit адреса не поддерживаются"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain": MessageLookupByLibrary.simpleMessage(
             "Ошибка, пожалуйста попробуйте еще раз"),
         "errorTryLater": MessageLookupByLibrary.simpleMessage(
@@ -647,32 +657,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Пожалуйста, введите данные"),
         "estimateValue":
             MessageLookupByLibrary.simpleMessage("Расчетная общая стоимость"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -725,12 +735,13 @@ class MessageLookup extends MessageLookupByLibrary {
             "Элементы которые были успешно экспортированы:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Свопы"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Экспорт"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Маскировочный баланс:"),
         "faqTitle":
             MessageLookupByLibrary.simpleMessage("Часто задаваемые вопросы"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Ошибка"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("FAUCET"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Успешно"),
         "faucetTimedOut":
@@ -738,7 +749,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("Новости"),
         "feedNotFound":
             MessageLookupByLibrary.simpleMessage("Здесь ничего нет"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("Узнать больше"),
         "feedTab": MessageLookupByLibrary.simpleMessage("Лента"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("Лента новостей"),
@@ -751,7 +762,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedUpdated":
             MessageLookupByLibrary.simpleMessage("Лента новостей обновлена"),
         "feedback": MessageLookupByLibrary.simpleMessage("Отправить логи"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("Все"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Фильтр"),
         "filtersClearAll":
@@ -775,9 +786,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("Из"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "Мы будем синхронизировать будущие транзакции, совершенные после активации, связанные с вашим открытым ключом. Это самый быстрый вариант и занимает меньше всего места."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Лимит газа"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("Цена Gas"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "Общая защита PIN-кодом не активна.\nРежим маскировки будет недоступен.\nВключите защиту PIN-кодом."),
@@ -787,7 +798,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Идет транзакция, пожалуйста, подождите"),
         "goToPorfolio":
             MessageLookupByLibrary.simpleMessage("Перейти в портфолио"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Помощь"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("Помощь и поддержка"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("Спрятать баланс"),
@@ -839,7 +850,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
             "Ошибка декодирования json файла"),
         "importTitle": MessageLookupByLibrary.simpleMessage("Импорт"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку."),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -848,7 +859,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Эта транзакция может занять до 10 минут - НЕ закрывайте приложение!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "Вы можете зашифровать свой кошелек паролем. Если вы решите не использовать пароль, вам нужно будет вводить свою seed-фразу каждый раз, когда вы хотите получить доступ к своему кошельку."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "Минимальное количество необходимое для этого ордера составляет"),
         "insufficientTitle":
@@ -857,12 +868,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Обновить"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Соединение с интернетом восстановлено"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Невозможно продолжить своп"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Подробнее"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Японский"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Корейский"),
         "language": MessageLookupByLibrary.simpleMessage("Язык"),
@@ -870,8 +881,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Последние Транзакции"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Легальные аспекты"),
         "less": MessageLookupByLibrary.simpleMessage("Меньше"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Загрузка..."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Загрузка книги ордеров..."),
@@ -943,11 +954,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("МИН"),
         "minOrder":
             MessageLookupByLibrary.simpleMessage("Минимальные объем ордера"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Должно быть меньше чем сумма продажи"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -957,10 +968,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Предупреждение: сворачивание приложения на iOS приведет к прекращению процесса активации."),
         "minutes": MessageLookupByLibrary.simpleMessage("мин"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Больше информации"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Ещё"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Сумма"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Монета"),
@@ -968,7 +979,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Отменить"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Подтвердить"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Создать"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Ордер"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Ордеры"),
@@ -983,8 +994,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Некорректная сумма"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Неверная сумма продажи"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("Макс сумма к продаже"),
         "multiMinReceiveAmt":
@@ -1019,7 +1030,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ничего не выбрано"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Совпадающих ордеров не найдено"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Нажмите, чтобы создать ордер"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1034,7 +1045,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput": MessageLookupByLibrary.simpleMessage(
             "Значение должно быть указано в цифрах"),
         "none": MessageLookupByLibrary.simpleMessage("Никто"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Недостаточно баланса для комиссий - выполните сделку на меньшую сумму"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1044,24 +1055,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Заметка"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Ничего не найдено"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Своп завершен"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Своп не был завершен"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Новый своп начался"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Статус свопа изменен"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Превышен тайм-аут свопа"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Входящая транзакция"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Официальный пресс-релиз"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ок"),
@@ -1073,14 +1084,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Открыть сообщение об ошибке"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Меньше"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Более"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated": MessageLookupByLibrary.simpleMessage("Ордер создан"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Ордер успешно создан"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Адрес"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Отменить"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("на"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Совпадает с СЕХ"),
@@ -1095,7 +1106,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Отправьте"),
         "orderDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Подробности"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Сделка найдена"),
         "orderMatching":
             MessageLookupByLibrary.simpleMessage("Поиск сделки в процессе"),
@@ -1105,9 +1116,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("ордера"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Активные"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("История"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Перезаписать"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("Это ваш ордер!"),
         "paidFromBalance":
@@ -1133,8 +1144,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Отмена:"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Оплата запрошена"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Разместить ордер"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Пожалуйста, примите все специальные запросы на активацию монет или отмените выбор монет."),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Пожалуйста добавьте монету"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1157,19 +1171,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("Сканер QR-кода"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Вы храните мои приватные ключи?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Сколько времени занимает каждый атомарный своп?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Необходимо ли мне быть в сети во время свопа?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Предоставляете ли вы поддержку пользователей?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Есть ли у вас какие-либо географические ограничения?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Это новая эра! Мы официально изменили наше название с «AtomicDEX» на «Komodo Wallet»."),
         "receive": MessageLookupByLibrary.simpleMessage("ПОЛУЧИТЬ"),
@@ -1209,7 +1223,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Узнать больше о KMD вознаграждениях"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Получить"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Фиат"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Вознаграждений\nKMD"),
@@ -1218,9 +1232,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsTableTitle":
             MessageLookupByLibrary.simpleMessage("Инфо о вознаграждениях:"),
         "rewardsTableUXTO": MessageLookupByLibrary.simpleMessage("UTXO,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Инфо о вознаграждениях:"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Русский"),
@@ -1273,7 +1287,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("Найти Тикер"),
         "seconds": MessageLookupByLibrary.simpleMessage("сек"),
         "security": MessageLookupByLibrary.simpleMessage("Безопасность"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("Показать историю транзакций"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Seed Фраза"),
@@ -1314,13 +1328,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Языки"),
         "settings": MessageLookupByLibrary.simpleMessage("Настройки"),
         "share": MessageLookupByLibrary.simpleMessage("ПОДЕЛИТЬСЯ"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("Показать адрес"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Показать детали"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("ПОКАЗАТЬ МОИ ОРДЕРЫ"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Войти с паролем"),
         "signInWithSeedPhrase":
@@ -1328,23 +1342,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Просто"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Активировать"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Купить"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Закрыть"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Получить"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Продать"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Отправить"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("Скрыть"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Показать больше"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Пропустить"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Убрать"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Звук"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Настройки звука"),
@@ -1361,16 +1375,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Шаг"),
         "success": MessageLookupByLibrary.simpleMessage("Успех!"),
         "support": MessageLookupByLibrary.simpleMessage("Поддержка"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("обмен"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Текущий"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("ПОДТВЕРДИТЕ ДЕТАЛИ ОБМЕНА"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("прибл"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Обмен не удался"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Обмен в процессе"),
         "swapProgress":
             MessageLookupByLibrary.simpleMessage("Детали прогресса"),
@@ -1385,7 +1399,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Синхронизация с активацией саженца"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
             "Синхронизировать новые транзакции"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1446,26 +1460,26 @@ class MessageLookup extends MessageLookupByLibrary {
             "Слишком много запросов.\nПревышен лимит запросов истории транзакций.\nПовторите попытку позже."),
         "txNotConfirmed":
             MessageLookupByLibrary.simpleMessage("НЕПОДТВЕРЖДЕНА"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Украинский"),
         "unlock": MessageLookupByLibrary.simpleMessage("разблокировать"),
         "unlockFunds":
             MessageLookupByLibrary.simpleMessage("Разблокировать средства"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable":
             MessageLookupByLibrary.simpleMessage("неизрасходованный"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Доступна новая версия"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Проверка обновлений..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Доступна новая версия. Пожалуйста, обновитесь."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Доступно обновление"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("Пропустить"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage(
             "Установлена последняя версия"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Обновление"),
@@ -1491,9 +1505,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("OK"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Предупреждение - в особых случаях логи могут содержать конфиденциальную информацию, которую можно использовать для доступа к монетам из незавершенных свопов!"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("ДАВАЙТЕ ВСЕ НАСТРОИМ!"),
         "welcomeTitle":
@@ -1504,14 +1518,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Это займет некоторое время, и приложение должно оставаться на переднем плане.\nЗакрытие приложения во время активации может привести к проблемам."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Вывести"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Доступ запрещен"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Подтвердите вывод"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Что-то пошло не так. Попробуйте позже."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Вы пытаетесь сканировать QR code для оплаты"),
         "wrongCoinSpan2":
@@ -1534,7 +1548,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "у вас есть ордер, которому могут соответствовать новые ордеры"),
         "youAreSending":
             MessageLookupByLibrary.simpleMessage("Вы отправляете:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("Вы получите:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("ваш кошелек")
       };

--- a/lib/l10n/messages_tr.dart
+++ b/lib/l10n/messages_tr.dart
@@ -78,240 +78,246 @@ class MessageLookup extends MessageLookupByLibrary {
   static m21(index) =>
       "Gizli kelimeleriniz arasından ${index} olanı hangisidir ?";
 
-  static m22(protocolName) => "${protocolName} parası etkinleştirildi";
+  static m22(coin) => "${coin} aktivasyonu iptal edildi";
 
-  static m23(protocolName) =>
+  static m23(coin) => "${coin} başarıyla etkinleştirildi";
+
+  static m24(protocolName) => "${protocolName} parası etkinleştirildi";
+
+  static m25(protocolName) =>
       "${protocolName} parası başarıyla etkinleştirildi";
 
-  static m24(protocolName) => "${protocolName} parası etkinleştirilmedi";
+  static m26(protocolName) => "${protocolName} parası etkinleştirilmedi";
 
-  static m25(name) => "${name} kişisini silmek istediğinizden emin misiniz ?";
+  static m27(name) => "${name} kişisini silmek istediğinizden emin misiniz ?";
 
-  static m26(iUnderstand) =>
+  static m28(iUnderstand) =>
       "Özelleştirilmiş gizli kelime kullanımı yeterince güvenli olmayabilir ve uygulama tarafından oluşturulan BIP39 uyumlu gizli kelimeler ya da özel anahtara (WIF) kıyasla daha kolay kırılabilmektedir. Riskleri kabul edip ne yaptığınızdan emin olduğunuzu tasdiklemek için aşağıdaki kutucuğa \"${iUnderstand}\" yazınız.";
 
-  static m27(coinName) => "${coinName} işlem ücretini alın";
+  static m29(coinName) => "${coinName} işlem ücretini alın";
 
-  static m28(coinName) => "${coinName} işlem ücretini gönder";
+  static m30(coinName) => "${coinName} işlem ücretini gönder";
 
-  static m29(abbr) => "${abbr} adresini girin";
+  static m31(abbr) => "${abbr} adresini girin";
 
-  static m31(gas) => "Yeteri kadar gaz ücreti yok, en az ${gas} Gwei gerekli";
+  static m33(gas) => "Yeteri kadar gaz ücreti yok, en az ${gas} Gwei gerekli";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "${coin} musluğuna talep gönderiliyor..";
+  static m48(coinAbbr) => "${coinAbbr} aktivasyonu iptal edilemedi";
 
-  static m47(appCompanyShort) => "${appCompanyShort} haberleri";
+  static m49(coin) => "${coin} musluğuna talep gönderiliyor..";
 
-  static m48(value) => "Ücretler en fazla ${value} olmalıdır";
+  static m50(appCompanyShort) => "${appCompanyShort} haberleri";
 
-  static m49(coin) => "${coin} gideri";
+  static m51(value) => "Ücretler en fazla ${value} olmalıdır";
 
-  static m50(coin) => "Lütfen ${coin} koinini aktifleştirin.";
+  static m52(coin) => "${coin} gideri";
 
-  static m51(value) => "Gwei en fazla ${value} olmalıdır";
+  static m53(coin) => "Lütfen ${coin} koinini aktifleştirin.";
 
-  static m52(coinName) => "Gelen ${coinName} txs koruma ayarları";
+  static m54(value) => "Gwei en fazla ${value} olmalıdır";
 
-  static m53(abbr) =>
+  static m55(coinName) => "Gelen ${coinName} txs koruma ayarları";
+
+  static m56(abbr) =>
       "${abbr} bakiyesi, alım satım işlem ücretlerini karşılamaya yetmiyor.";
 
-  static m54(coin) => "Geçersiz ${coin} adresi";
+  static m57(coin) => "Geçersiz ${coin} adresi";
 
-  static m55(coinAbbr) => "${coinAbbr} mevcut değil :(";
+  static m58(coinAbbr) => "${coinAbbr} mevcut değil :(";
 
-  static m56(coinName) =>
+  static m59(coinName) =>
       "❗Dikkat! ${coinName} piyasasının 24 saatlik işlem hacmi 10 bin dolardan az!";
 
-  static m57(value) => "Sınır en fazla ${value} olmalıdır";
-
-  static m58(coinName, number) =>
-      "${coinName} için yapılabilecek en düşük satış hacmi: ${number}";
-
-  static m59(coinName, number) =>
-      "${coinName} için yapılabilecek en düşük alım hacmi: ${number}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "En düşük emir için: ${buyCoin} ${buyAmount}\n(${sellCoin} ${sellAmount})";
+  static m60(value) => "Sınır en fazla ${value} olmalıdır";
 
   static m61(coinName, number) =>
+      "${coinName} için yapılabilecek en düşük satış hacmi: ${number}";
+
+  static m62(coinName, number) =>
+      "${coinName} için yapılabilecek en düşük alım hacmi: ${number}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "En düşük emir için: ${buyCoin} ${buyAmount}\n(${sellCoin} ${sellAmount})";
+
+  static m64(coinName, number) =>
       "${coinName} için en düşük satım miktarı: ${number}";
 
-  static m62(minValue, coin) => "${minValue} ${coin}\'den büyük olmalı";
+  static m65(minValue, coin) => "${minValue} ${coin}\'den büyük olmalı";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "Lütfen artık hücresel veri kullandığınızı ve ${appName} P2P ağına katılımınızın internet trafiğini tükettiğini unutmayın. Hücresel veri planınız maliyetliyse bir WiFi ağı kullanmak daha iyidir.";
 
-  static m64(coin) => "Önce ${coin}\'i etkinleştirin ve bakiyeyi tamamlayın";
+  static m67(coin) => "Önce ${coin}\'i etkinleştirin ve bakiyeyi tamamlayın";
 
-  static m65(number) => "${number} Sipariş oluştur:";
+  static m68(number) => "${number} Sipariş oluştur:";
 
-  static m66(coin) => "${coin} bakiyesi yetersiz";
+  static m69(coin) => "${coin} bakiyesi yetersiz";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "İşlem masrafını ödemeye yetecek ${coin} yok. En az ${fee} ${coin} olmalı.";
 
-  static m68(coinName) =>
+  static m71(coinName) =>
       "Uygun bir ${coinName} emri bulunmuyor - bir emir girmeyi deneyin veya daha sonra yeniden kontrol edin.";
 
-  static m69(coin) => "İşlem için yeteri kadar ${coin} yok !";
+  static m72(coin) => "İşlem için yeteri kadar ${coin} yok !";
 
-  static m70(sell, buy) => "${sell}/${buy} takası başarıyla tamamlandı";
+  static m73(sell, buy) => "${sell}/${buy} takası başarıyla tamamlandı";
 
-  static m71(sell, buy) => "${sell}/${buy} takası başarısız oldu";
+  static m74(sell, buy) => "${sell}/${buy} takası başarısız oldu";
 
-  static m72(sell, buy) => "${sell}/${buy} takası başladı";
+  static m75(sell, buy) => "${sell}/${buy} takası başladı";
 
-  static m73(sell, buy) => "${sell}/${buy} takas zaman aşımına uğradı";
+  static m76(sell, buy) => "${sell}/${buy} takas zaman aşımına uğradı";
 
-  static m74(coin) => "${coin} işlemi aldınız!";
+  static m77(coin) => "${coin} işlemi aldınız!";
 
-  static m75(assets) => "${assets} Varlıklar";
+  static m78(assets) => "${assets} Varlıklar";
 
-  static m76(coin) => "Tüm ${coin} emirleri iptal edilecek";
+  static m79(coin) => "Tüm ${coin} emirleri iptal edilecek";
 
-  static m77(delta) => "Ucuz: CEX + %${delta}";
+  static m80(delta) => "Ucuz: CEX + %${delta}";
 
-  static m78(delta) => "Pahalı: CEX + %${delta}";
+  static m81(delta) => "Pahalı: CEX + %${delta}";
 
-  static m79(fill) => "${fill}% tamamlandı";
+  static m82(fill) => "${fill}% tamamlandı";
 
-  static m80(coin) => "(${coin}) miktarı";
+  static m83(coin) => "(${coin}) miktarı";
 
-  static m81(coin) => "(${coin}) fiyatı";
+  static m84(coin) => "(${coin}) fiyatı";
 
-  static m82(coin) => "Toplam (${coin})";
+  static m85(coin) => "Toplam (${coin})";
 
-  static m83(abbr) =>
+  static m86(abbr) =>
       "${abbr} aktif değil. Lütfen aktifleştirip öyle deneyiniz.";
 
-  static m84(appName) => "Komodo Wallet\'ı hangi cihazlarda kullanabilirim ?";
-
-  static m85(appName) =>
-      "${appName}\'te alım satım yapmanın diğer DEX\'lerdekinden ne gibi farkları vardır ?";
-
-  static m86(appName) =>
-      "${appName}\'te işlem ücretleri nasıl hesaplanmaktadır ?";
-
-  static m87(appName) => "Komodo Wallet\'ın arkasında kimler var ?";
+  static m87(appName) => "Komodo Wallet\'ı hangi cihazlarda kullanabilirim ?";
 
   static m88(appName) =>
+      "${appName}\'te alım satım yapmanın diğer DEX\'lerdekinden ne gibi farkları vardır ?";
+
+  static m89(appName) =>
+      "${appName}\'te işlem ücretleri nasıl hesaplanmaktadır ?";
+
+  static m90(appName) => "Komodo Wallet\'ın arkasında kimler var ?";
+
+  static m91(appName) =>
       "${appName} üzerinde kendi beyaz etiketli değişimimi geliştirmem mümkün mü?";
 
-  static m89(amount) => "Başarılı ! ${amount} KMD geldi.";
+  static m92(amount) => "Başarılı ! ${amount} KMD geldi.";
 
-  static m90(dd) => "${dd} gün";
+  static m93(dd) => "${dd} gün";
 
-  static m91(hh, minutes) => "${hh}sa ${minutes}dk";
+  static m94(hh, minutes) => "${hh}sa ${minutes}dk";
 
-  static m92(mm) => "${mm}dk";
+  static m95(mm) => "${mm}dk";
 
-  static m93(amount) => "${amount} adet emri görmek için tıklayın";
+  static m96(amount) => "${amount} adet emri görmek için tıklayın";
 
-  static m94(coinName, address) => "${coinName} adresim:\n${address}";
+  static m97(coinName, address) => "${coinName} adresim:\n${address}";
 
-  static m95(coin) => "Geçmişteki ${coin} işlemleri taransın mı?";
+  static m98(coin) => "Geçmişteki ${coin} işlemleri taransın mı?";
 
-  static m96(count, maxCount) =>
+  static m99(count, maxCount) =>
       "${maxCount} siparişten ${count} tanesi gösteriliyor.";
 
-  static m97(coin) => "Lütfen alınacak ${coin} adetini girin";
+  static m100(coin) => "Lütfen alınacak ${coin} adetini girin";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "Maksimum aktif jeton sayısı ${maxCoins}\'dir. Lütfen bazılarını devre dışı bırakın.";
 
-  static m99(coin) => "${coin} koini aktif değil !";
+  static m102(coin) => "${coin} koini aktif değil !";
 
-  static m100(coin) => "Lütfen satmak için ${coin} miktarı girin";
+  static m103(coin) => "Lütfen satmak için ${coin} miktarı girin";
 
-  static m101(coin) => "${coin} aktifleştirilemedi";
+  static m104(coin) => "${coin} aktifleştirilemedi";
 
-  static m102(description) =>
+  static m105(description) =>
       "Lütfen bir mp3 ya da waw dosyası seçin. ${description}\'de ses dosyalarını oynatacağız.";
 
-  static m103(description) => "${description}\'de oynatıldı.";
+  static m106(description) => "${description}\'de oynatıldı.";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "Herhangi bir sorunuz varsa veyahut ${appName} uygulamasıyla ile ilgili teknik bir hata bulduğunuzu düşünüyorsanız bunu ekibimize bildirebilir ve destek alabilirsiniz.";
 
-  static m105(coin) => "Lütfen önce ${coin} ve kontör bakiyesini etkinleştirin";
+  static m108(coin) => "Lütfen önce ${coin} ve kontör bakiyesini etkinleştirin";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "${coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "${coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük. ${amount} ${coin} gerekli.";
 
-  static m108(name) =>
+  static m111(name) =>
       "Hangi ${name} işlemlerini senkronize etmek istiyorsunuz?";
 
-  static m109(left) => "Kalan işlem: ${left}";
+  static m112(left) => "Kalan işlem: ${left}";
 
-  static m110(amnt, hash) =>
+  static m113(amnt, hash) =>
       "${amnt} fonun kilidi başarıyla kaldırıldı - TX: ${hash}";
 
-  static m111(version) => "${version} sürümünü kullanmaktasınız.";
+  static m114(version) => "${version} sürümünü kullanmaktasınız.";
 
-  static m112(version) =>
+  static m115(version) =>
       "Güncel ${version} sürümü mevcut. Lütfen güncelleyiniz.";
 
-  static m113(appName) => "Komodo Wallet güncellemeleri";
+  static m116(appName) => "Komodo Wallet güncellemeleri";
 
-  static m114(coinAbbr) => "${coinAbbr} koinini etkinleştiremedik.";
+  static m117(coinAbbr) => "${coinAbbr} koinini etkinleştiremedik.";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "${coinAbbr} koinini etkinleştiremedik.\nLütfen uygulamayı yeniden başlatıp tekrar deneyiniz.";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "Komodo Wallet mobil yerleşik üçüncü nesil DEX işlevselliği ve daha fazla özellikleri ile yeni nesil bir çoklu koin cüzdanıdır.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "${appName}\'in kameraya erişimi engellenmiş.\nQR kod taramasını yapabilmek için lütfen telefon ayarlarınızdan kamera erişimine izin veriniz.";
 
-  static m118(amount, coinName) => "${amount} adet ${coinName} ÇEK";
+  static m121(amount, coinName) => "${amount} adet ${coinName} ÇEK";
 
-  static m119(amount, coin) => "${amount} adet ${coin} alacaksınız";
+  static m122(amount, coin) => "${amount} adet ${coin} alacaksınız";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -340,6 +346,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled": MessageLookupByLibrary.simpleMessage(
+            "Coin aktivasyonu iptal edildi"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("Koin etkinleştir"),
         "addingCoinSuccess": m4,
@@ -482,15 +490,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Kod:"),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Temizle"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Aktif koin yok"),
         "coinSelectTitle": MessageLookupByLibrary.simpleMessage("Koin Seç"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "Maksimum varlık sayısını seçtiniz"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("Yakında..."),
         "commingsoon":
             MessageLookupByLibrary.simpleMessage("TX detayları yakında !"),
@@ -520,7 +530,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactCancel": MessageLookupByLibrary.simpleMessage("İptal"),
         "contactDelete": MessageLookupByLibrary.simpleMessage("Kişiyi Sil"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Sil"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Vazgeç"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Düzenle"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Çık"),
@@ -548,7 +558,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Özelleştirilmiş gider"),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "Özelleştirilmiş giderleri yalnızca ne yaptığınızdan emin olduğunuzda kullanın !"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW Koruması"),
         "date": MessageLookupByLibrary.simpleMessage("Tarih"),
         "decryptingWallet":
@@ -565,8 +575,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteWallet": MessageLookupByLibrary.simpleMessage("Cüzdanı Sil"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Cüzdan siliniyor.."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "işlem ücreti gönder işlem ücreti"),
@@ -590,7 +600,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Parola istemiyorum"),
         "duration": MessageLookupByLibrary.simpleMessage("Süre"),
         "editContact": MessageLookupByLibrary.simpleMessage("Kişiyi Düzenle"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "Parola şifreleme kısmı boş kalamaz"),
         "emptyImportPass":
@@ -635,7 +645,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Geçerli bir adres değil"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Segwiit adresler henüz desteklenmemektir"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain": MessageLookupByLibrary.simpleMessage(
             "Hata, lütfen tekrar deneyiniz"),
         "errorTryLater": MessageLookupByLibrary.simpleMessage(
@@ -646,32 +656,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Lütfen veri giriniz"),
         "estimateValue":
             MessageLookupByLibrary.simpleMessage("Tahmini Toplam Değer"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -720,19 +730,20 @@ class MessageLookup extends MessageLookupByLibrary {
             "Öğeler dışa başarıyla aktarıldı."),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Takaslar"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Dışa Aktar"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Sahte bakiye tutarı:"),
         "faqTitle":
             MessageLookupByLibrary.simpleMessage("Sıkça Sorulan Sorular"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Hata"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("MUSLUK"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Başarılı"),
         "faucetTimedOut":
             MessageLookupByLibrary.simpleMessage("Talep zaman aşımına uğradı"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("Haberler"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("Bir şey yok"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore":
             MessageLookupByLibrary.simpleMessage("Daha fazlası için.."),
         "feedTab": MessageLookupByLibrary.simpleMessage("Bülten"),
@@ -746,7 +757,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Haber bülteni güncellendi"),
         "feedback":
             MessageLookupByLibrary.simpleMessage("Geri Bildirim Gönder"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("Hepsi"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Filtre"),
         "filtersClearAll":
@@ -769,9 +780,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("Gönderici"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "Genel anahtarınızla ilişkili etkinleştirme sonrasında gelecekte yapılacak işlemleri senkronize edeceğiz. Bu en hızlı seçenektir ve en az depolama alanını kaplar."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Gaz ücreti limiti"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("Gaz ücreti"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "Normal PIN koruması aktif değil.\nKamuflajlı koruma modu aktif olmayacak.\nLütfen PIN korumasını aktifleştirin."),
@@ -780,7 +791,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "gettingTxWait": MessageLookupByLibrary.simpleMessage(
             "İşlem alınıyor, lütfen bekleyin"),
         "goToPorfolio": MessageLookupByLibrary.simpleMessage("Portföye git"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Yardım"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("Yardım ve Destek"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("Bakiyeleri gizle"),
@@ -832,7 +843,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
             "Json dosyası çözülürken hata oluştu."),
         "importTitle": MessageLookupByLibrary.simpleMessage("İçeri Al"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Güvenlı bir parola kullanın ve onu, uygulamayı kullandığınız cihazda saklamayın."),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -841,7 +852,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Bu işlem 60 dakikaya kadar sürebilir. Uygulamayı KAPATMAYINIZ !"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "Cüzdanınızın güvenlik tehditlerine karşı şifrelenebilmesi için bir parola ayarlamalısınız."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "Bu işlem için gereken en az hacim şu kadardır"),
         "insufficientTitle":
@@ -849,20 +860,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("Yenile"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "İnternet Bağlantısı Yeniden Sağlandı"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Takasa devam edilemiyor"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Detaylar"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japonca"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Koreli"),
         "language": MessageLookupByLibrary.simpleMessage("Diller"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("Son İşlemler"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Yasal"),
         "less": MessageLookupByLibrary.simpleMessage("Daha az"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Yükleniyor.."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Emir defteri yükleniyor..."),
@@ -934,11 +945,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("DK"),
         "minOrder": MessageLookupByLibrary.simpleMessage("En düşük emir hacmi"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Satış miktarından düşük olmalı"),
         "minVolumeTitle":
@@ -947,17 +958,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Uyarı: iOS\'ta uygulamanın simge durumuna küçültülmesi etkinleştirme sürecini sonlandıracaktır."),
         "minutes": MessageLookupByLibrary.simpleMessage("dk"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Daha fazla bilgi"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Daha Fazla"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Miktar"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Koin"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("Sat"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("İptal"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("Onayla"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Oluştur"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Emir"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Emirler"),
@@ -973,8 +984,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Geçersiz miktar"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Geçersiz satış miktarı"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("En fazla satış miktarı:"),
         "multiMinReceiveAmt":
@@ -1008,7 +1019,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Bir öğe seçilmedi"),
         "noMatchingOrders":
             MessageLookupByLibrary.simpleMessage("Eşleşen sipariş bulunamadı"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Emir oluşturmak için tıklayın"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1024,7 +1035,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("Girilen değer rakam olmalı"),
         "none": MessageLookupByLibrary.simpleMessage("Hiçbiri"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Takas masrafını karşılayacak bakiye bulunmuyor - daha küçük tutar deneyin"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1033,23 +1044,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Not"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Bir şey bulunamadı"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Takas tamamlandı"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Takas başarısız"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Yeni takas başladı"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Takas durumu değişti"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Takas zaman aşımına uğradı"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("Gelen işlem"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Resmi basın açıklaması"),
         "okButton": MessageLookupByLibrary.simpleMessage("Tamam"),
@@ -1060,15 +1071,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("Hata Mesajını Aç"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Az"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Daha"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Emir oluşturuldu"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Emir başarıyla oluşturuldu"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Adres"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("İptal"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("için"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("CEX\'de"),
@@ -1081,7 +1092,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ayrıntıları tek dokunuşla açın ve Uzun dokunuşla sipariş et\'i seçin"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Harca"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Detaylar"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Emir eşleşti"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("Emir eşleşiyor"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("Emir"),
@@ -1090,9 +1101,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("emirler"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Açık"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Geçmiş"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Üstüne yaz"),
         "ownOrder":
             MessageLookupByLibrary.simpleMessage("Bu sizin kendi emriniz !"),
@@ -1117,8 +1128,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("İptal"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Ödeme Talep Edildi"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Emrinizi girin"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Lütfen tüm özel jeton aktivasyon isteklerini kabul edin veya jetonların seçimini kaldırın."),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Lütfen bir Koin Ekleyiniz"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1142,19 +1156,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR Kod Tarayıcı"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Gizli kelimelerimi kaydediyor musunuz ?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Takas işlemleri ne kadar sürmektedir ?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Takas işlemi boyunca çevrimiçi olmam mı gerekir ?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Kullanıcılara destek sunuyor musunuz ?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Uygulamanın kullanılamadığı ülkeler var mı ?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Bu yeni bir dönem! \'AtomicDEX\' olan ismimizi resmi olarak \'Komodo Wallet\' olarak değiştirdik."),
         "receive": MessageLookupByLibrary.simpleMessage("AL"),
@@ -1193,7 +1207,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "KMD aktif kullanıcı ödülleri hakkında daha fazla bilgi edinin"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Al"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat":
             MessageLookupByLibrary.simpleMessage("İtibari para"),
         "rewardsTableRewards":
@@ -1204,9 +1218,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ödül bilgisi:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("Ödül bilgisi"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Rusça"),
         "saveMerged":
@@ -1259,7 +1273,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Kayan Yazı Ara"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Güvenlik"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("İşlem Geçmişini Görüntüle"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Gizli Kelimeler"),
@@ -1297,13 +1311,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Diller"),
         "settings": MessageLookupByLibrary.simpleMessage("Ayarlar"),
         "share": MessageLookupByLibrary.simpleMessage("Paylaş"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("Adresi Göster"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Detayları Göster"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("EMİRLERİMİ GÖSTER"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Parola ile giriş yap"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
@@ -1311,24 +1325,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Basit"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Aktifleştir"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Satın al"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Kapat"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Al"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Sat"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Gönder"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Daha az göster"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Daha fazla göster"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Geç"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Kapat"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Ses"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Ses seçenekleri"),
@@ -1345,16 +1359,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Adım"),
         "success": MessageLookupByLibrary.simpleMessage("Başarılı !"),
         "support": MessageLookupByLibrary.simpleMessage("Destek"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("takas"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Mevcut"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("TAKAS DETAYLARINI ONAYLA"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Yaklaşık"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Takas başarısız"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing":
             MessageLookupByLibrary.simpleMessage("Takas devam ediyor"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("İşlem detayları"),
@@ -1369,7 +1383,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Fidan aktivasyonundan senkronizasyon"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
             "Yeni işlemleri senkronize et"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1429,25 +1443,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Çok fazla istek.\nİşlem geçmişi istekleri sınırı aşıldı.\nLütfen daha sonra tekrar deneyiniz."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("onaylanmamış"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrayna"),
         "unlock": MessageLookupByLibrary.simpleMessage("kilidi aç"),
         "unlockFunds":
             MessageLookupByLibrary.simpleMessage("Fonların Kilidini Açın"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("harcanamaz"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Yeni sürüm mevcut"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage(
             "Güncellemeler kontrol ediliyor.."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Yeni sürüm mevcut. Lütfen güncelleyiniz."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Güncelleme mevcut"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("Şimdilik atla"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Son sürüm yüklü"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Güncelle"),
@@ -1473,9 +1487,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Tamam"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Dikkat ! Bu kayıt defteri özel durumlarda, başarısız takaslardan kalan koinlerin harcanmasına sebep olabilecek hassas bilgiler içerebilir."),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("HADİ AYARLAYALIM !"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("HOŞ GELDİNİZ"),
@@ -1485,14 +1499,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Bu biraz zaman alacak ve uygulamanın ön planda tutulması gerekiyor.\nEtkinleştirme devam ederken uygulamayı sonlandırmak sorunlara yol açabilir."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Çek"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Erişim Engellendi"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Çekimi Onayla"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1":
             MessageLookupByLibrary.simpleMessage("QR kodlu bir ödemeyi"),
         "wrongCoinSpan2":
@@ -1514,7 +1528,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "yeni siparişlerin eşleşebileceği bir siparişiniz var"),
         "youAreSending":
             MessageLookupByLibrary.simpleMessage("Gönderiyorsunuz:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("Alacağınız:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("Cüzdanınız")
       };

--- a/lib/l10n/messages_tr.dart
+++ b/lib/l10n/messages_tr.dart
@@ -157,154 +157,161 @@ class MessageLookup extends MessageLookupByLibrary {
   static m53(abbr) =>
       "${abbr} bakiyesi, alım satım işlem ücretlerini karşılamaya yetmiyor.";
 
-  static m54(coinAbbr) => "${coinAbbr} mevcut değil :(";
+  static m54(coin) => "Geçersiz ${coin} adresi";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} mevcut değil :(";
+
+  static m56(coinName) =>
       "❗Dikkat! ${coinName} piyasasının 24 saatlik işlem hacmi 10 bin dolardan az!";
 
-  static m56(value) => "Sınır en fazla ${value} olmalıdır";
-
-  static m57(coinName, number) =>
-      "${coinName} için yapılabilecek en düşük satış hacmi: ${number}";
+  static m57(value) => "Sınır en fazla ${value} olmalıdır";
 
   static m58(coinName, number) =>
+      "${coinName} için yapılabilecek en düşük satış hacmi: ${number}";
+
+  static m59(coinName, number) =>
       "${coinName} için yapılabilecek en düşük alım hacmi: ${number}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "En düşük emir için: ${buyCoin} ${buyAmount}\n(${sellCoin} ${sellAmount})";
 
-  static m60(coinName, number) =>
+  static m61(coinName, number) =>
       "${coinName} için en düşük satım miktarı: ${number}";
 
-  static m61(minValue, coin) => "${minValue} ${coin}\'den büyük olmalı";
+  static m62(minValue, coin) => "${minValue} ${coin}\'den büyük olmalı";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "Lütfen artık hücresel veri kullandığınızı ve ${appName} P2P ağına katılımınızın internet trafiğini tükettiğini unutmayın. Hücresel veri planınız maliyetliyse bir WiFi ağı kullanmak daha iyidir.";
 
-  static m63(coin) => "Önce ${coin}\'i etkinleştirin ve bakiyeyi tamamlayın";
+  static m64(coin) => "Önce ${coin}\'i etkinleştirin ve bakiyeyi tamamlayın";
 
-  static m64(number) => "${number} Sipariş oluştur:";
+  static m65(number) => "${number} Sipariş oluştur:";
 
-  static m65(coin) => "${coin} bakiyesi yetersiz";
+  static m66(coin) => "${coin} bakiyesi yetersiz";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "İşlem masrafını ödemeye yetecek ${coin} yok. En az ${fee} ${coin} olmalı.";
 
-  static m67(coinName) =>
+  static m68(coinName) =>
       "Uygun bir ${coinName} emri bulunmuyor - bir emir girmeyi deneyin veya daha sonra yeniden kontrol edin.";
 
-  static m68(coin) => "İşlem için yeteri kadar ${coin} yok !";
+  static m69(coin) => "İşlem için yeteri kadar ${coin} yok !";
 
-  static m69(sell, buy) => "${sell}/${buy} takası başarıyla tamamlandı";
+  static m70(sell, buy) => "${sell}/${buy} takası başarıyla tamamlandı";
 
-  static m70(sell, buy) => "${sell}/${buy} takası başarısız oldu";
+  static m71(sell, buy) => "${sell}/${buy} takası başarısız oldu";
 
-  static m71(sell, buy) => "${sell}/${buy} takası başladı";
+  static m72(sell, buy) => "${sell}/${buy} takası başladı";
 
-  static m72(sell, buy) => "${sell}/${buy} takas zaman aşımına uğradı";
+  static m73(sell, buy) => "${sell}/${buy} takas zaman aşımına uğradı";
 
-  static m73(coin) => "${coin} işlemi aldınız!";
+  static m74(coin) => "${coin} işlemi aldınız!";
 
-  static m74(assets) => "${assets} Varlıklar";
+  static m75(assets) => "${assets} Varlıklar";
 
-  static m75(coin) => "Tüm ${coin} emirleri iptal edilecek";
+  static m76(coin) => "Tüm ${coin} emirleri iptal edilecek";
 
-  static m76(delta) => "Ucuz: CEX + %${delta}";
+  static m77(delta) => "Ucuz: CEX + %${delta}";
 
-  static m77(delta) => "Pahalı: CEX + %${delta}";
+  static m78(delta) => "Pahalı: CEX + %${delta}";
 
-  static m78(fill) => "${fill}% tamamlandı";
+  static m79(fill) => "${fill}% tamamlandı";
 
-  static m79(coin) => "(${coin}) miktarı";
+  static m80(coin) => "(${coin}) miktarı";
 
-  static m80(coin) => "(${coin}) fiyatı";
+  static m81(coin) => "(${coin}) fiyatı";
 
-  static m81(coin) => "Toplam (${coin})";
+  static m82(coin) => "Toplam (${coin})";
 
-  static m82(abbr) =>
+  static m83(abbr) =>
       "${abbr} aktif değil. Lütfen aktifleştirip öyle deneyiniz.";
 
-  static m83(appName) => "Komodo Wallet\'ı hangi cihazlarda kullanabilirim ?";
-
-  static m84(appName) =>
-      "${appName}\'te alım satım yapmanın diğer DEX\'lerdekinden ne gibi farkları vardır ?";
+  static m84(appName) => "Komodo Wallet\'ı hangi cihazlarda kullanabilirim ?";
 
   static m85(appName) =>
+      "${appName}\'te alım satım yapmanın diğer DEX\'lerdekinden ne gibi farkları vardır ?";
+
+  static m86(appName) =>
       "${appName}\'te işlem ücretleri nasıl hesaplanmaktadır ?";
 
-  static m86(appName) => "Komodo Wallet\'ın arkasında kimler var ?";
+  static m87(appName) => "Komodo Wallet\'ın arkasında kimler var ?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "${appName} üzerinde kendi beyaz etiketli değişimimi geliştirmem mümkün mü?";
 
-  static m88(amount) => "Başarılı ! ${amount} KMD geldi.";
+  static m89(amount) => "Başarılı ! ${amount} KMD geldi.";
 
-  static m89(dd) => "${dd} gün";
+  static m90(dd) => "${dd} gün";
 
-  static m90(hh, minutes) => "${hh}sa ${minutes}dk";
+  static m91(hh, minutes) => "${hh}sa ${minutes}dk";
 
-  static m91(mm) => "${mm}dk";
+  static m92(mm) => "${mm}dk";
 
-  static m92(amount) => "${amount} adet emri görmek için tıklayın";
+  static m93(amount) => "${amount} adet emri görmek için tıklayın";
 
-  static m93(coinName, address) => "${coinName} adresim:\n${address}";
+  static m94(coinName, address) => "${coinName} adresim:\n${address}";
 
-  static m94(count, maxCount) =>
+  static m95(coin) => "Geçmişteki ${coin} işlemleri taransın mı?";
+
+  static m96(count, maxCount) =>
       "${maxCount} siparişten ${count} tanesi gösteriliyor.";
 
-  static m95(coin) => "Lütfen alınacak ${coin} adetini girin";
+  static m97(coin) => "Lütfen alınacak ${coin} adetini girin";
 
-  static m96(maxCoins) =>
+  static m98(maxCoins) =>
       "Maksimum aktif jeton sayısı ${maxCoins}\'dir. Lütfen bazılarını devre dışı bırakın.";
 
-  static m97(coin) => "${coin} koini aktif değil !";
+  static m99(coin) => "${coin} koini aktif değil !";
 
-  static m98(coin) => "Lütfen satmak için ${coin} miktarı girin";
+  static m100(coin) => "Lütfen satmak için ${coin} miktarı girin";
 
-  static m99(coin) => "${coin} aktifleştirilemedi";
+  static m101(coin) => "${coin} aktifleştirilemedi";
 
-  static m100(description) =>
+  static m102(description) =>
       "Lütfen bir mp3 ya da waw dosyası seçin. ${description}\'de ses dosyalarını oynatacağız.";
 
-  static m101(description) => "${description}\'de oynatıldı.";
+  static m103(description) => "${description}\'de oynatıldı.";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "Herhangi bir sorunuz varsa veyahut ${appName} uygulamasıyla ile ilgili teknik bir hata bulduğunuzu düşünüyorsanız bunu ekibimize bildirebilir ve destek alabilirsiniz.";
 
-  static m103(coin) => "Lütfen önce ${coin} ve kontör bakiyesini etkinleştirin";
+  static m105(coin) => "Lütfen önce ${coin} ve kontör bakiyesini etkinleştirin";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "${coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "${coin} bakiyesi, işlem ücretlerini karşılayamayacak kadar düşük. ${amount} ${coin} gerekli.";
 
-  static m106(left) => "Kalan işlem: ${left}";
+  static m108(name) =>
+      "Hangi ${name} işlemlerini senkronize etmek istiyorsunuz?";
 
-  static m107(amnt, hash) =>
+  static m109(left) => "Kalan işlem: ${left}";
+
+  static m110(amnt, hash) =>
       "${amnt} fonun kilidi başarıyla kaldırıldı - TX: ${hash}";
 
-  static m108(version) => "${version} sürümünü kullanmaktasınız.";
+  static m111(version) => "${version} sürümünü kullanmaktasınız.";
 
-  static m109(version) =>
+  static m112(version) =>
       "Güncel ${version} sürümü mevcut. Lütfen güncelleyiniz.";
 
-  static m110(appName) => "Komodo Wallet güncellemeleri";
+  static m113(appName) => "Komodo Wallet güncellemeleri";
 
-  static m111(coinAbbr) => "${coinAbbr} koinini etkinleştiremedik.";
+  static m114(coinAbbr) => "${coinAbbr} koinini etkinleştiremedik.";
 
-  static m112(coinAbbr) =>
+  static m115(coinAbbr) =>
       "${coinAbbr} koinini etkinleştiremedik.\nLütfen uygulamayı yeniden başlatıp tekrar deneyiniz.";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "Komodo Wallet mobil yerleşik üçüncü nesil DEX işlevselliği ve daha fazla özellikleri ile yeni nesil bir çoklu koin cüzdanıdır.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "${appName}\'in kameraya erişimi engellenmiş.\nQR kod taramasını yapabilmek için lütfen telefon ayarlarınızdan kamera erişimine izin veriniz.";
 
-  static m115(amount, coinName) => "${amount} adet ${coinName} ÇEK";
+  static m118(amount, coinName) => "${amount} adet ${coinName} ÇEK";
 
-  static m116(amount, coin) => "${amount} adet ${coin} alacaksınız";
+  static m119(amount, coin) => "${amount} adet ${coin} alacaksınız";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -350,6 +357,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("Alıcı adresi"),
         "advanced": MessageLookupByLibrary.simpleMessage("Gelişmiş"),
         "all": MessageLookupByLibrary.simpleMessage("Hepsi"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "Cüzdanınız geçmiş işlemleri gösterecektir. Tüm bloklar indirilip taranacağından bu, önemli miktarda depolama alanı ve zaman alacaktır."),
         "allowCustomSeed":
             MessageLookupByLibrary.simpleMessage("Kişisel kelimeleri kullan"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("Zaten mevcut"),
@@ -421,6 +430,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup":
             MessageLookupByLibrary.simpleMessage("Kamuflajlı PIN Kurulumu"),
         "cancel": MessageLookupByLibrary.simpleMessage("İptal"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Etkinleştirmeyi İptal Et"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("İptal"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("Emri İptal Et"),
         "candleChartError": MessageLookupByLibrary.simpleMessage(
@@ -467,6 +480,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closePreview":
             MessageLookupByLibrary.simpleMessage("Ön izlemeyi kapat"),
         "code": MessageLookupByLibrary.simpleMessage("Kod:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Etkinleştirmeyi iptal etmek istediğinizden emin misiniz?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Temizle"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Aktif koin yok"),
@@ -752,6 +767,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("QR Kodu Bulundu"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("Fransızca"),
         "from": MessageLookupByLibrary.simpleMessage("Gönderici"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "Genel anahtarınızla ilişkili etkinleştirme sonrasında gelecekte yapılacak işlemleri senkronize edeceğiz. Bu en hızlı seçenektir ve en az depolama alanını kaplar."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Gaz ücreti limiti"),
         "gasNotActive": m50,
@@ -832,19 +849,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("Yenile"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "İnternet Bağlantısı Yeniden Sağlandı"),
+        "invalidCoinAddress": m54,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Takasa devam edilemiyor"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Detaylar"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Japonca"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Koreli"),
         "language": MessageLookupByLibrary.simpleMessage("Diller"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("Son İşlemler"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Yasal"),
         "less": MessageLookupByLibrary.simpleMessage("Daha az"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Yükleniyor.."),
         "loadingOrderbook":
             MessageLookupByLibrary.simpleMessage("Emir defteri yükleniyor..."),
@@ -916,11 +934,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("ms"),
         "min": MessageLookupByLibrary.simpleMessage("DK"),
         "minOrder": MessageLookupByLibrary.simpleMessage("En düşük emir hacmi"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Satış miktarından düşük olmalı"),
         "minVolumeTitle":
@@ -929,17 +947,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Uyarı: iOS\'ta uygulamanın simge durumuna küçültülmesi etkinleştirme sürecini sonlandıracaktır."),
         "minutes": MessageLookupByLibrary.simpleMessage("dk"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Daha fazla bilgi"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Daha Fazla"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder":
             MessageLookupByLibrary.simpleMessage("Miktar"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Koin"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("Sat"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("İptal"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("Onayla"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Oluştur"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Emir"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Emirler"),
@@ -955,8 +973,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Geçersiz miktar"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Geçersiz satış miktarı"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt":
             MessageLookupByLibrary.simpleMessage("En fazla satış miktarı:"),
         "multiMinReceiveAmt":
@@ -990,7 +1008,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Bir öğe seçilmedi"),
         "noMatchingOrders":
             MessageLookupByLibrary.simpleMessage("Eşleşen sipariş bulunamadı"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Emir oluşturmak için tıklayın"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1006,7 +1024,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("Girilen değer rakam olmalı"),
         "none": MessageLookupByLibrary.simpleMessage("Hiçbiri"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Takas masrafını karşılayacak bakiye bulunmuyor - daha küçük tutar deneyin"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1015,23 +1033,23 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Not"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Bir şey bulunamadı"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Takas tamamlandı"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Takas başarısız"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Yeni takas başladı"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Takas durumu değişti"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Takas zaman aşımına uğradı"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("Gelen işlem"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Resmi basın açıklaması"),
         "okButton": MessageLookupByLibrary.simpleMessage("Tamam"),
@@ -1042,15 +1060,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("Hata Mesajını Aç"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("Az"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("Daha"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Emir oluşturuldu"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Emir başarıyla oluşturuldu"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Adres"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("İptal"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("için"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("CEX\'de"),
@@ -1063,7 +1081,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ayrıntıları tek dokunuşla açın ve Uzun dokunuşla sipariş et\'i seçin"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Harca"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Detaylar"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("Emir eşleşti"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("Emir eşleşiyor"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("Emir"),
@@ -1072,9 +1090,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("emirler"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Açık"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Geçmiş"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Üstüne yaz"),
         "ownOrder":
             MessageLookupByLibrary.simpleMessage("Bu sizin kendi emriniz !"),
@@ -1085,6 +1103,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Ödendi"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "Parolanız en az 12 karakterden oluşurken en az; bir büyük harf, bir küçük harf ve bir sembol içermelidir."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "Cüzdanınız, belirtilen tarihten sonra yaptığınız geçmiş işlemleri gösterecektir."),
         "paymentUriDetailsAccept": MessageLookupByLibrary.simpleMessage("Öde"),
         "paymentUriDetailsAcceptQuestion": MessageLookupByLibrary.simpleMessage(
             "Bu işlemi kabul ediyor musunuz ?"),
@@ -1097,7 +1117,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("İptal"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Ödeme Talep Edildi"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("Emrinizi girin"),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Lütfen bir Koin Ekleyiniz"),
@@ -1122,19 +1142,19 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("QR Kod Tarayıcı"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Gizli kelimelerimi kaydediyor musunuz ?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Takas işlemleri ne kadar sürmektedir ?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Takas işlemi boyunca çevrimiçi olmam mı gerekir ?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Kullanıcılara destek sunuyor musunuz ?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Uygulamanın kullanılamadığı ülkeler var mı ?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Bu yeni bir dönem! \'AtomicDEX\' olan ismimizi resmi olarak \'Komodo Wallet\' olarak değiştirdik."),
         "receive": MessageLookupByLibrary.simpleMessage("AL"),
@@ -1173,7 +1193,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "KMD aktif kullanıcı ödülleri hakkında daha fazla bilgi edinin"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Al"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat":
             MessageLookupByLibrary.simpleMessage("İtibari para"),
         "rewardsTableRewards":
@@ -1184,9 +1204,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ödül bilgisi:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO amt,\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("Ödül bilgisi"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Rusça"),
         "saveMerged":
@@ -1239,7 +1259,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Kayan Yazı Ara"),
         "seconds": MessageLookupByLibrary.simpleMessage("s"),
         "security": MessageLookupByLibrary.simpleMessage("Güvenlik"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("İşlem Geçmişini Görüntüle"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Gizli Kelimeler"),
@@ -1254,6 +1274,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "ALMAK istediğiniz koini seçin"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "SATMAK istediğiniz koini seçin"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("Bir Tarih Seçin"),
         "selectFileImport": MessageLookupByLibrary.simpleMessage("Dosya seç"),
         "selectLanguage": MessageLookupByLibrary.simpleMessage("Dili Seç"),
         "selectPaymentMethod":
@@ -1276,12 +1297,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Diller"),
         "settings": MessageLookupByLibrary.simpleMessage("Ayarlar"),
         "share": MessageLookupByLibrary.simpleMessage("Paylaş"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("Adresi Göster"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Detayları Göster"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("EMİRLERİMİ GÖSTER"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword":
             MessageLookupByLibrary.simpleMessage("Parola ile giriş yap"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
@@ -1289,24 +1311,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Basit"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Aktifleştir"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Satın al"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Kapat"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Al"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Sat"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Gönder"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Daha az göster"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Daha fazla göster"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Geç"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Kapat"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Ses"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Ses seçenekleri"),
@@ -1318,20 +1340,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Kendi özelleştirilmiş sesli bildirimlerinizi uygulamanın ayarlar bölümünden etkinleştirebileceğinizi unutmayın."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("İspanyolca"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Başlangıç tarihi"),
         "startSwap": MessageLookupByLibrary.simpleMessage("Takası Başlat"),
         "step": MessageLookupByLibrary.simpleMessage("Adım"),
         "success": MessageLookupByLibrary.simpleMessage("Başarılı !"),
         "support": MessageLookupByLibrary.simpleMessage("Destek"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("takas"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Mevcut"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("TAKAS DETAYLARINI ONAYLA"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Yaklaşık"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Takas başarısız"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing":
             MessageLookupByLibrary.simpleMessage("Takas devam ediyor"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("İşlem detayları"),
@@ -1340,6 +1363,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Toplam"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("Takas UUID"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Temayı Değiştir"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Belirtilen tarihten itibaren senkronizasyon"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Fidan aktivasyonundan senkronizasyon"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Yeni işlemleri senkronize et"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1399,25 +1429,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded": MessageLookupByLibrary.simpleMessage(
             "Çok fazla istek.\nİşlem geçmişi istekleri sınırı aşıldı.\nLütfen daha sonra tekrar deneyiniz."),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("onaylanmamış"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("Ukrayna"),
         "unlock": MessageLookupByLibrary.simpleMessage("kilidi aç"),
         "unlockFunds":
             MessageLookupByLibrary.simpleMessage("Fonların Kilidini Açın"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("harcanamaz"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Yeni sürüm mevcut"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage(
             "Güncellemeler kontrol ediliyor.."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Yeni sürüm mevcut. Lütfen güncelleyiniz."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Güncelleme mevcut"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("Şimdilik atla"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Son sürüm yüklü"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Güncelle"),
@@ -1443,9 +1473,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Tamam"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Dikkat ! Bu kayıt defteri özel durumlarda, başarısız takaslardan kalan koinlerin harcanmasına sebep olabilecek hassas bilgiler içerebilir."),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("HADİ AYARLAYALIM !"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("HOŞ GELDİNİZ"),
@@ -1455,14 +1485,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Bu biraz zaman alacak ve uygulamanın ön planda tutulması gerekiyor.\nEtkinleştirme devam ederken uygulamayı sonlandırmak sorunlara yol açabilir."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Çek"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Erişim Engellendi"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Çekimi Onayla"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Bir hata oluştu. Lütfen daha sonra tekrar deneyiniz."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1":
             MessageLookupByLibrary.simpleMessage("QR kodlu bir ödemeyi"),
         "wrongCoinSpan2":
@@ -1484,7 +1514,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "yeni siparişlerin eşleşebileceği bir siparişiniz var"),
         "youAreSending":
             MessageLookupByLibrary.simpleMessage("Gönderiyorsunuz:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("Alacağınız:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("Cüzdanınız")
       };

--- a/lib/l10n/messages_uk.dart
+++ b/lib/l10n/messages_uk.dart
@@ -76,232 +76,238 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "Яке ${index} слово у вашій насінній фразі?";
 
-  static m22(protocolName) => "Монети ${protocolName} активовані";
+  static m22(coin) => "Активацію ${coin} скасовано";
 
-  static m23(protocolName) => "Монети ${protocolName} успішно активовані";
+  static m23(coin) => "Успішно активовано ${coin}";
 
-  static m24(protocolName) => "Монети ${protocolName} не активовані";
+  static m24(protocolName) => "Монети ${protocolName} активовані";
 
-  static m25(name) => "Ви впевнені, що хочете видалити контакт ${name}?";
+  static m25(protocolName) => "Монети ${protocolName} успішно активовані";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "Монети ${protocolName} не активовані";
+
+  static m27(name) => "Ви впевнені, що хочете видалити контакт ${name}?";
+
+  static m28(iUnderstand) =>
       "Довільна насінна фраза може бути менш безпечною та її легше зламати, ніж згенерована початкова фраза або закритий ключ (WIF), сумісна з BIP39. Щоб підтвердити, що ви розумієте ризик і знаєте, що робите, введіть \"\$${iUnderstand}\" у полі нижче.";
 
-  static m27(coinName) => "отримати комісію за транзакцію ${coinName}";
+  static m29(coinName) => "отримати комісію за транзакцію ${coinName}";
 
-  static m28(coinName) => "надіслати комісію за транзакцію ${coinName}";
+  static m30(coinName) => "надіслати комісію за транзакцію ${coinName}";
 
-  static m29(abbr) => "Ведіть ${abbr} адресу";
+  static m31(abbr) => "Ведіть ${abbr} адресу";
 
-  static m30(selected, remains) =>
+  static m32(selected, remains) =>
       "Ви все ще можете ввімкнути ${remains}, Вибрано: ${selected}";
 
-  static m31(gas) => "Недостатньо газу  - використовуйте принаймні ${gas} Gwei";
+  static m33(gas) => "Недостатньо газу  - використовуйте принаймні ${gas} Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}.\nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application.\nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights.\nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.\n\n";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.\n\n";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).\n\n";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages.\nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You.\nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from:\n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses;\n(b) server failure or data loss;\n(c) corrupted or otherwise non-performing Wallets or Wallet files;\n(d) unauthorized access to applications;\n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.\n\n";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.\n\n";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}.\nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination.\nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination.\n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time.\n\n";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.\n\n";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data).\nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.\n\n";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities.\nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.\n\n";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.\n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.\n\n";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:\n\n";
 
-  static m46(coin) => "Надсилання запиту на FAUCET ${coin}...";
+  static m48(coinAbbr) => "Не вдалося скасувати активацію ${coinAbbr}";
 
-  static m47(appCompanyShort) => "Новини ${appCompanyShort}";
+  static m49(coin) => "Надсилання запиту на FAUCET ${coin}...";
 
-  static m48(value) => "Комісії мають бути до ${value}";
+  static m50(appCompanyShort) => "Новини ${appCompanyShort}";
 
-  static m49(coin) => "Комісія ${coin}";
+  static m51(value) => "Комісії мають бути до ${value}";
 
-  static m50(coin) => "Будь ласка, активуйте ${coin}.";
+  static m52(coin) => "Комісія ${coin}";
 
-  static m51(value) => "Gwei має бути до ${value}";
+  static m53(coin) => "Будь ласка, активуйте ${coin}.";
 
-  static m52(coinName) => "Налаштування захисту вхідних ${coinName} txs";
+  static m54(value) => "Gwei має бути до ${value}";
 
-  static m53(abbr) =>
+  static m55(coinName) => "Налаштування захисту вхідних ${coinName} txs";
+
+  static m56(abbr) =>
       "${abbr} балансу недостатньо для оплати комісії за торгівлю";
 
-  static m54(coin) => "Недійсна адреса ${coin}";
+  static m57(coin) => "Недійсна адреса ${coin}";
 
-  static m55(coinAbbr) => "${coinAbbr} недоступен :(";
+  static m58(coinAbbr) => "${coinAbbr} недоступен :(";
 
-  static m56(coinName) =>
+  static m59(coinName) =>
       "❗Обережно! Ринок для ${coinName} має менше 10 тисяч доларів США за 24 години!";
 
-  static m57(value) => "Обмеження має бути до ${value}";
-
-  static m58(coinName, number) =>
-      "Мінімальна сума для продажу становить ${number} ${coinName}";
-
-  static m59(coinName, number) =>
-      "Мінімальна сума для купівлі становить ${number}${coinName}";
-
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
-      "Мінімальна сума замовлення становить ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
+  static m60(value) => "Обмеження має бути до ${value}";
 
   static m61(coinName, number) =>
+      "Мінімальна сума для продажу становить ${number} ${coinName}";
+
+  static m62(coinName, number) =>
+      "Мінімальна сума для купівлі становить ${number}${coinName}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
+      "Мінімальна сума замовлення становить ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
+
+  static m64(coinName, number) =>
       "Мінімальна сума для продажу становить ${number}${coinName}";
 
-  static m62(minValue, coin) => "Має бути більше ніж ${minValue} ${coin}";
+  static m65(minValue, coin) => "Має бути більше ніж ${minValue} ${coin}";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "Зауважте, що зараз ви використовуєте мобільні дані та участь у мережі ${appName} P2P споживає інтернет-трафік. Краще використовувати мережу WiFi, якщо ваш тарифний план стільникового зв’язку є дорогим.";
 
-  static m64(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
+  static m67(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
 
-  static m65(number) => "Створіть замовлення (${number}):";
+  static m68(number) => "Створіть замовлення (${number}):";
 
-  static m66(coin) => "Баланс ${coin} замалий";
+  static m69(coin) => "Баланс ${coin} замалий";
 
-  static m67(coin, fee) =>
+  static m70(coin, fee) =>
       "Недостатньо ${coin} для оплати комісії. MIN баланс становить ${fee} ${coin}";
 
-  static m68(coinName) => "Введіть суму ${coinName}.";
+  static m71(coinName) => "Введіть суму ${coinName}.";
 
-  static m69(coin) => "Недостатньо ${coin} для транзакції!";
+  static m72(coin) => "Недостатньо ${coin} для транзакції!";
 
-  static m70(sell, buy) => "Обмін ${sell}/${buy} успішно завершено";
+  static m73(sell, buy) => "Обмін ${sell}/${buy} успішно завершено";
 
-  static m71(sell, buy) => "Не вдалося обміняти ${sell}/${buy}";
+  static m74(sell, buy) => "Не вдалося обміняти ${sell}/${buy}";
 
-  static m72(sell, buy) => "Розпочато обмін ${sell}/${buy}";
+  static m75(sell, buy) => "Розпочато обмін ${sell}/${buy}";
 
-  static m73(sell, buy) => "Час очікування обміну ${sell}/${buy} минув";
+  static m76(sell, buy) => "Час очікування обміну ${sell}/${buy} минув";
 
-  static m74(coin) => "Ви отримали ${coin} трансакцію!";
+  static m77(coin) => "Ви отримали ${coin} трансакцію!";
 
-  static m75(assets) => "${assets} активів";
+  static m78(assets) => "${assets} активів";
 
-  static m76(coin) => "Усі замовлення ${coin} буде скасовано.";
+  static m79(coin) => "Усі замовлення ${coin} буде скасовано.";
 
-  static m77(delta) => "Доцільно: CEX +${delta}%";
+  static m80(delta) => "Доцільно: CEX +${delta}%";
 
-  static m78(delta) => "Дорого: CEX ${delta}%";
+  static m81(delta) => "Дорого: CEX ${delta}%";
 
-  static m79(fill) => "${fill}% заповнено";
+  static m82(fill) => "${fill}% заповнено";
 
-  static m80(coin) => "Сума (${coin})";
+  static m83(coin) => "Сума (${coin})";
 
-  static m81(coin) => "Ціна (${coin})";
+  static m84(coin) => "Ціна (${coin})";
 
-  static m82(coin) => "Усього (${coin})";
+  static m85(coin) => "Усього (${coin})";
 
-  static m83(abbr) =>
+  static m86(abbr) =>
       "${abbr} не активний. Будь ласка, активуйте і спробуйте ще раз.";
 
-  static m84(appName) => "На яких пристроях я можу використовувати ${appName}?";
-
-  static m85(appName) =>
-      "Чим торгівля в ${appName} відрізняється від торгівлі в інших DEX?";
-
-  static m86(appName) => "Як розраховуються комісії за ${appName}?";
-
-  static m87(appName) => "Хто стоїть за ${appName}?";
+  static m87(appName) => "На яких пристроях я можу використовувати ${appName}?";
 
   static m88(appName) =>
+      "Чим торгівля в ${appName} відрізняється від торгівлі в інших DEX?";
+
+  static m89(appName) => "Як розраховуються комісії за ${appName}?";
+
+  static m90(appName) => "Хто стоїть за ${appName}?";
+
+  static m91(appName) =>
       "Чи можна розробити власну біржу white-label у ${appName}?";
 
-  static m89(amount) => "Успіх! Отримано ${amount} KMD.";
+  static m92(amount) => "Успіх! Отримано ${amount} KMD.";
 
-  static m90(dd) => "${dd} дн.";
+  static m93(dd) => "${dd} дн.";
 
-  static m93(amount) => "Натистіть щоб побачити ${amount} угоди";
+  static m96(amount) => "Натистіть щоб побачити ${amount} угоди";
 
-  static m94(coinName, address) => "Моя адреса ${coinName}:\n${address}";
+  static m97(coinName, address) => "Моя адреса ${coinName}:\n${address}";
 
-  static m95(coin) => "Сканувати минулі транзакції ${coin}?";
+  static m98(coin) => "Сканувати минулі транзакції ${coin}?";
 
-  static m96(count, maxCount) => "Показано ${count} із ${maxCount} замовлень.";
+  static m99(count, maxCount) => "Показано ${count} із ${maxCount} замовлень.";
 
-  static m97(coin) => "Будь ласка, введіть ${coin} суму для купівлі";
+  static m100(coin) => "Будь ласка, введіть ${coin} суму для купівлі";
 
-  static m98(maxCoins) =>
+  static m101(maxCoins) =>
       "Максимальна кількість активних монет становить ${maxCoins}. Будь ласка, деактивуйте кілька монет.";
 
-  static m99(coin) => "${coin} не активований!";
+  static m102(coin) => "${coin} не активований!";
 
-  static m100(coin) => "Будь ласка, введіть ${coin} суму для продажу";
+  static m103(coin) => "Будь ласка, введіть ${coin} суму для продажу";
 
-  static m101(coin) => "Неможливо активувати ${coin}";
+  static m104(coin) => "Неможливо активувати ${coin}";
 
-  static m102(description) =>
+  static m105(description) =>
       "Будь ласка, виберіть файл mp3 або wav. Ми почнемо це, коли ${description}.";
 
-  static m103(description) => "Грає, коли ${description}";
+  static m106(description) => "Грає, коли ${description}";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "Якщо у вас виникли запитання або ви вважаєте, що виявили технічну проблему з додатком ${appName}, ви можете повідомити про це та отримати підтримку від нашої команди.";
 
-  static m105(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
+  static m108(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
 
-  static m106(coin) =>
+  static m109(coin) =>
       "На балансі ${coin} недостатньо для оплати комісії за трансакцію.";
 
-  static m107(coin, amount) =>
+  static m110(coin, amount) =>
       "На балансі ${coin} недостатньо для оплати комісії за трансакцію. Потрібно ${coin} ${amount}.";
 
-  static m108(name) => "Які транзакції ${name} ви хочете синхронізувати?";
+  static m111(name) => "Які транзакції ${name} ви хочете синхронізувати?";
 
-  static m109(left) => "Транзакцій залишилось: ${left}";
+  static m112(left) => "Транзакцій залишилось: ${left}";
 
-  static m110(amnt, hash) => "Успішно розблоковано ${amnt} - TX: ${hash}";
+  static m113(amnt, hash) => "Успішно розблоковано ${amnt} - TX: ${hash}";
 
-  static m111(version) => "Ви використовуєте версію ${version}";
+  static m114(version) => "Ви використовуєте версію ${version}";
 
-  static m112(version) => "Доступна версія ${version}. Будь ласка, оновіть.";
+  static m115(version) => "Доступна версія ${version}. Будь ласка, оновіть.";
 
-  static m113(appName) => "Оновлення ${appName}";
+  static m116(appName) => "Оновлення ${appName}";
 
-  static m114(coinAbbr) => "Не вдалося активувати ${coinAbbr}";
+  static m117(coinAbbr) => "Не вдалося активувати ${coinAbbr}";
 
-  static m115(coinAbbr) =>
+  static m118(coinAbbr) =>
       "Не вдалося активувати ${coinAbbr}. Будь-ласка спробуйте ще";
 
-  static m116(appName) =>
+  static m119(appName) =>
       "${appName} mobile — це мультимонетний гаманець нового покоління з вбудованою функцією DEX третього покоління та більше.";
 
-  static m117(appName) =>
+  static m120(appName) =>
       "Ви раніше забороняли ${appName} доступ до камери. Будь ласка, вручну змініть дозвіл камери в налаштуваннях телефону, щоб продовжити сканування QR-коду";
 
-  static m118(amount, coinName) => "ВІДПРАВИТИ ${amount} ${coinName}";
+  static m121(amount, coinName) => "ВІДПРАВИТИ ${amount} ${coinName}";
 
-  static m119(amount, coin) => "Ви отримаєте ${amount} ${coin}";
+  static m122(amount, coin) => "Ви отримаєте ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -330,6 +336,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled":
+            MessageLookupByLibrary.simpleMessage("Активацію монет скасовано"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("Активувати монету"),
         "addingCoinSuccess": m4,
@@ -481,6 +489,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("Код:"),
         "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
             "Ви впевнені, що бажаєте скасувати активацію?"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Стерти"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Немає активних монет"),
@@ -488,9 +498,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Виберіть монету"),
         "coinsActivatedLimitReached": MessageLookupByLibrary.simpleMessage(
             "Ви вибрали максимальну кількість ресурсів"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("Незабаром..."),
         "commingsoon":
             MessageLookupByLibrary.simpleMessage("Деталі TX незабаром!"),
@@ -522,7 +532,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactDelete":
             MessageLookupByLibrary.simpleMessage("Видалити контакт"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("Видалити"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("Відмінити"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("Редагувати"),
         "contactExit": MessageLookupByLibrary.simpleMessage("Вихід"),
@@ -551,7 +561,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("Довільна комісія "),
         "customFeeWarning": MessageLookupByLibrary.simpleMessage(
             "Використовуйте довільні комісії, лише якщо знаєте, що робите!"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Безпека Komodo dPoW"),
         "date": MessageLookupByLibrary.simpleMessage("Дата"),
         "decryptingWallet":
@@ -569,8 +579,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Видалити гаманець"),
         "deletingWallet":
             MessageLookupByLibrary.simpleMessage("Видалення гаманця..."),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage(
                 "відправити плату за торгівлю плату за транзакцію"),
@@ -596,7 +606,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "duration": MessageLookupByLibrary.simpleMessage("Тривалість"),
         "editContact":
             MessageLookupByLibrary.simpleMessage("Редагувати контакт"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage(
             "Пароль шифрування не може бути порожнім"),
         "emptyImportPass": MessageLookupByLibrary.simpleMessage(
@@ -605,7 +615,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ім’я контакта не може бути пустим"),
         "emptyWallet": MessageLookupByLibrary.simpleMessage(
             "Ім’я гаманця не може бути пустим"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage(
                 "Увімкніть сповіщення, щоб отримувати оновлення про хід активації."),
@@ -642,7 +652,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Недійсна адреса"),
         "errorNotAValidAddressSegWit": MessageLookupByLibrary.simpleMessage(
             "Адреси Segwit не підтримуються (поки що)"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain":
             MessageLookupByLibrary.simpleMessage("Помилка, спробуйте ще раз"),
         "errorTryLater":
@@ -653,32 +663,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Будь-ласка введіть дані"),
         "estimateValue": MessageLookupByLibrary.simpleMessage(
             "Розрахункова загальна вартість"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information;\n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section.\n\n"),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any.\n\n"),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases.\n\n"),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application.\nYour access to this application does not itself create an adviser-client relationship between You and us.\nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us.\nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document.\n\n"),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free.\nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies).\n\n"),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY\n\n"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -730,19 +740,20 @@ class MessageLookup extends MessageLookupByLibrary {
             "Елементи успішно експортовано:"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("Обмін"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("Експорт"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt":
             MessageLookupByLibrary.simpleMessage("Підроблена сума балансу:"),
         "faqTitle":
             MessageLookupByLibrary.simpleMessage("Часто задавані питання"),
         "faucetError": MessageLookupByLibrary.simpleMessage("Помилка"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("FAUCET"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("Успіх"),
         "faucetTimedOut":
             MessageLookupByLibrary.simpleMessage("Час запиту вичерпано"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("Новини"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("Тут нічого"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("Детальніше..."),
         "feedTab": MessageLookupByLibrary.simpleMessage("Новини"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("Стрічка новин"),
@@ -755,7 +766,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Стрічку новин оновлено"),
         "feedback":
             MessageLookupByLibrary.simpleMessage("Поділитися файлом журналу"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("Все"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("Фільтр"),
         "filtersClearAll":
@@ -780,9 +791,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("Від"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "Ми будемо синхронізувати майбутні транзакції, здійснені після активації, пов’язаної з вашим відкритим ключем. Це найшвидший варіант, який займає найменшу кількість пам’яті."),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Ліміт комісії"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("Ціна на комісію"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "Загальний захист PIN-кодом не активний.\nРежим камуфляжу буде недоступний.\nУвімкніть захист PIN-кодом."),
@@ -792,7 +803,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Отримання трансакції, зачекайте"),
         "goToPorfolio":
             MessageLookupByLibrary.simpleMessage("Перейти до портфоліо"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("Допомога"),
         "helpTitle":
             MessageLookupByLibrary.simpleMessage("Допомога та підтримка"),
@@ -846,7 +857,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError": MessageLookupByLibrary.simpleMessage(
             "Помилка декодування файлу json"),
         "importTitle": MessageLookupByLibrary.simpleMessage("Імпорт"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog": MessageLookupByLibrary.simpleMessage(
             "Використовуйте надійний пароль і не зберігайте його ні на одному пристрої"),
         "infoTrade1": MessageLookupByLibrary.simpleMessage(
@@ -855,7 +866,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Обмін може тривати до 60 хвилин. НЕ закривайте додаток!"),
         "infoWalletPassword": MessageLookupByLibrary.simpleMessage(
             "Ви повинні вказати пароль для шифрування гаманця з міркувань безпеки."),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage(
             "Мінімальна кількість, необхідна для цього замовлення"),
         "insufficientTitle":
@@ -864,20 +875,20 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Оновити"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Підключення до Інтернету відновлено"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Неможливо продовжити обмін"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Подробиці"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Японська"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Корейська"),
         "language": MessageLookupByLibrary.simpleMessage("Мова"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("Останні транзакції"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Юридичний"),
         "less": MessageLookupByLibrary.simpleMessage("Менше"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("Завантаження..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
             "Завантаження книги замовлень..."),
@@ -952,11 +963,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("ХВ"),
         "minOrder": MessageLookupByLibrary.simpleMessage(
             "Мінімальна кількість замовлень:"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Має бути нижчою за суму продажу"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -966,10 +977,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Попередження: згортання програми на iOS припинить процес активації."),
         "minutes": MessageLookupByLibrary.simpleMessage("хв"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Більше інформації"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Більше"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("Сума"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Монета"),
         "multiBaseSelectTitle":
@@ -977,7 +988,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Скасувати"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Підтвердити"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Створити"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Замовлення"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Замовлення"),
@@ -992,8 +1003,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Недійсна сума"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Недійсна сума продажу"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage(
             "Максимальна сума продажу становить"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
@@ -1027,7 +1038,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Елементи не вибрано"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Відповідних замовлень не знайдено"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Натисніть, щоб створити замовлення"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1042,7 +1053,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("Значення має бути числовим"),
         "none": MessageLookupByLibrary.simpleMessage("Жодного"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Недостатньо балансу для комісій - торгуйте на меншу суму"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1052,24 +1063,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Примітка"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Нічого не знайдено"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Обмін завершено"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Помилка обміну"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Розпочато новий обмін"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Статус обміну змінено"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Час очікування обміну минув"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Вхідна транзакція"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Офіційний прес-реліз"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ок"),
@@ -1081,15 +1092,15 @@ class MessageLookup extends MessageLookupByLibrary {
             "Відкрийте повідомлення про помилку"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("менше"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("більше"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Замовлення створено"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Замовлення успішно створено"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Адреса"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Скасувати"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("для"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Ідентичний CEX"),
@@ -1102,7 +1113,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Відкрийте «Деталі» одним дотиком і виберіть «Замовити довгим дотиком»."),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Витратити"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Подробиці"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched":
             MessageLookupByLibrary.simpleMessage("Замовлення поєднане"),
         "orderMatching":
@@ -1113,9 +1124,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("Замовлення"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Активні"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Історія"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("Перезаписати"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("Це ваше замовлення!"),
         "paidFromBalance":
@@ -1141,9 +1152,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Скасувати"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Запит на оплату"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder":
             MessageLookupByLibrary.simpleMessage("Розмістіть своє замовлення"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage(
+                "Будь ласка, прийміть усі спеціальні запити на активацію монет або скасуйте вибір монет."),
         "pleaseAddCoin":
             MessageLookupByLibrary.simpleMessage("Будь ласка додайте монету"),
         "pleaseRestart": MessageLookupByLibrary.simpleMessage(
@@ -1166,19 +1180,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("Сканер QR-коду"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Ви зберігаєте мої особисті ключі?"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Скільки часу займає кожна атомарна заміна?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Чи потрібно мені бути онлайн під час обміну?"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Чи забезпечуєте ви підтримку користувачів?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Чи є у вас обмеження по країні?"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Це нова ера! Ми офіційно змінили назву з \"AtomicDEX\" на \"Komodo Wallet\""),
         "receive": MessageLookupByLibrary.simpleMessage("ОТРИМАТИ"),
@@ -1218,7 +1232,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Докладніше про нагороди KMD для активних користувачів"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Отримати"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Фіат"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Нагороди,\nKMD"),
@@ -1228,7 +1242,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Інформація про нагороди:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO кіл,\nKMD"),
-        "rewardsTimeDays": m90,
+        "rewardsTimeDays": m93,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Інформація про нагороди"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Російська"),
@@ -1282,7 +1296,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Шукати по тікету"),
         "seconds": MessageLookupByLibrary.simpleMessage("с"),
         "security": MessageLookupByLibrary.simpleMessage("Безпека"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("Побачити історію транзакції"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Фраза насіння"),
@@ -1323,13 +1337,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Мови"),
         "settings": MessageLookupByLibrary.simpleMessage("Налаштування"),
         "share": MessageLookupByLibrary.simpleMessage("Поділитись"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("Показати адресу"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Показати деталі"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("Показати мої угоди"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword": MessageLookupByLibrary.simpleMessage(
             "Увійдіть за допомогою пароля"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
@@ -1337,24 +1351,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Простий"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Активувати"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Купити"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Закрити"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Отримати"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Продати"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Надіслати"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Показати менше"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Показати більше"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("Пропустити"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Відхилити"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Звук"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Налаштування звуку"),
@@ -1371,16 +1385,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("Крок"),
         "success": MessageLookupByLibrary.simpleMessage("Успішно!"),
         "support": MessageLookupByLibrary.simpleMessage("Підтримка"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("своп"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Поточний"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("ПІДТВЕРДИТИ ДЕТАЛІ ОБМІНУ"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Оцінка"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Помилка обміну"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Обмін триває"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("Деталі прогресу"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("Розпочато"),
@@ -1394,7 +1408,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Синхронізація з активації саджанця"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
             "Синхронізувати нові транзакції"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1458,26 +1472,26 @@ class MessageLookup extends MessageLookupByLibrary {
             "Забагато запитів.\nПеревищено ліміт запитів історії транзакцій.\nБудь-ласка спробуйте пізніше."),
         "txNotConfirmed":
             MessageLookupByLibrary.simpleMessage("НЕПІДТВЕРДЖЕНО"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage":
             MessageLookupByLibrary.simpleMessage("Український"),
         "unlock": MessageLookupByLibrary.simpleMessage("розблокувати"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Розблокувати"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("невитрачений"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Доступна нова версія"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Перевірка оновлень..."),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Доступна нова версія. Будь ласка, оновіть."),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Доступне оновлення"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Пропустити поки що"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Вже актуально"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Оновлення"),
@@ -1503,9 +1517,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ок"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Увага! В особливих випадках дані журналу містять конфіденційну інформацію, яка може бути використана для витрачання монет із невдалих обмінів!"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("ДАВАЙТЕ НАЛАШТОВУВАТИ!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("ЛАСКАВО ПРОСИМО"),
@@ -1515,14 +1529,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Це займе деякий час, і програма має залишатися в активному режимі.\nЗакриття програми під час активації може призвести до проблем."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Відправити"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Доступ заборонено"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Підтвердити зняття"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Щось пішло не так. Спробуйте ще раз пізніше."),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Ви намагаєтеся відсканувати платіжний QR-код для"),
         "wrongCoinSpan2":
@@ -1542,7 +1556,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "у вас є замовлення, з яким можуть відповідати нові замовлення"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Ви надсилаєте:"),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("Ви отримаєте:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("твій гаманець")

--- a/lib/l10n/messages_uk.dart
+++ b/lib/l10n/messages_uk.dart
@@ -157,145 +157,151 @@ class MessageLookup extends MessageLookupByLibrary {
   static m53(abbr) =>
       "${abbr} балансу недостатньо для оплати комісії за торгівлю";
 
-  static m54(coinAbbr) => "${coinAbbr} недоступен :(";
+  static m54(coin) => "Недійсна адреса ${coin}";
 
-  static m55(coinName) =>
+  static m55(coinAbbr) => "${coinAbbr} недоступен :(";
+
+  static m56(coinName) =>
       "❗Обережно! Ринок для ${coinName} має менше 10 тисяч доларів США за 24 години!";
 
-  static m56(value) => "Обмеження має бути до ${value}";
-
-  static m57(coinName, number) =>
-      "Мінімальна сума для продажу становить ${number} ${coinName}";
+  static m57(value) => "Обмеження має бути до ${value}";
 
   static m58(coinName, number) =>
+      "Мінімальна сума для продажу становить ${number} ${coinName}";
+
+  static m59(coinName, number) =>
       "Мінімальна сума для купівлі становить ${number}${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "Мінімальна сума замовлення становить ${buyAmount}${buyCoin}\n(${sellAmount}${sellCoin})";
 
-  static m60(coinName, number) =>
+  static m61(coinName, number) =>
       "Мінімальна сума для продажу становить ${number}${coinName}";
 
-  static m61(minValue, coin) => "Має бути більше ніж ${minValue} ${coin}";
+  static m62(minValue, coin) => "Має бути більше ніж ${minValue} ${coin}";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "Зауважте, що зараз ви використовуєте мобільні дані та участь у мережі ${appName} P2P споживає інтернет-трафік. Краще використовувати мережу WiFi, якщо ваш тарифний план стільникового зв’язку є дорогим.";
 
-  static m63(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
+  static m64(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
 
-  static m64(number) => "Створіть замовлення (${number}):";
+  static m65(number) => "Створіть замовлення (${number}):";
 
-  static m65(coin) => "Баланс ${coin} замалий";
+  static m66(coin) => "Баланс ${coin} замалий";
 
-  static m66(coin, fee) =>
+  static m67(coin, fee) =>
       "Недостатньо ${coin} для оплати комісії. MIN баланс становить ${fee} ${coin}";
 
-  static m67(coinName) => "Введіть суму ${coinName}.";
+  static m68(coinName) => "Введіть суму ${coinName}.";
 
-  static m68(coin) => "Недостатньо ${coin} для транзакції!";
+  static m69(coin) => "Недостатньо ${coin} для транзакції!";
 
-  static m69(sell, buy) => "Обмін ${sell}/${buy} успішно завершено";
+  static m70(sell, buy) => "Обмін ${sell}/${buy} успішно завершено";
 
-  static m70(sell, buy) => "Не вдалося обміняти ${sell}/${buy}";
+  static m71(sell, buy) => "Не вдалося обміняти ${sell}/${buy}";
 
-  static m71(sell, buy) => "Розпочато обмін ${sell}/${buy}";
+  static m72(sell, buy) => "Розпочато обмін ${sell}/${buy}";
 
-  static m72(sell, buy) => "Час очікування обміну ${sell}/${buy} минув";
+  static m73(sell, buy) => "Час очікування обміну ${sell}/${buy} минув";
 
-  static m73(coin) => "Ви отримали ${coin} трансакцію!";
+  static m74(coin) => "Ви отримали ${coin} трансакцію!";
 
-  static m74(assets) => "${assets} активів";
+  static m75(assets) => "${assets} активів";
 
-  static m75(coin) => "Усі замовлення ${coin} буде скасовано.";
+  static m76(coin) => "Усі замовлення ${coin} буде скасовано.";
 
-  static m76(delta) => "Доцільно: CEX +${delta}%";
+  static m77(delta) => "Доцільно: CEX +${delta}%";
 
-  static m77(delta) => "Дорого: CEX ${delta}%";
+  static m78(delta) => "Дорого: CEX ${delta}%";
 
-  static m78(fill) => "${fill}% заповнено";
+  static m79(fill) => "${fill}% заповнено";
 
-  static m79(coin) => "Сума (${coin})";
+  static m80(coin) => "Сума (${coin})";
 
-  static m80(coin) => "Ціна (${coin})";
+  static m81(coin) => "Ціна (${coin})";
 
-  static m81(coin) => "Усього (${coin})";
+  static m82(coin) => "Усього (${coin})";
 
-  static m82(abbr) =>
+  static m83(abbr) =>
       "${abbr} не активний. Будь ласка, активуйте і спробуйте ще раз.";
 
-  static m83(appName) => "На яких пристроях я можу використовувати ${appName}?";
+  static m84(appName) => "На яких пристроях я можу використовувати ${appName}?";
 
-  static m84(appName) =>
+  static m85(appName) =>
       "Чим торгівля в ${appName} відрізняється від торгівлі в інших DEX?";
 
-  static m85(appName) => "Як розраховуються комісії за ${appName}?";
+  static m86(appName) => "Як розраховуються комісії за ${appName}?";
 
-  static m86(appName) => "Хто стоїть за ${appName}?";
+  static m87(appName) => "Хто стоїть за ${appName}?";
 
-  static m87(appName) =>
+  static m88(appName) =>
       "Чи можна розробити власну біржу white-label у ${appName}?";
 
-  static m88(amount) => "Успіх! Отримано ${amount} KMD.";
+  static m89(amount) => "Успіх! Отримано ${amount} KMD.";
 
-  static m89(dd) => "${dd} дн.";
+  static m90(dd) => "${dd} дн.";
 
-  static m92(amount) => "Натистіть щоб побачити ${amount} угоди";
+  static m93(amount) => "Натистіть щоб побачити ${amount} угоди";
 
-  static m93(coinName, address) => "Моя адреса ${coinName}:\n${address}";
+  static m94(coinName, address) => "Моя адреса ${coinName}:\n${address}";
 
-  static m94(count, maxCount) => "Показано ${count} із ${maxCount} замовлень.";
+  static m95(coin) => "Сканувати минулі транзакції ${coin}?";
 
-  static m95(coin) => "Будь ласка, введіть ${coin} суму для купівлі";
+  static m96(count, maxCount) => "Показано ${count} із ${maxCount} замовлень.";
 
-  static m96(maxCoins) =>
+  static m97(coin) => "Будь ласка, введіть ${coin} суму для купівлі";
+
+  static m98(maxCoins) =>
       "Максимальна кількість активних монет становить ${maxCoins}. Будь ласка, деактивуйте кілька монет.";
 
-  static m97(coin) => "${coin} не активований!";
+  static m99(coin) => "${coin} не активований!";
 
-  static m98(coin) => "Будь ласка, введіть ${coin} суму для продажу";
+  static m100(coin) => "Будь ласка, введіть ${coin} суму для продажу";
 
-  static m99(coin) => "Неможливо активувати ${coin}";
+  static m101(coin) => "Неможливо активувати ${coin}";
 
-  static m100(description) =>
+  static m102(description) =>
       "Будь ласка, виберіть файл mp3 або wav. Ми почнемо це, коли ${description}.";
 
-  static m101(description) => "Грає, коли ${description}";
+  static m103(description) => "Грає, коли ${description}";
 
-  static m102(appName) =>
+  static m104(appName) =>
       "Якщо у вас виникли запитання або ви вважаєте, що виявили технічну проблему з додатком ${appName}, ви можете повідомити про це та отримати підтримку від нашої команди.";
 
-  static m103(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
+  static m105(coin) => "Спочатку активуйте ${coin} і поповніть баланс";
 
-  static m104(coin) =>
+  static m106(coin) =>
       "На балансі ${coin} недостатньо для оплати комісії за трансакцію.";
 
-  static m105(coin, amount) =>
+  static m107(coin, amount) =>
       "На балансі ${coin} недостатньо для оплати комісії за трансакцію. Потрібно ${coin} ${amount}.";
 
-  static m106(left) => "Транзакцій залишилось: ${left}";
+  static m108(name) => "Які транзакції ${name} ви хочете синхронізувати?";
 
-  static m107(amnt, hash) => "Успішно розблоковано ${amnt} - TX: ${hash}";
+  static m109(left) => "Транзакцій залишилось: ${left}";
 
-  static m108(version) => "Ви використовуєте версію ${version}";
+  static m110(amnt, hash) => "Успішно розблоковано ${amnt} - TX: ${hash}";
 
-  static m109(version) => "Доступна версія ${version}. Будь ласка, оновіть.";
+  static m111(version) => "Ви використовуєте версію ${version}";
 
-  static m110(appName) => "Оновлення ${appName}";
+  static m112(version) => "Доступна версія ${version}. Будь ласка, оновіть.";
 
-  static m111(coinAbbr) => "Не вдалося активувати ${coinAbbr}";
+  static m113(appName) => "Оновлення ${appName}";
 
-  static m112(coinAbbr) =>
+  static m114(coinAbbr) => "Не вдалося активувати ${coinAbbr}";
+
+  static m115(coinAbbr) =>
       "Не вдалося активувати ${coinAbbr}. Будь-ласка спробуйте ще";
 
-  static m113(appName) =>
+  static m116(appName) =>
       "${appName} mobile — це мультимонетний гаманець нового покоління з вбудованою функцією DEX третього покоління та більше.";
 
-  static m114(appName) =>
+  static m117(appName) =>
       "Ви раніше забороняли ${appName} доступ до камери. Будь ласка, вручну змініть дозвіл камери в налаштуваннях телефону, щоб продовжити сканування QR-коду";
 
-  static m115(amount, coinName) => "ВІДПРАВИТИ ${amount} ${coinName}";
+  static m118(amount, coinName) => "ВІДПРАВИТИ ${amount} ${coinName}";
 
-  static m116(amount, coin) => "Ви отримаєте ${amount} ${coin}";
+  static m119(amount, coin) => "Ви отримаєте ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -343,6 +349,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Адреса отримувача"),
         "advanced": MessageLookupByLibrary.simpleMessage("Розвинутий"),
         "all": MessageLookupByLibrary.simpleMessage("Усі"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "У вашому гаманці відображатимуться всі минулі транзакції. Це займе багато пам’яті та часу, оскільки всі блоки будуть завантажені та відскановані."),
         "allowCustomSeed":
             MessageLookupByLibrary.simpleMessage("Дозволити довільне насіння"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("вже існує"),
@@ -418,6 +426,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "camouflageSetup": MessageLookupByLibrary.simpleMessage(
             "Налаштування камуфляжного PIN-коду"),
         "cancel": MessageLookupByLibrary.simpleMessage("Скасувати"),
+        "cancelActivation":
+            MessageLookupByLibrary.simpleMessage("Скасувати активацію"),
+        "cancelActivationQuestion": MessageLookupByLibrary.simpleMessage(
+            "Ви впевнені, що бажаєте скасувати активацію?"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("Скасувати"),
         "cancelOrder":
             MessageLookupByLibrary.simpleMessage("Відмінити замовлення"),
@@ -467,6 +479,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closePreview":
             MessageLookupByLibrary.simpleMessage("Закрити попередній перегляд"),
         "code": MessageLookupByLibrary.simpleMessage("Код:"),
+        "cofirmCancelActivation": MessageLookupByLibrary.simpleMessage(
+            "Ви впевнені, що бажаєте скасувати активацію?"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("Стерти"),
         "coinSelectNotFound":
             MessageLookupByLibrary.simpleMessage("Немає активних монет"),
@@ -764,6 +778,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("Знайдено QR-код"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("Французька"),
         "from": MessageLookupByLibrary.simpleMessage("Від"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "Ми будемо синхронізувати майбутні транзакції, здійснені після активації, пов’язаної з вашим відкритим ключем. Це найшвидший варіант, який займає найменшу кількість пам’яті."),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("Ліміт комісії"),
         "gasNotActive": m50,
@@ -848,19 +864,20 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Оновити"),
         "internetRestored": MessageLookupByLibrary.simpleMessage(
             "Підключення до Інтернету відновлено"),
+        "invalidCoinAddress": m54,
         "invalidSwap":
             MessageLookupByLibrary.simpleMessage("Неможливо продовжити обмін"),
         "invalidSwapDetailsLink":
             MessageLookupByLibrary.simpleMessage("Подробиці"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("Японська"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("Корейська"),
         "language": MessageLookupByLibrary.simpleMessage("Мова"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("Останні транзакції"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("Юридичний"),
         "less": MessageLookupByLibrary.simpleMessage("Менше"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("Завантаження..."),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage(
             "Завантаження книги замовлень..."),
@@ -935,11 +952,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "min": MessageLookupByLibrary.simpleMessage("ХВ"),
         "minOrder": MessageLookupByLibrary.simpleMessage(
             "Мінімальна кількість замовлень:"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage(
             "Має бути нижчою за суму продажу"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage(
@@ -949,10 +966,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "minimizingWillTerminate": MessageLookupByLibrary.simpleMessage(
             "Попередження: згортання програми на iOS припинить процес активації."),
         "minutes": MessageLookupByLibrary.simpleMessage("хв"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("Більше інформації"),
         "moreTab": MessageLookupByLibrary.simpleMessage("Більше"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("Сума"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("Монета"),
         "multiBaseSelectTitle":
@@ -960,7 +977,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("Скасувати"),
         "multiConfirmConfirm":
             MessageLookupByLibrary.simpleMessage("Підтвердити"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("Створити"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("Замовлення"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("Замовлення"),
@@ -975,8 +992,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Недійсна сума"),
         "multiInvalidSellAmt":
             MessageLookupByLibrary.simpleMessage("Недійсна сума продажу"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage(
             "Максимальна сума продажу становить"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage(
@@ -1010,7 +1027,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Елементи не вибрано"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage(
             "Відповідних замовлень не знайдено"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage(
             "Натисніть, щоб створити замовлення"),
         "noOrders": MessageLookupByLibrary.simpleMessage(
@@ -1025,7 +1042,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nonNumericInput":
             MessageLookupByLibrary.simpleMessage("Значення має бути числовим"),
         "none": MessageLookupByLibrary.simpleMessage("Жодного"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee": MessageLookupByLibrary.simpleMessage(
             "Недостатньо балансу для комісій - торгуйте на меншу суму"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage(
@@ -1035,24 +1052,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "noteTitle": MessageLookupByLibrary.simpleMessage("Примітка"),
         "nothingFound":
             MessageLookupByLibrary.simpleMessage("Нічого не знайдено"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("Обмін завершено"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle":
             MessageLookupByLibrary.simpleMessage("Помилка обміну"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle":
             MessageLookupByLibrary.simpleMessage("Розпочато новий обмін"),
         "notifSwapStatusTitle":
             MessageLookupByLibrary.simpleMessage("Статус обміну змінено"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle":
             MessageLookupByLibrary.simpleMessage("Час очікування обміну минув"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle":
             MessageLookupByLibrary.simpleMessage("Вхідна транзакція"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease":
             MessageLookupByLibrary.simpleMessage("Офіційний прес-реліз"),
         "okButton": MessageLookupByLibrary.simpleMessage("Ок"),
@@ -1064,15 +1081,15 @@ class MessageLookup extends MessageLookupByLibrary {
             "Відкрийте повідомлення про помилку"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("менше"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("більше"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated":
             MessageLookupByLibrary.simpleMessage("Замовлення створено"),
         "orderCreatedInfo":
             MessageLookupByLibrary.simpleMessage("Замовлення успішно створено"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("Адреса"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("Скасувати"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("для"),
         "orderDetailsIdentical":
             MessageLookupByLibrary.simpleMessage("Ідентичний CEX"),
@@ -1085,7 +1102,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Відкрийте «Деталі» одним дотиком і виберіть «Замовити довгим дотиком»."),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("Витратити"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("Подробиці"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched":
             MessageLookupByLibrary.simpleMessage("Замовлення поєднане"),
         "orderMatching":
@@ -1096,9 +1113,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("Замовлення"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("Активні"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("Історія"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("Перезаписати"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("Це ваше замовлення!"),
         "paidFromBalance":
@@ -1108,6 +1125,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("Сплачено з"),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "Пароль має містити щонайменше 12 символів, з літерою нижнього та верхнього регістру та одного спеціального символу."),
+        "pastTransactionsFromDate": MessageLookupByLibrary.simpleMessage(
+            "Ваш гаманець відображатиме ваші минулі транзакції, здійснені після вказаної дати."),
         "paymentUriDetailsAccept":
             MessageLookupByLibrary.simpleMessage("Оплатити"),
         "paymentUriDetailsAcceptQuestion":
@@ -1122,7 +1141,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Скасувати"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("Запит на оплату"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder":
             MessageLookupByLibrary.simpleMessage("Розмістіть своє замовлення"),
         "pleaseAddCoin":
@@ -1147,19 +1166,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("Сканер QR-коду"),
         "question_1": MessageLookupByLibrary.simpleMessage(
             "Ви зберігаєте мої особисті ключі?"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage(
             "Скільки часу займає кожна атомарна заміна?"),
         "question_4": MessageLookupByLibrary.simpleMessage(
             "Чи потрібно мені бути онлайн під час обміну?"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage(
             "Чи забезпечуєте ви підтримку користувачів?"),
         "question_7": MessageLookupByLibrary.simpleMessage(
             "Чи є у вас обмеження по країні?"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "Це нова ера! Ми офіційно змінили назву з \"AtomicDEX\" на \"Komodo Wallet\""),
         "receive": MessageLookupByLibrary.simpleMessage("ОТРИМАТИ"),
@@ -1199,7 +1218,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore": MessageLookupByLibrary.simpleMessage(
             "Докладніше про нагороди KMD для активних користувачів"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("Отримати"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("Фіат"),
         "rewardsTableRewards":
             MessageLookupByLibrary.simpleMessage("Нагороди,\nKMD"),
@@ -1209,7 +1228,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Інформація про нагороди:"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO кіл,\nKMD"),
-        "rewardsTimeDays": m89,
+        "rewardsTimeDays": m90,
         "rewardsTitle":
             MessageLookupByLibrary.simpleMessage("Інформація про нагороди"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("Російська"),
@@ -1263,7 +1282,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Шукати по тікету"),
         "seconds": MessageLookupByLibrary.simpleMessage("с"),
         "security": MessageLookupByLibrary.simpleMessage("Безпека"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory":
             MessageLookupByLibrary.simpleMessage("Побачити історію транзакції"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("Фраза насіння"),
@@ -1278,6 +1297,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Виберіть монету, яку хочете КУПИТИ"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage(
             "Виберіть монету, яку хочете ПРОДАТИ"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("Виберіть дату"),
         "selectFileImport":
             MessageLookupByLibrary.simpleMessage("Виберіть файл"),
         "selectLanguage": MessageLookupByLibrary.simpleMessage("Виберіть мову"),
@@ -1303,12 +1323,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("Мови"),
         "settings": MessageLookupByLibrary.simpleMessage("Налаштування"),
         "share": MessageLookupByLibrary.simpleMessage("Поділитись"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("Показати адресу"),
         "showDetails": MessageLookupByLibrary.simpleMessage("Показати деталі"),
         "showMyOrders":
             MessageLookupByLibrary.simpleMessage("Показати мої угоди"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword": MessageLookupByLibrary.simpleMessage(
             "Увійдіть за допомогою пароля"),
         "signInWithSeedPhrase": MessageLookupByLibrary.simpleMessage(
@@ -1316,24 +1337,24 @@ class MessageLookup extends MessageLookupByLibrary {
         "simple": MessageLookupByLibrary.simpleMessage("Простий"),
         "simpleTradeActivate":
             MessageLookupByLibrary.simpleMessage("Активувати"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("Купити"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("Закрити"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("Отримати"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("Продати"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("Надіслати"),
         "simpleTradeShowLess":
             MessageLookupByLibrary.simpleMessage("Показати менше"),
         "simpleTradeShowMore":
             MessageLookupByLibrary.simpleMessage("Показати більше"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("Пропустити"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("Відхилити"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("Звук"),
         "soundSettingsTitle":
             MessageLookupByLibrary.simpleMessage("Налаштування звуку"),
@@ -1345,20 +1366,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote": MessageLookupByLibrary.simpleMessage(
             "Зверніть увагу, що ви можете встановити власні звуки в налаштуваннях програми."),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("Іспанська"),
+        "startDate": MessageLookupByLibrary.simpleMessage("Дата початку"),
         "startSwap": MessageLookupByLibrary.simpleMessage("Почати обмін"),
         "step": MessageLookupByLibrary.simpleMessage("Крок"),
         "success": MessageLookupByLibrary.simpleMessage("Успішно!"),
         "support": MessageLookupByLibrary.simpleMessage("Підтримка"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("своп"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("Поточний"),
         "swapDetailTitle":
             MessageLookupByLibrary.simpleMessage("ПІДТВЕРДИТИ ДЕТАЛІ ОБМІНУ"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("Оцінка"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("Помилка обміну"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("Обмін триває"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("Деталі прогресу"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("Розпочато"),
@@ -1366,6 +1388,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("Всього"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("Swap UUID"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("Змінити тему"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage(
+            "Синхронізувати з указаної дати"),
+        "syncFromSaplingActivation": MessageLookupByLibrary.simpleMessage(
+            "Синхронізація з активації саджанця"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage(
+            "Синхронізувати нові транзакції"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1380,7 +1409,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "tagQRC20": MessageLookupByLibrary.simpleMessage("QRC20"),
         "tagSBCH": MessageLookupByLibrary.simpleMessage("SBCH"),
         "tagUBQ": MessageLookupByLibrary.simpleMessage("UBQ"),
-        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ЖТЛЦ"),
+        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ZHTLC"),
         "takerOrder":
             MessageLookupByLibrary.simpleMessage("Замовлення покупця"),
         "timeOut": MessageLookupByLibrary.simpleMessage("Час вийшов"),
@@ -1429,26 +1458,26 @@ class MessageLookup extends MessageLookupByLibrary {
             "Забагато запитів.\nПеревищено ліміт запитів історії транзакцій.\nБудь-ласка спробуйте пізніше."),
         "txNotConfirmed":
             MessageLookupByLibrary.simpleMessage("НЕПІДТВЕРДЖЕНО"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage":
             MessageLookupByLibrary.simpleMessage("Український"),
         "unlock": MessageLookupByLibrary.simpleMessage("розблокувати"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("Розблокувати"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("невитрачений"),
         "updatesAvailable":
             MessageLookupByLibrary.simpleMessage("Доступна нова версія"),
         "updatesChecking":
             MessageLookupByLibrary.simpleMessage("Перевірка оновлень..."),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable": MessageLookupByLibrary.simpleMessage(
             "Доступна нова версія. Будь ласка, оновіть."),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle":
             MessageLookupByLibrary.simpleMessage("Доступне оновлення"),
         "updatesSkip":
             MessageLookupByLibrary.simpleMessage("Пропустити поки що"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate":
             MessageLookupByLibrary.simpleMessage("Вже актуально"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("Оновлення"),
@@ -1474,9 +1503,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("Ок"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "Увага! В особливих випадках дані журналу містять конфіденційну інформацію, яка може бути використана для витрачання монет із невдалих обмінів!"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp":
             MessageLookupByLibrary.simpleMessage("ДАВАЙТЕ НАЛАШТОВУВАТИ!"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("ЛАСКАВО ПРОСИМО"),
@@ -1486,14 +1515,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "Це займе деякий час, і програма має залишатися в активному режимі.\nЗакриття програми під час активації може призвести до проблем."),
         "withdraw": MessageLookupByLibrary.simpleMessage("Відправити"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("Доступ заборонено"),
         "withdrawConfirm":
             MessageLookupByLibrary.simpleMessage("Підтвердити зняття"),
         "withdrawConfirmError": MessageLookupByLibrary.simpleMessage(
             "Щось пішло не так. Спробуйте ще раз пізніше."),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage(
             "Ви намагаєтеся відсканувати платіжний QR-код для"),
         "wrongCoinSpan2":
@@ -1513,7 +1542,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "у вас є замовлення, з яким можуть відповідати нові замовлення"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("Ви надсилаєте:"),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived":
             MessageLookupByLibrary.simpleMessage("Ви отримаєте:"),
         "yourWallet": MessageLookupByLibrary.simpleMessage("твій гаманець")

--- a/lib/l10n/messages_zh.dart
+++ b/lib/l10n/messages_zh.dart
@@ -151,134 +151,140 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m53(abbr) => "${abbr}余额不足以支付交易费";
 
-  static m54(coinAbbr) => "${coinAbbr} 不可用:(";
+  static m54(coin) => "${coin} 地址无效";
 
-  static m55(coinName) => "❗注意！ ${coinName} 市场的 24 小时交易量不到 1 万美元！";
+  static m55(coinAbbr) => "${coinAbbr} 不可用:(";
 
-  static m56(value) => "限制必须达到 ${value}";
+  static m56(coinName) => "❗注意！ ${coinName} 市场的 24 小时交易量不到 1 万美元！";
 
-  static m57(coinName, number) => "最低售出量为${number} ${coinName}";
+  static m57(value) => "限制必须达到 ${value}";
 
-  static m58(coinName, number) => "最低买入量为${number} ${coinName}";
+  static m58(coinName, number) => "最低售出量为${number} ${coinName}";
 
-  static m59(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m59(coinName, number) => "最低买入量为${number} ${coinName}";
+
+  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "最小交易量为 ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
 
-  static m60(coinName, number) => "最低售出量为 ${number} ${coinName}";
+  static m61(coinName, number) => "最低售出量为 ${number} ${coinName}";
 
-  static m61(minValue, coin) => "必须大于${minValue} ${coin}";
+  static m62(minValue, coin) => "必须大于${minValue} ${coin}";
 
-  static m62(appName) =>
+  static m63(appName) =>
       "请注意，您现在正在使用流量，使用${appName} P2P网络会消耗互联网流量。如果您的手机流量很贵，最好连接WIFI。";
 
-  static m63(coin) => "先激活${coin}并充值余额";
+  static m64(coin) => "先激活${coin}并充值余额";
 
-  static m64(number) => "创建${number}订单：";
+  static m65(number) => "创建${number}订单：";
 
-  static m65(coin) => "${coin}余额过低";
+  static m66(coin) => "${coin}余额过低";
 
-  static m66(coin, fee) => "${coin}不足支付。最低余额为 ${fee} ${coin}";
+  static m67(coin, fee) => "${coin}不足支付。最低余额为 ${fee} ${coin}";
 
-  static m67(coinName) => "请输入 ${coinName} 量";
+  static m68(coinName) => "请输入 ${coinName} 量";
 
-  static m68(coin) => "没有足够的${coin} 用于交易！";
+  static m69(coin) => "没有足够的${coin} 用于交易！";
 
-  static m69(sell, buy) => "${sell}/${buy} 已成功完成交换";
+  static m70(sell, buy) => "${sell}/${buy} 已成功完成交换";
 
-  static m70(sell, buy) => "${sell}/${buy}交换失败";
+  static m71(sell, buy) => "${sell}/${buy}交换失败";
 
-  static m71(sell, buy) => "${sell}/${buy}交换开始";
+  static m72(sell, buy) => "${sell}/${buy}交换开始";
 
-  static m72(sell, buy) => "${sell}/${buy}交换超时";
+  static m73(sell, buy) => "${sell}/${buy}交换超时";
 
-  static m73(coin) => "您已收到｛coin｝交易！";
+  static m74(coin) => "您已收到｛coin｝交易！";
 
-  static m74(assets) => "${assets} 资产";
+  static m75(assets) => "${assets} 资产";
 
-  static m75(coin) => "所有${coin}订单将被取消。";
+  static m76(coin) => "所有${coin}订单将被取消。";
 
-  static m76(delta) => "划算的: CEX +${delta}%";
+  static m77(delta) => "划算的: CEX +${delta}%";
 
-  static m77(delta) => "昂贵的: CEX ${delta}%";
+  static m78(delta) => "昂贵的: CEX ${delta}%";
 
-  static m78(fill) => "${fill}%已填充";
+  static m79(fill) => "${fill}%已填充";
 
-  static m79(coin) => "数量(${coin})";
+  static m80(coin) => "数量(${coin})";
 
-  static m80(coin) => "价格 (${coin})";
+  static m81(coin) => "价格 (${coin})";
 
-  static m81(coin) => "总计 (${coin})";
+  static m82(coin) => "总计 (${coin})";
 
-  static m82(abbr) => "${abbr} 未激活。请激活后重试。";
+  static m83(abbr) => "${abbr} 未激活。请激活后重试。";
 
-  static m83(appName) => "我可以在哪些设备上使用${appName} ？";
+  static m84(appName) => "我可以在哪些设备上使用${appName} ？";
 
-  static m84(appName) => "在${appName} 上交易与在其他DEX上交易有何不同？";
+  static m85(appName) => "在${appName} 上交易与在其他DEX上交易有何不同？";
 
-  static m85(appName) => "${appName} 的费用如何计算？";
+  static m86(appName) => "${appName} 的费用如何计算？";
 
-  static m86(appName) => "${appName} 的背后是谁？";
+  static m87(appName) => "${appName} 的背后是谁？";
 
-  static m87(appName) => "是否可以在${appName} 上开发我个人的白标交换？";
+  static m88(appName) => "是否可以在${appName} 上开发我个人的白标交换？";
 
-  static m88(amount) => "成功！收到 ${amount}KMD";
+  static m89(amount) => "成功！收到 ${amount}KMD";
 
-  static m89(dd) => "${dd} 天";
+  static m90(dd) => "${dd} 天";
 
-  static m90(hh, minutes) => "${hh}小时 ${minutes}分钟";
+  static m91(hh, minutes) => "${hh}小时 ${minutes}分钟";
 
-  static m91(mm) => "${mm}分钟";
+  static m92(mm) => "${mm}分钟";
 
-  static m92(amount) => "点击查看${amount} 交易";
+  static m93(amount) => "点击查看${amount} 交易";
 
-  static m93(coinName, address) => "我的${coinName} 地址:\n${address}";
+  static m94(coinName, address) => "我的${coinName} 地址:\n${address}";
 
-  static m94(count, maxCount) => "显示 ${count} 个订单（共 ${maxCount} 个）。";
+  static m95(coin) => "扫描过去的 ${coin} 交易？";
 
-  static m95(coin) => "请输入要买入的 ${coin} 数量";
+  static m96(count, maxCount) => "显示 ${count} 个订单（共 ${maxCount} 个）。";
 
-  static m96(maxCoins) => "货币最大活跃量为${maxCoins}。请停用一些。";
+  static m97(coin) => "请输入要买入的 ${coin} 数量";
 
-  static m97(coin) => "${coin}未激活！";
+  static m98(maxCoins) => "货币最大活跃量为${maxCoins}。请停用一些。";
 
-  static m98(coin) => "请输入要卖出的${coin}数量";
+  static m99(coin) => "${coin}未激活！";
 
-  static m99(coin) => "无法激活${coin}";
+  static m100(coin) => "请输入要卖出的${coin}数量";
 
-  static m100(description) => "请选择mp3或wav文件。我们将在${description}时播放它。";
+  static m101(coin) => "无法激活${coin}";
 
-  static m101(description) => "当${description}播放";
+  static m102(description) => "请选择mp3或wav文件。我们将在${description}时播放它。";
 
-  static m102(appName) =>
+  static m103(description) => "当${description}播放";
+
+  static m104(appName) =>
       "如果您有任何问题，或者认为您发现${appName} 应用程序存在技术问题，请联系我们获取我们团队的支持。";
 
-  static m103(coin) => "请先激活 ${coin} 并充值余额";
+  static m105(coin) => "请先激活 ${coin} 并充值余额";
 
-  static m104(coin) => "${coin} 余额不足以支付交易费用。";
+  static m106(coin) => "${coin} 余额不足以支付交易费用。";
 
-  static m105(coin, amount) => "${coin} 余额不足以支付交易费用。需要 ${coin} ${amount}";
+  static m107(coin, amount) => "${coin} 余额不足以支付交易费用。需要 ${coin} ${amount}";
 
-  static m106(left) => "剩余交易: ${left}";
+  static m108(name) => "您想要同步哪些${name}交易？";
 
-  static m107(amnt, hash) => "成功解锁 ${amnt} 基金 - 交易: ${hash}";
+  static m109(left) => "剩余交易: ${left}";
 
-  static m108(version) => "您正在使用版本${version}";
+  static m110(amnt, hash) => "成功解锁 ${amnt} 基金 - 交易: ${hash}";
 
-  static m109(version) => "版本${version}可用。请更新。";
+  static m111(version) => "您正在使用版本${version}";
 
-  static m110(appName) => "更新${appName}";
+  static m112(version) => "版本${version}可用。请更新。";
 
-  static m111(coinAbbr) => "我们无法激活 ${coinAbbr}";
+  static m113(appName) => "更新${appName}";
 
-  static m112(coinAbbr) => "我们无法激活${coinAbbr}.\n请重启应用程序后重试";
+  static m114(coinAbbr) => "我们无法激活 ${coinAbbr}";
 
-  static m113(appName) => "${appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。";
+  static m115(coinAbbr) => "我们无法激活${coinAbbr}.\n请重启应用程序后重试";
 
-  static m114(appName) => "您之前禁止${appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描";
+  static m116(appName) => "${appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。";
 
-  static m115(amount, coinName) => "提取 ${amount} ${coinName}";
+  static m117(appName) => "您之前禁止${appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描";
 
-  static m116(amount, coin) => "您将获得 ${amount} ${coin}";
+  static m118(amount, coinName) => "提取 ${amount} ${coinName}";
+
+  static m119(amount, coin) => "您将获得 ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -317,6 +323,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addressSend": MessageLookupByLibrary.simpleMessage("收款人钱包地址"),
         "advanced": MessageLookupByLibrary.simpleMessage("高级"),
         "all": MessageLookupByLibrary.simpleMessage("全部"),
+        "allPastTransactions": MessageLookupByLibrary.simpleMessage(
+            "您的钱包将显示任何过去的交易。这将占用大量存储空间和时间，因为所有块都将被下载和扫描。"),
         "allowCustomSeed": MessageLookupByLibrary.simpleMessage("允许自定义助记词"),
         "alreadyExists": MessageLookupByLibrary.simpleMessage("已存在"),
         "amount": MessageLookupByLibrary.simpleMessage("数量"),
@@ -372,6 +380,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "camoSetupTitle": MessageLookupByLibrary.simpleMessage("伪装PIN设置"),
         "camouflageSetup": MessageLookupByLibrary.simpleMessage("伪装PIN设置"),
         "cancel": MessageLookupByLibrary.simpleMessage("取消"),
+        "cancelActivation": MessageLookupByLibrary.simpleMessage("取消激活"),
+        "cancelActivationQuestion":
+            MessageLookupByLibrary.simpleMessage("您确定要取消激活吗？"),
         "cancelButton": MessageLookupByLibrary.simpleMessage("取消"),
         "cancelOrder": MessageLookupByLibrary.simpleMessage("取消交易"),
         "candleChartError": MessageLookupByLibrary.simpleMessage("出现错误，稍后重试"),
@@ -409,6 +420,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "closeMessage": MessageLookupByLibrary.simpleMessage("关闭错误信息"),
         "closePreview": MessageLookupByLibrary.simpleMessage("关闭预览"),
         "code": MessageLookupByLibrary.simpleMessage("代码"),
+        "cofirmCancelActivation":
+            MessageLookupByLibrary.simpleMessage("您确定要取消激活吗？"),
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("清除"),
         "coinSelectNotFound": MessageLookupByLibrary.simpleMessage("没有活跃币"),
         "coinSelectTitle": MessageLookupByLibrary.simpleMessage("选择货币"),
@@ -639,6 +652,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "foundQrCode": MessageLookupByLibrary.simpleMessage("找到二维码"),
         "frenchLanguage": MessageLookupByLibrary.simpleMessage("法语"),
         "from": MessageLookupByLibrary.simpleMessage("起始日期"),
+        "futureTransactions": MessageLookupByLibrary.simpleMessage(
+            "我们将同步与您的公钥关联的激活后进行的未来交易。这是最快的选项，占用的存储空间最少。"),
         "gasFee": m49,
         "gasLimit": MessageLookupByLibrary.simpleMessage("燃料上限"),
         "gasNotActive": m50,
@@ -700,17 +715,18 @@ class MessageLookup extends MessageLookupByLibrary {
         "insufficientTitle": MessageLookupByLibrary.simpleMessage("交易量不足"),
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("刷新"),
         "internetRestored": MessageLookupByLibrary.simpleMessage("已重新连接互联网"),
+        "invalidCoinAddress": m54,
         "invalidSwap": MessageLookupByLibrary.simpleMessage("无法继续交换"),
         "invalidSwapDetailsLink": MessageLookupByLibrary.simpleMessage("详细信息"),
-        "isUnavailable": m54,
+        "isUnavailable": m55,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("日文"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("韩国人"),
         "language": MessageLookupByLibrary.simpleMessage("语言"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("最新交易"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("合法的"),
         "less": MessageLookupByLibrary.simpleMessage("较少"),
-        "lessThanCaution": m55,
-        "limitError": m56,
+        "lessThanCaution": m56,
+        "limitError": m57,
         "loading": MessageLookupByLibrary.simpleMessage("載入中"),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage("正在加载订单记录"),
         "lockScreen": MessageLookupByLibrary.simpleMessage("屏幕已锁定"),
@@ -763,27 +779,27 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("毫秒"),
         "min": MessageLookupByLibrary.simpleMessage("最小"),
         "minOrder": MessageLookupByLibrary.simpleMessage("最小交易量"),
-        "minValue": m57,
-        "minValueBuy": m58,
-        "minValueOrder": m59,
-        "minValueSell": m60,
-        "minVolumeInput": m61,
+        "minValue": m58,
+        "minValueBuy": m59,
+        "minValueOrder": m60,
+        "minValueSell": m61,
+        "minVolumeInput": m62,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage("必须低于售出量"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage("所需最小量"),
         "minVolumeToggle": MessageLookupByLibrary.simpleMessage("使用自定义最小量"),
         "minimizingWillTerminate":
             MessageLookupByLibrary.simpleMessage("警告：最小化 iOS 上的应用程序将终止激活过程。"),
         "minutes": MessageLookupByLibrary.simpleMessage("分钟"),
-        "mobileDataWarning": m62,
+        "mobileDataWarning": m63,
         "moreInfo": MessageLookupByLibrary.simpleMessage("更多信息"),
         "moreTab": MessageLookupByLibrary.simpleMessage("更多"),
-        "multiActivateGas": m63,
+        "multiActivateGas": m64,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("数量"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("货币"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("卖出"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("取消"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("确认"),
-        "multiConfirmTitle": m64,
+        "multiConfirmTitle": m65,
         "multiCreate": MessageLookupByLibrary.simpleMessage("创建"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("订单"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("订单"),
@@ -794,8 +810,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiFixErrors": MessageLookupByLibrary.simpleMessage("请在继续之前修复所有错误"),
         "multiInvalidAmt": MessageLookupByLibrary.simpleMessage("数量无效"),
         "multiInvalidSellAmt": MessageLookupByLibrary.simpleMessage("售出量无效"),
-        "multiLowGas": m65,
-        "multiLowerThanFee": m66,
+        "multiLowGas": m66,
+        "multiLowerThanFee": m67,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage("最大售出量为"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage("最小接收量为"),
         "multiMinSellAmt": MessageLookupByLibrary.simpleMessage("最小售出量为"),
@@ -819,7 +835,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noItemsToExport": MessageLookupByLibrary.simpleMessage("未选择项目"),
         "noItemsToImport": MessageLookupByLibrary.simpleMessage("未选择项目"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage("无匹配订单"),
-        "noOrder": m67,
+        "noOrder": m68,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage("点击创建订单"),
         "noOrders": MessageLookupByLibrary.simpleMessage("没有订单，请先交易"),
         "noRewardYet": MessageLookupByLibrary.simpleMessage("没有奖励可领取-请一小时后重试"),
@@ -829,26 +845,26 @@ class MessageLookup extends MessageLookupByLibrary {
         "noTxs": MessageLookupByLibrary.simpleMessage("没有交易"),
         "nonNumericInput": MessageLookupByLibrary.simpleMessage("该值必须是数字"),
         "none": MessageLookupByLibrary.simpleMessage("没有任何"),
-        "notEnoughGas": m68,
+        "notEnoughGas": m69,
         "notEnoughtBalanceForFee":
             MessageLookupByLibrary.simpleMessage("手续费余额不足-减少交易量"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage("备注：不能取消已匹配的订单"),
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("添加备注"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("备注"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("无内容"),
-        "notifSwapCompletedText": m69,
+        "notifSwapCompletedText": m70,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("交换已完成"),
-        "notifSwapFailedText": m70,
+        "notifSwapFailedText": m71,
         "notifSwapFailedTitle": MessageLookupByLibrary.simpleMessage("交换失败"),
-        "notifSwapStartedText": m71,
+        "notifSwapStartedText": m72,
         "notifSwapStartedTitle": MessageLookupByLibrary.simpleMessage("已开始新交换"),
         "notifSwapStatusTitle": MessageLookupByLibrary.simpleMessage("交换状态已更改"),
-        "notifSwapTimeoutText": m72,
+        "notifSwapTimeoutText": m73,
         "notifSwapTimeoutTitle": MessageLookupByLibrary.simpleMessage("交换超时"),
-        "notifTxText": m73,
+        "notifTxText": m74,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("应记交易"),
-        "numberAssets": m74,
+        "numberAssets": m75,
         "officialPressRelease": MessageLookupByLibrary.simpleMessage("官方新闻稿"),
         "okButton": MessageLookupByLibrary.simpleMessage("好的"),
         "oldLogsDelete": MessageLookupByLibrary.simpleMessage("删除"),
@@ -857,13 +873,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("打开错误消息"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("较少的"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("更多的"),
-        "orderCancel": m75,
+        "orderCancel": m76,
         "orderCreated": MessageLookupByLibrary.simpleMessage("订单已创建"),
         "orderCreatedInfo": MessageLookupByLibrary.simpleMessage("订单已成功创建"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("地址"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("取消"),
-        "orderDetailsExpedient": m76,
-        "orderDetailsExpensive": m77,
+        "orderDetailsExpedient": m77,
+        "orderDetailsExpensive": m78,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("与"),
         "orderDetailsIdentical": MessageLookupByLibrary.simpleMessage("CEX相同"),
         "orderDetailsMin": MessageLookupByLibrary.simpleMessage("最小量"),
@@ -875,7 +891,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("单击打开详细信息，然后长按选择订购"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("花费"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("详细信息"),
-        "orderFilled": m78,
+        "orderFilled": m79,
         "orderMatched": MessageLookupByLibrary.simpleMessage("已匹配订单"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("订单匹配中"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("订单"),
@@ -883,9 +899,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("订单"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("活跃"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("历史记录"),
-        "ordersTableAmount": m79,
-        "ordersTablePrice": m80,
-        "ordersTableTotal": m81,
+        "ordersTableAmount": m80,
+        "ordersTablePrice": m81,
+        "ordersTableTotal": m82,
         "overwrite": MessageLookupByLibrary.simpleMessage("覆盖"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("这是您个人的订单"),
         "paidFromBalance": MessageLookupByLibrary.simpleMessage("用余额支付："),
@@ -893,6 +909,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "paidWith": MessageLookupByLibrary.simpleMessage("支付方式："),
         "passwordRequirement": MessageLookupByLibrary.simpleMessage(
             "密码必须至少包含12个字符，包括一个小写、一个大写和一个特殊符号"),
+        "pastTransactionsFromDate":
+            MessageLookupByLibrary.simpleMessage("您的钱包将显示您过去在指定日期之后进行的交易。"),
         "paymentUriDetailsAccept": MessageLookupByLibrary.simpleMessage("支付"),
         "paymentUriDetailsAcceptQuestion":
             MessageLookupByLibrary.simpleMessage("您接受这笔交易吗？"),
@@ -905,7 +923,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("取消"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("已请求的付款"),
-        "paymentUriInactiveCoin": m82,
+        "paymentUriInactiveCoin": m83,
         "placeOrder": MessageLookupByLibrary.simpleMessage("下单"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage("请添加货币"),
         "pleaseRestart":
@@ -926,15 +944,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "pubkey": MessageLookupByLibrary.simpleMessage("公钥"),
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("二维码扫描仪"),
         "question_1": MessageLookupByLibrary.simpleMessage("你们会保存我的私钥吗？"),
-        "question_10": m83,
-        "question_2": m84,
+        "question_10": m84,
+        "question_2": m85,
         "question_3": MessageLookupByLibrary.simpleMessage("每次原子交换需要多长时间？"),
         "question_4": MessageLookupByLibrary.simpleMessage("在交换期间我要保持在线吗"),
-        "question_5": m85,
+        "question_5": m86,
         "question_6": MessageLookupByLibrary.simpleMessage("你们会提供用户支持吗？"),
         "question_7": MessageLookupByLibrary.simpleMessage("你们有地区限制吗？"),
-        "question_8": m86,
-        "question_9": m87,
+        "question_8": m87,
+        "question_9": m88,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "这是一个新时代！我们已正式将名称从“AtomicDEX”更改为“Komodo Wallet”"),
         "receive": MessageLookupByLibrary.simpleMessage("接收"),
@@ -963,7 +981,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore":
             MessageLookupByLibrary.simpleMessage("阅读有关KMD活跃用户奖励的更多信息"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("接收"),
-        "rewardsSuccess": m88,
+        "rewardsSuccess": m89,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("法币"),
         "rewardsTableRewards": MessageLookupByLibrary.simpleMessage("奖励，KMD"),
         "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("状态"),
@@ -971,9 +989,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsTableTitle": MessageLookupByLibrary.simpleMessage("奖励信息"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO 数量\nKMD"),
-        "rewardsTimeDays": m89,
-        "rewardsTimeHours": m90,
-        "rewardsTimeMin": m91,
+        "rewardsTimeDays": m90,
+        "rewardsTimeHours": m91,
+        "rewardsTimeMin": m92,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("奖励信息"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("俄语"),
         "saveMerged": MessageLookupByLibrary.simpleMessage("保存合并"),
@@ -1022,7 +1040,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("搜索货币代码"),
         "seconds": MessageLookupByLibrary.simpleMessage("秒"),
         "security": MessageLookupByLibrary.simpleMessage("证券"),
-        "seeOrders": m92,
+        "seeOrders": m93,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage("查看交易记录"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("助记词"),
         "seedPhraseTitle": MessageLookupByLibrary.simpleMessage("您的新助記詞"),
@@ -1032,6 +1050,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectCoinTitle": MessageLookupByLibrary.simpleMessage("激活货币："),
         "selectCoinToBuy": MessageLookupByLibrary.simpleMessage("选择您想买入的货币"),
         "selectCoinToSell": MessageLookupByLibrary.simpleMessage("选择您想卖出的货币"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("选择日期"),
         "selectFileImport": MessageLookupByLibrary.simpleMessage("选择文件"),
         "selectLanguage": MessageLookupByLibrary.simpleMessage("选择语言"),
         "selectPaymentMethod": MessageLookupByLibrary.simpleMessage("选择您的支付方式"),
@@ -1050,32 +1069,33 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("语言"),
         "settings": MessageLookupByLibrary.simpleMessage("设置"),
         "share": MessageLookupByLibrary.simpleMessage("分享"),
-        "shareAddress": m93,
+        "shareAddress": m94,
+        "shouldScanPastTransaction": m95,
         "showAddress": MessageLookupByLibrary.simpleMessage("显示地址"),
         "showDetails": MessageLookupByLibrary.simpleMessage("显示详细信息"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("显示我的订单"),
-        "showingOrders": m94,
+        "showingOrders": m96,
         "signInWithPassword": MessageLookupByLibrary.simpleMessage("使用密码登录"),
         "signInWithSeedPhrase":
             MessageLookupByLibrary.simpleMessage("忘记密码？用助记词恢复钱包"),
         "simple": MessageLookupByLibrary.simpleMessage("简单"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("激活"),
-        "simpleTradeBuyHint": m95,
+        "simpleTradeBuyHint": m97,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("买入"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("关闭"),
-        "simpleTradeMaxActiveCoins": m96,
-        "simpleTradeNotActive": m97,
+        "simpleTradeMaxActiveCoins": m98,
+        "simpleTradeNotActive": m99,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("接收"),
-        "simpleTradeSellHint": m98,
+        "simpleTradeSellHint": m100,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("卖出"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("发送"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("收起"),
         "simpleTradeShowMore": MessageLookupByLibrary.simpleMessage("显示更多"),
-        "simpleTradeUnableActivate": m99,
+        "simpleTradeUnableActivate": m101,
         "skip": MessageLookupByLibrary.simpleMessage("跳过"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("不予考虑"),
-        "soundCantPlayThatMsg": m100,
-        "soundPlayedWhen": m101,
+        "soundCantPlayThatMsg": m102,
+        "soundPlayedWhen": m103,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("声音"),
         "soundSettingsTitle": MessageLookupByLibrary.simpleMessage("声音设置"),
         "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("声音"),
@@ -1086,19 +1106,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "soundsNote":
             MessageLookupByLibrary.simpleMessage("请注意，您可以在应用程序设置中设置自定义声音。"),
         "spanishLanguage": MessageLookupByLibrary.simpleMessage("西班牙语"),
+        "startDate": MessageLookupByLibrary.simpleMessage("开始日期"),
         "startSwap": MessageLookupByLibrary.simpleMessage("开始交换"),
         "step": MessageLookupByLibrary.simpleMessage("步骤"),
         "success": MessageLookupByLibrary.simpleMessage("成功"),
         "support": MessageLookupByLibrary.simpleMessage("支持"),
-        "supportLinksDesc": m102,
+        "supportLinksDesc": m104,
         "swap": MessageLookupByLibrary.simpleMessage("交换"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("现状"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage("确认兑换细节"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("预估"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("交换失败"),
-        "swapGasActivate": m103,
-        "swapGasAmount": m104,
-        "swapGasAmountRequired": m105,
+        "swapGasActivate": m105,
+        "swapGasAmount": m106,
+        "swapGasAmountRequired": m107,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("正在交换"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("进度详情"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("已开始"),
@@ -1106,6 +1127,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "swapTotal": MessageLookupByLibrary.simpleMessage("总共"),
         "swapUUID": MessageLookupByLibrary.simpleMessage("UUID交换"),
         "switchTheme": MessageLookupByLibrary.simpleMessage("切换主题"),
+        "syncFromDate": MessageLookupByLibrary.simpleMessage("从指定日期同步"),
+        "syncFromSaplingActivation":
+            MessageLookupByLibrary.simpleMessage("从树苗激活同步"),
+        "syncNewTransactions": MessageLookupByLibrary.simpleMessage("同步新交易"),
+        "syncTransactionsQuestion": m108,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1120,7 +1146,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "tagQRC20": MessageLookupByLibrary.simpleMessage("QRC20"),
         "tagSBCH": MessageLookupByLibrary.simpleMessage("SBCH"),
         "tagUBQ": MessageLookupByLibrary.simpleMessage("UBQ"),
-        "tagZHTLC": MessageLookupByLibrary.simpleMessage("中山HTLC"),
+        "tagZHTLC": MessageLookupByLibrary.simpleMessage("ZHTLC"),
         "takerOrder": MessageLookupByLibrary.simpleMessage("吃单交易"),
         "timeOut": MessageLookupByLibrary.simpleMessage("超时"),
         "titleCreatePassword": MessageLookupByLibrary.simpleMessage("创建密码"),
@@ -1157,21 +1183,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded":
             MessageLookupByLibrary.simpleMessage("请求过多。超出交易历史请求限制。请稍后重试"),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("未确认"),
-        "txleft": m106,
+        "txleft": m109,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("乌克兰"),
         "unlock": MessageLookupByLibrary.simpleMessage("解锁"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("解锁基金"),
-        "unlockSuccess": m107,
+        "unlockSuccess": m110,
         "unspendable": MessageLookupByLibrary.simpleMessage("不可交易"),
         "updatesAvailable": MessageLookupByLibrary.simpleMessage("已有新版本"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage("正在检查更新"),
-        "updatesCurrentVersion": m108,
+        "updatesCurrentVersion": m111,
         "updatesNotifAvailable":
             MessageLookupByLibrary.simpleMessage("已有新版本。请更新。"),
-        "updatesNotifAvailableVersion": m109,
+        "updatesNotifAvailableVersion": m112,
         "updatesNotifTitle": MessageLookupByLibrary.simpleMessage("可更新"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("暂时跳过"),
-        "updatesTitle": m110,
+        "updatesTitle": m113,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage("准备更新"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("已更新"),
         "uriInsufficientBalanceSpan1":
@@ -1192,9 +1218,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("好的"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "警告-在特殊情况下，此登录数据包含敏感信息，可用于消费交换失败的货币！"),
-        "weFailedTo": m111,
-        "weFailedToActivate": m112,
-        "welcomeInfo": m113,
+        "weFailedTo": m114,
+        "weFailedToActivate": m115,
+        "welcomeInfo": m116,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("让我们开始吧"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("欢迎"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("钱包"),
@@ -1203,13 +1229,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "这将需要一段时间，并且应用程序必须保持在前台。\n在激活过程中终止应用程序可能会导致问题。"),
         "withdraw": MessageLookupByLibrary.simpleMessage("提取"),
-        "withdrawCameraAccessText": m114,
+        "withdrawCameraAccessText": m117,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("被拒绝使用"),
         "withdrawConfirm": MessageLookupByLibrary.simpleMessage("确认提取"),
         "withdrawConfirmError":
             MessageLookupByLibrary.simpleMessage("出现错误。请稍后重试。"),
-        "withdrawValue": m115,
+        "withdrawValue": m118,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage("您正在尝试扫描付款二维码"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("但您在"),
         "wrongCoinSpan3": MessageLookupByLibrary.simpleMessage("提取页面"),
@@ -1223,7 +1249,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "you have an order that new orders can match with":
             MessageLookupByLibrary.simpleMessage("你有一个新订单可以匹配的订单"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("您正在发送："),
-        "youWillReceiveClaim": m116,
+        "youWillReceiveClaim": m119,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("您将收到："),
         "yourWallet": MessageLookupByLibrary.simpleMessage("您的钱包")
       };

--- a/lib/l10n/messages_zh.dart
+++ b/lib/l10n/messages_zh.dart
@@ -72,219 +72,225 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m21(index) => "您的助記詞的第 ${index}個单词是什麼？";
 
-  static m22(protocolName) => "${protocolName} 币已激活";
+  static m22(coin) => "${coin}激活已取消";
 
-  static m23(protocolName) => "${protocolName}币激活成功";
+  static m23(coin) => "成功激活${coin}";
 
-  static m24(protocolName) => "${protocolName} 代币未激活";
+  static m24(protocolName) => "${protocolName} 币已激活";
 
-  static m25(name) => "确认删除该联系人${name}？";
+  static m25(protocolName) => "${protocolName}币激活成功";
 
-  static m26(iUnderstand) =>
+  static m26(protocolName) => "${protocolName} 代币未激活";
+
+  static m27(name) => "确认删除该联系人${name}？";
+
+  static m28(iUnderstand) =>
       "自定义助记词的安全性可能比自动生成的符合BIP39规范的助记词或私钥（WIF）低，更容易被破解。如您已了解风险并知道您正在做什么，请在下面的框中输入\"${iUnderstand}\"。";
 
-  static m27(coinName) => "接收${coinName}交易费";
+  static m29(coinName) => "接收${coinName}交易费";
 
-  static m28(coinName) => "发送 ${coinName} 交易费";
+  static m30(coinName) => "发送 ${coinName} 交易费";
 
-  static m29(abbr) => "输入${abbr}地址";
+  static m31(abbr) => "输入${abbr}地址";
 
-  static m30(selected, remains) => "您仍然可以启用${remains}，已选择：${selected}";
+  static m32(selected, remains) => "您仍然可以启用${remains}，已选择：${selected}";
 
-  static m31(gas) => "燃料不足-至少使用｛gas｝Gwei";
+  static m33(gas) => "燃料不足-至少使用｛gas｝Gwei";
 
-  static m32(appName, appCompanyLong) =>
+  static m34(appName, appCompanyLong) =>
       "This End-User License Agreement (\'EULA\') is a legal agreement between you and ${appCompanyLong}.\n\nThis EULA agreement governs your acquisition and use of our ${appName} mobile software (\'Software\', \'Mobile Application\', \'Application\' or \'App\') directly from ${appCompanyLong} or indirectly through a ${appCompanyLong} authorized entity, reseller or distributor (a \'Distributor\').\nPlease read this EULA agreement carefully before completing the installation process and using the ${appName} mobile software. It provides a license to use the ${appName} mobile software and contains warranty information and liability disclaimers.\nIf you register for the beta program of the ${appName} mobile software, this EULA agreement will also govern that trial. By clicking \'accept\' or installing and/or using the ${appName} mobile software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.\nIf you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.\nThis EULA agreement shall apply only to the Software supplied by ${appCompanyLong} herewith regardless of whether other software is referred to or described herein. The terms also apply to any ${appCompanyLong} updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply.\n\nLICENSE GRANT\n\n${appCompanyLong} hereby grants you a personal, non-transferable, non-exclusive license to use the ${appName} mobile software on your devices in accordance with the terms of this EULA agreement.\n\nYou are permitted to load the ${appName} mobile software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum security and resource requirements of the ${appName} mobile software.\n\nYou are not permitted to:\n(a) edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things;\n(b) reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose;\n(c) use the Software in any way which breaches any applicable local, national or international law;\n(d) use the Software for any purpose that ${appCompanyLong} considers is a breach of this EULA agreement.\n\nINTELLECTUAL PROPERTY AND OWNERSHIP\n\n${appCompanyLong} shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of ${appCompanyLong}.\n\n${appCompanyLong} reserves the right to grant licenses to use the Software to third parties.\n\nTERMINATION\n\nThis EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to ${appCompanyLong}.\nIt will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.\n\nGOVERNING LAW\n\nThis EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Vietnam.\n\nThis document was last updated on January 31st, 2020";
 
-  static m33(appCompanyLong) =>
+  static m35(appCompanyLong) =>
       "${appCompanyLong} is the owner and/or authorised user of all trademarks, service marks, design marks, patents, copyrights, database rights and all other intellectual property appearing on or contained within the application, unless otherwise indicated. All information, text, material, graphics, software and advertisements on the application interface are copyright of ${appCompanyLong}, its suppliers and licensors, unless otherwise expressly indicated by ${appCompanyLong}. \nExcept as provided in the Terms, use of the application does not grant You any right, title, interest or license to any such intellectual property You may have access to on the application. \nWe own the rights, or have permission to use, the trademarks listed in our application. You are not authorised to use any of those trademarks without our written authorization – doing so would constitute a breach of our or another party’s intellectual property rights. \nAlternatively, we might authorise You to use the content in our application if You previously contact us and we agree in writing.";
 
-  static m34(appCompanyShort, appCompanyLong) =>
+  static m36(appCompanyShort, appCompanyLong) =>
       "${appCompanyLong} cannot guarantee the safety or security of your computer systems. We do not accept liability for any loss or corruption of electronically stored data or any damage to any computer system occurred in connection with the use of the application or of the user content.\n${appCompanyLong} makes no representation or warranty of any kind, express or implied, as to the operation of the application or the user content. You expressly agree that your use of the application is entirely at your sole risk.\nYou agree that the content provided in the application and the user content do not constitute financial product, legal or taxation advice, and You agree on not representing the user content or the application as such.\nTo the extent permitted by current legislation, the application is provided on an “as is, as available” basis.\n\n${appCompanyLong} expressly disclaims all responsibility for any loss, injury, claim, liability, or damage, or any indirect, incidental, special or consequential damages or loss of profits whatsoever resulting from, arising out of or in any way related to:\n(a) any errors in or omissions of the application and/or the user content, including but not limited to technical inaccuracies and typographical errors;\n(b) any third party website, application or content directly or indirectly accessed through links in the application, including but not limited to any errors or omissions;\n(c) the unavailability of the application or any portion of it;\n(d) your use of the application;\n(e) your use of any equipment or software in connection with the application.\n\nAny Services offered in connection with the Platform are provided on an \'as is\' basis, without any representation or warranty, whether express, implied or statutory. To the maximum extent permitted by applicable law, we specifically disclaim any implied warranties of title, merchantability, suitability for a particular purpose and/or non-infringement. We do not make any representations or warranties that use of the Platform will be continuous, uninterrupted, timely, or error-free.\nWe make no warranty that any Platform will be free from viruses, malware, or other related harmful material and that your ability to access any Platform will be uninterrupted. Any defects or malfunction in the product should be directed to the third party offering the Platform, not to ${appCompanyShort}.\nWe will not be responsible or liable to You for any loss of any kind, from action taken, or taken in reliance on the material or information contained in or through the Platform.\nThis is experimental and unfinished software. Use at your own risk. No warranty for any kind of damage. By using this application you agree to this terms and conditions.";
 
-  static m35(appCompanyLong) =>
+  static m37(appCompanyLong) =>
       "You agree and understand that there are risks associated with utilizing Services involving Virtual Currencies including, but not limited to, the risk of failure of hardware, software and internet connections, the risk of malicious software introduction, and the risk that third parties may obtain unauthorized access to information stored within your Wallet, including but not limited to your public and private keys. You agree and understand that ${appCompanyLong} will not be responsible for any communication failures, disruptions, errors, distortions or delays You may experience when using the Services, however caused.\nYou accept and acknowledge that there are risks associated with utilizing any virtual currency network, including, but not limited to, the risk of unknown vulnerabilities in or unanticipated changes to the network protocol. You acknowledge and accept that ${appCompanyLong} has no control over any cryptocurrency network and will not be responsible for any harm occurring as a result of such risks, including, but not limited to, the inability to reverse a transaction, and any losses in connection therewith due to erroneous or fraudulent actions.\nThe risk of loss in using Services involving Virtual Currencies may be substantial and losses may occur over a short period of time. In addition, price and liquidity are subject to significant fluctuations that may be unpredictable.\nVirtual Currencies are not legal tender and are not backed by any sovereign government. In addition, the legislative and regulatory landscape around Virtual Currencies is constantly changing and may affect your ability to use, transfer, or exchange Virtual Currencies.\nCFDs are complex instruments and come with a high risk of losing money rapidly due to leverage. 80.6% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether You understand how CFDs work and whether You can afford to take the high risk of losing your money.";
 
-  static m36(appCompanyLong) =>
+  static m38(appCompanyLong) =>
       "You agree to indemnify, defend and hold harmless ${appCompanyLong}, its officers, directors, employees, agents, licensors, suppliers and any third party information providers to the application from and against all losses, expenses, damages and costs, including reasonable lawyer fees, resulting from any violation of the Terms by You.\nYou also agree to indemnify ${appCompanyLong} against any claims that information or material which You have submitted to ${appCompanyLong} is in violation of any law or in breach of any third party rights (including, but not limited to, claims in respect of defamation, invasion of privacy, breach of confidence, infringement of copyright or infringement of any other intellectual property right).";
 
-  static m37(appCompanyLong) =>
+  static m39(appCompanyLong) =>
       "In order to be completed, any Virtual Currency transaction created with the ${appCompanyLong} must be confirmed and recorded in the Virtual Currency ledger associated with the relevant Virtual Currency network. Such networks are decentralized, peer-to-peer networks supported by independent third parties, which are not owned, controlled or operated by ${appCompanyLong}.\n${appCompanyLong} has no control over any Virtual Currency network and therefore cannot and does not ensure that any transaction details You submit via our Services will be confirmed on the relevant Virtual Currency network. You agree and understand that the transaction details You submit via our Services may not be completed, or may be substantially delayed, by the Virtual Currency network used to process the transaction. We do not guarantee that the Wallet can transfer title or right in any Virtual Currency or make any warranties whatsoever with regard to title.\nOnce transaction details have been submitted to a Virtual Currency network, we cannot assist You to cancel or otherwise modify your transaction or transaction details. ${appCompanyLong} has no control over any Virtual Currency network and does not have the ability to facilitate any cancellation or modification requests.\nIn the event of a Fork, ${appCompanyLong} may not be able to support activity related to your Virtual Currency. You agree and understand that, in the event of a Fork, the transactions may not be completed, completed partially, incorrectly completed, or substantially delayed. ${appCompanyLong} is not responsible for any loss incurred by You caused in whole or in part, directly or indirectly, by a Fork.\nIn no event shall ${appCompanyLong}, its affiliates and service providers, or any of their respective officers, directors, agents, employees or representatives, be liable for any lost profits or any special, incidental, indirect, intangible, or consequential damages, whether based on contract, tort, negligence, strict liability, or otherwise, arising out of or in connection with authorized or unauthorized use of the services, or this agreement, even if an authorized representative of ${appCompanyLong} has been advised of, has known of, or should have known of the possibility of such damages. \nFor example (and without limiting the scope of the preceding sentence), You may not recover for lost profits, lost business opportunities, or other types of special, incidental, indirect, intangible, or consequential damages. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to You. \nWe will not be responsible or liable to You for any loss and take no responsibility for damages or claims arising in whole or in part, directly or indirectly from: \n(a) user error such as forgotten passwords, incorrectly constructed transactions, or mistyped Virtual Currency addresses; \n(b) server failure or data loss; \n(c) corrupted or otherwise non-performing Wallets or Wallet files; \n(d) unauthorized access to applications; \n(e) any unauthorized activities, including without limitation the use of hacking, viruses, phishing, brute forcing or other means of attack against the Services.";
 
-  static m38(appCompanyShort, appCompanyLong) =>
+  static m40(appCompanyShort, appCompanyLong) =>
       "For the avoidance of doubt, ${appCompanyLong} does not provide investment, tax or legal advice, nor does ${appCompanyLong} broker trades on your behalf. All ${appCompanyLong} trades are executed automatically, based on the parameters of your order instructions and in accordance with posted Trade execution procedures, and You are solely responsible for determining whether any investment, investment strategy or related transaction is appropriate for You based on your personal investment objectives, financial circumstances and risk tolerance. You should consult your legal or tax professional regarding your specific situation. Neither ${appCompanyShort} nor its owners, members, officers, directors, partners, consultants, nor anyone involved in the publication of this application, is a registered investment adviser or broker-dealer or associated person with a registered investment adviser or broker-dealer and none of the foregoing make any recommendation that the purchase or sale of crypto-assets or securities of any company profiled in the mobile Application is suitable or advisable for any person or that an investment or transaction in such crypto-assets or securities will be profitable. The information contained in the mobile Application is not intended to be, and shall not constitute, an offer to sell or the solicitation of any offer to buy any crypto-asset or security. The information presented in the mobile Application is provided for informational purposes only and is not to be treated as advice or a recommendation to make any specific investment or transaction. Please, consult with a qualified professional before making any decisions. The opinions and analysis included in this applications are based on information from sources deemed to be reliable and are provided “as is” in good faith. ${appCompanyShort} makes no representation or warranty, expressed, implied, or statutory, as to the accuracy or completeness of such information, which may be subject to change without notice. ${appCompanyShort} shall not be liable for any errors or any actions taken in relation to the above. Statements of opinion and belief are those of the authors and/or editors who contribute to this application, and are based solely upon the information possessed by such authors and/or editors. No inference should be drawn that ${appCompanyShort} or such authors or editors have any special or greater knowledge about the crypto-assets or companies profiled or any particular expertise in the industries or markets in which the profiled crypto-assets and companies operate and compete. Information on this application is obtained from sources deemed to be reliable; however, ${appCompanyShort} takes no responsibility for verifying the accuracy of such information and makes no representation that such information is accurate or complete. Certain statements included in this application may be forward-looking statements based on current expectations. ${appCompanyShort} makes no representation and provides no assurance or guarantee that such forward-looking statements will prove to be accurate. Persons using the ${appCompanyShort} application are urged to consult with a qualified professional with respect to an investment or transaction in any crypto-asset or company profiled herein. Additionally, persons using this application expressly represent that the content in this application is not and will not be a consideration in such persons’ investment or transaction decisions. Traders should verify independently information provided in the ${appCompanyShort} application by completing their own due diligence on any crypto-asset or company in which they are contemplating an investment or transaction of any kind and review a complete information package on that crypto-asset or company, which should include, but not be limited to, related blog updates and press releases. Past performance of profiled crypto-assets and securities is not indicative of future results. Crypto-assets and companies profiled on this site may lack an active trading market and invest in a crypto-asset or security that lacks an active trading market or trade on certain media, platforms and markets are deemed highly speculative and carry a high degree of risk. Anyone holding such crypto-assets and securities should be financially able and prepared to bear the risk of loss and the actual loss of his or her entire trade. The information in this application is not designed to be used as a basis for an investment decision. Persons using the ${appCompanyShort} application should confirm to their own satisfaction the veracity of any information prior to entering into any investment or making any transaction. The decision to buy or sell any crypto-asset or security that may be featured by ${appCompanyShort} is done purely and entirely at the reader’s own risk. As a reader and user of this application, You agree that under no circumstances will You seek to hold liable owners, members, officers, directors, partners, consultants or other persons involved in the publication of this application for any losses incurred by the use of information contained in this application ${appCompanyShort} and its contractors and affiliates may profit in the event the crypto-assets and securities increase or decrease in value. Such crypto-assets and securities may be bought or sold from time to time, even after ${appCompanyShort} has distributed positive information regarding the crypto-assets and companies. ${appCompanyShort} has no obligation to inform readers of its trading activities or the trading activities of any of its owners, members, officers, directors, contractors and affiliates and/or any companies affiliated with BC Relations’ owners, members, officers, directors, contractors and affiliates. ${appCompanyShort} and its affiliates may from time to time enter into agreements to purchase crypto-assets or securities to provide a method to reach their goals.";
 
-  static m39(appCompanyLong) =>
+  static m41(appCompanyLong) =>
       "The Terms are effective until terminated by ${appCompanyLong}. \nIn the event of termination, You are no longer authorized to access the Application, but all restrictions imposed on You and the disclaimers and limitations of liability set out in the Terms will survive termination. \nSuch termination shall not affect any legal right that may have accrued to ${appCompanyLong} against You up to the date of termination. \n${appCompanyLong} may also remove the Application as a whole or any sections or features of the Application at any time. ";
 
-  static m40(appCompanyLong) =>
+  static m42(appCompanyLong) =>
       "The provisions of previous paragraphs are for the benefit of ${appCompanyLong} and its officers, directors, employees, agents, licensors, suppliers, and any third party information providers to the Application. Each of these individuals or entities shall have the right to assert and enforce those provisions directly against You on its own behalf.";
 
-  static m41(appName, appCompanyLong) =>
+  static m43(appName, appCompanyLong) =>
       "${appName} mobile is a non-custodial, decentralized and blockchain based application and as such does ${appCompanyLong} never store any user-data (accounts and authentication data). \nWe also collect and process non-personal, anonymized data for statistical purposes and analysis and to help us provide a better service.\n\nThis document was last updated on January 31st, 2020";
 
-  static m42(appName, appCompanyLong) =>
+  static m44(appName, appCompanyLong) =>
       "This disclaimer applies to the contents and services of the app ${appName} and is valid for all users of the “Application” (\'Software\', “Mobile Application”, “Application” or “App”).\n\nThe Application is owned by ${appCompanyLong}.\n\nWe reserve the right to amend the following Terms and Conditions (governing the use of the application “${appName} mobile”) at any time without prior notice and at our sole discretion. It is your responsibility to periodically check this Terms and Conditions for any updates to these Terms, which shall come into force once published.\nYour continued use of the application shall be deemed as acceptance of the following Terms.\nWe are a company incorporated in Vietnam and these Terms and Conditions are governed by and subject to the laws of Vietnam.\nIf You do not agree with these Terms and Conditions, You must not use or access this software.";
 
-  static m43(appName) =>
+  static m45(appName) =>
       "You are not allowed to decompile, decode, disassemble, rent, lease, loan, sell, sublicense, or create derivative works from the ${appName} mobile application or the user content. Nor are You allowed to use any network monitoring or detection software to determine the software architecture, or extract information about usage or individuals’ or users’ identities. \nYou are not allowed to copy, modify, reproduce, republish, distribute, display, or transmit for commercial, non-profit or public purposes all or any portion of the application or the user content without our prior written authorization.";
 
-  static m44(appName, appCompanyLong) =>
+  static m46(appName, appCompanyLong) =>
       "If you create an account in the Mobile Application, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account and any other actions taken in connection with it. We will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions. \n\n${appName} mobile is a non-custodial wallet implementation and thus ${appCompanyLong} can not access nor restore your account in case of (data) loss.";
 
-  static m45(appName) =>
+  static m47(appName) =>
       "End-User License Agreement (EULA) of ${appName} mobile:";
 
-  static m46(coin) => "正在向 ${coin} 水龙头发送请求";
+  static m48(coinAbbr) => "无法取消激活 ${coinAbbr}";
 
-  static m47(appCompanyShort) => "${appCompanyShort} 新闻";
+  static m49(coin) => "正在向 ${coin} 水龙头发送请求";
 
-  static m48(value) => "费用必须高达 ${value}";
+  static m50(appCompanyShort) => "${appCompanyShort} 新闻";
 
-  static m49(coin) => "${coin} 费用";
+  static m51(value) => "费用必须高达 ${value}";
 
-  static m50(coin) => "请激活${coin}.";
+  static m52(coin) => "${coin} 费用";
 
-  static m51(value) => "Gwei 必须达到 ${value}";
+  static m53(coin) => "请激活${coin}.";
 
-  static m52(coinName) => "传入 ${coinName} 交易保护设置";
+  static m54(value) => "Gwei 必须达到 ${value}";
 
-  static m53(abbr) => "${abbr}余额不足以支付交易费";
+  static m55(coinName) => "传入 ${coinName} 交易保护设置";
 
-  static m54(coin) => "${coin} 地址无效";
+  static m56(abbr) => "${abbr}余额不足以支付交易费";
 
-  static m55(coinAbbr) => "${coinAbbr} 不可用:(";
+  static m57(coin) => "${coin} 地址无效";
 
-  static m56(coinName) => "❗注意！ ${coinName} 市场的 24 小时交易量不到 1 万美元！";
+  static m58(coinAbbr) => "${coinAbbr} 不可用:(";
 
-  static m57(value) => "限制必须达到 ${value}";
+  static m59(coinName) => "❗注意！ ${coinName} 市场的 24 小时交易量不到 1 万美元！";
 
-  static m58(coinName, number) => "最低售出量为${number} ${coinName}";
+  static m60(value) => "限制必须达到 ${value}";
 
-  static m59(coinName, number) => "最低买入量为${number} ${coinName}";
+  static m61(coinName, number) => "最低售出量为${number} ${coinName}";
 
-  static m60(buyCoin, buyAmount, sellCoin, sellAmount) =>
+  static m62(coinName, number) => "最低买入量为${number} ${coinName}";
+
+  static m63(buyCoin, buyAmount, sellCoin, sellAmount) =>
       "最小交易量为 ${buyAmount} ${buyCoin}\n(${sellAmount} ${sellCoin})";
 
-  static m61(coinName, number) => "最低售出量为 ${number} ${coinName}";
+  static m64(coinName, number) => "最低售出量为 ${number} ${coinName}";
 
-  static m62(minValue, coin) => "必须大于${minValue} ${coin}";
+  static m65(minValue, coin) => "必须大于${minValue} ${coin}";
 
-  static m63(appName) =>
+  static m66(appName) =>
       "请注意，您现在正在使用流量，使用${appName} P2P网络会消耗互联网流量。如果您的手机流量很贵，最好连接WIFI。";
 
-  static m64(coin) => "先激活${coin}并充值余额";
+  static m67(coin) => "先激活${coin}并充值余额";
 
-  static m65(number) => "创建${number}订单：";
+  static m68(number) => "创建${number}订单：";
 
-  static m66(coin) => "${coin}余额过低";
+  static m69(coin) => "${coin}余额过低";
 
-  static m67(coin, fee) => "${coin}不足支付。最低余额为 ${fee} ${coin}";
+  static m70(coin, fee) => "${coin}不足支付。最低余额为 ${fee} ${coin}";
 
-  static m68(coinName) => "请输入 ${coinName} 量";
+  static m71(coinName) => "请输入 ${coinName} 量";
 
-  static m69(coin) => "没有足够的${coin} 用于交易！";
+  static m72(coin) => "没有足够的${coin} 用于交易！";
 
-  static m70(sell, buy) => "${sell}/${buy} 已成功完成交换";
+  static m73(sell, buy) => "${sell}/${buy} 已成功完成交换";
 
-  static m71(sell, buy) => "${sell}/${buy}交换失败";
+  static m74(sell, buy) => "${sell}/${buy}交换失败";
 
-  static m72(sell, buy) => "${sell}/${buy}交换开始";
+  static m75(sell, buy) => "${sell}/${buy}交换开始";
 
-  static m73(sell, buy) => "${sell}/${buy}交换超时";
+  static m76(sell, buy) => "${sell}/${buy}交换超时";
 
-  static m74(coin) => "您已收到｛coin｝交易！";
+  static m77(coin) => "您已收到｛coin｝交易！";
 
-  static m75(assets) => "${assets} 资产";
+  static m78(assets) => "${assets} 资产";
 
-  static m76(coin) => "所有${coin}订单将被取消。";
+  static m79(coin) => "所有${coin}订单将被取消。";
 
-  static m77(delta) => "划算的: CEX +${delta}%";
+  static m80(delta) => "划算的: CEX +${delta}%";
 
-  static m78(delta) => "昂贵的: CEX ${delta}%";
+  static m81(delta) => "昂贵的: CEX ${delta}%";
 
-  static m79(fill) => "${fill}%已填充";
+  static m82(fill) => "${fill}%已填充";
 
-  static m80(coin) => "数量(${coin})";
+  static m83(coin) => "数量(${coin})";
 
-  static m81(coin) => "价格 (${coin})";
+  static m84(coin) => "价格 (${coin})";
 
-  static m82(coin) => "总计 (${coin})";
+  static m85(coin) => "总计 (${coin})";
 
-  static m83(abbr) => "${abbr} 未激活。请激活后重试。";
+  static m86(abbr) => "${abbr} 未激活。请激活后重试。";
 
-  static m84(appName) => "我可以在哪些设备上使用${appName} ？";
+  static m87(appName) => "我可以在哪些设备上使用${appName} ？";
 
-  static m85(appName) => "在${appName} 上交易与在其他DEX上交易有何不同？";
+  static m88(appName) => "在${appName} 上交易与在其他DEX上交易有何不同？";
 
-  static m86(appName) => "${appName} 的费用如何计算？";
+  static m89(appName) => "${appName} 的费用如何计算？";
 
-  static m87(appName) => "${appName} 的背后是谁？";
+  static m90(appName) => "${appName} 的背后是谁？";
 
-  static m88(appName) => "是否可以在${appName} 上开发我个人的白标交换？";
+  static m91(appName) => "是否可以在${appName} 上开发我个人的白标交换？";
 
-  static m89(amount) => "成功！收到 ${amount}KMD";
+  static m92(amount) => "成功！收到 ${amount}KMD";
 
-  static m90(dd) => "${dd} 天";
+  static m93(dd) => "${dd} 天";
 
-  static m91(hh, minutes) => "${hh}小时 ${minutes}分钟";
+  static m94(hh, minutes) => "${hh}小时 ${minutes}分钟";
 
-  static m92(mm) => "${mm}分钟";
+  static m95(mm) => "${mm}分钟";
 
-  static m93(amount) => "点击查看${amount} 交易";
+  static m96(amount) => "点击查看${amount} 交易";
 
-  static m94(coinName, address) => "我的${coinName} 地址:\n${address}";
+  static m97(coinName, address) => "我的${coinName} 地址:\n${address}";
 
-  static m95(coin) => "扫描过去的 ${coin} 交易？";
+  static m98(coin) => "扫描过去的 ${coin} 交易？";
 
-  static m96(count, maxCount) => "显示 ${count} 个订单（共 ${maxCount} 个）。";
+  static m99(count, maxCount) => "显示 ${count} 个订单（共 ${maxCount} 个）。";
 
-  static m97(coin) => "请输入要买入的 ${coin} 数量";
+  static m100(coin) => "请输入要买入的 ${coin} 数量";
 
-  static m98(maxCoins) => "货币最大活跃量为${maxCoins}。请停用一些。";
+  static m101(maxCoins) => "货币最大活跃量为${maxCoins}。请停用一些。";
 
-  static m99(coin) => "${coin}未激活！";
+  static m102(coin) => "${coin}未激活！";
 
-  static m100(coin) => "请输入要卖出的${coin}数量";
+  static m103(coin) => "请输入要卖出的${coin}数量";
 
-  static m101(coin) => "无法激活${coin}";
+  static m104(coin) => "无法激活${coin}";
 
-  static m102(description) => "请选择mp3或wav文件。我们将在${description}时播放它。";
+  static m105(description) => "请选择mp3或wav文件。我们将在${description}时播放它。";
 
-  static m103(description) => "当${description}播放";
+  static m106(description) => "当${description}播放";
 
-  static m104(appName) =>
+  static m107(appName) =>
       "如果您有任何问题，或者认为您发现${appName} 应用程序存在技术问题，请联系我们获取我们团队的支持。";
 
-  static m105(coin) => "请先激活 ${coin} 并充值余额";
+  static m108(coin) => "请先激活 ${coin} 并充值余额";
 
-  static m106(coin) => "${coin} 余额不足以支付交易费用。";
+  static m109(coin) => "${coin} 余额不足以支付交易费用。";
 
-  static m107(coin, amount) => "${coin} 余额不足以支付交易费用。需要 ${coin} ${amount}";
+  static m110(coin, amount) => "${coin} 余额不足以支付交易费用。需要 ${coin} ${amount}";
 
-  static m108(name) => "您想要同步哪些${name}交易？";
+  static m111(name) => "您想要同步哪些${name}交易？";
 
-  static m109(left) => "剩余交易: ${left}";
+  static m112(left) => "剩余交易: ${left}";
 
-  static m110(amnt, hash) => "成功解锁 ${amnt} 基金 - 交易: ${hash}";
+  static m113(amnt, hash) => "成功解锁 ${amnt} 基金 - 交易: ${hash}";
 
-  static m111(version) => "您正在使用版本${version}";
+  static m114(version) => "您正在使用版本${version}";
 
-  static m112(version) => "版本${version}可用。请更新。";
+  static m115(version) => "版本${version}可用。请更新。";
 
-  static m113(appName) => "更新${appName}";
+  static m116(appName) => "更新${appName}";
 
-  static m114(coinAbbr) => "我们无法激活 ${coinAbbr}";
+  static m117(coinAbbr) => "我们无法激活 ${coinAbbr}";
 
-  static m115(coinAbbr) => "我们无法激活${coinAbbr}.\n请重启应用程序后重试";
+  static m118(coinAbbr) => "我们无法激活${coinAbbr}.\n请重启应用程序后重试";
 
-  static m116(appName) => "${appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。";
+  static m119(appName) => "${appName} 应用程序是新一代多币钱包，具有原生第三代DEX功能和更多功能。";
 
-  static m117(appName) => "您之前禁止${appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描";
+  static m120(appName) => "您之前禁止${appName} 使用相机。请手动更改手机设置中的相机权限，以便继续二维码扫描";
 
-  static m118(amount, coinName) => "提取 ${amount} ${coinName}";
+  static m121(amount, coinName) => "提取 ${amount} ${coinName}";
 
-  static m119(amount, coin) => "您将获得 ${amount} ${coin}";
+  static m122(amount, coin) => "您将获得 ${amount} ${coin}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -309,6 +315,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "activateCoins": m0,
         "activating": m1,
         "activation": m2,
+        "activationCancelled": MessageLookupByLibrary.simpleMessage("硬币激活已取消"),
         "activationInProgress": m3,
         "addCoin": MessageLookupByLibrary.simpleMessage("新增货币"),
         "addingCoinSuccess": m4,
@@ -422,14 +429,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "code": MessageLookupByLibrary.simpleMessage("代码"),
         "cofirmCancelActivation":
             MessageLookupByLibrary.simpleMessage("您确定要取消激活吗？"),
+        "coinActivationCancelled": m22,
+        "coinActivationSuccessfull": m23,
         "coinSelectClear": MessageLookupByLibrary.simpleMessage("清除"),
         "coinSelectNotFound": MessageLookupByLibrary.simpleMessage("没有活跃币"),
         "coinSelectTitle": MessageLookupByLibrary.simpleMessage("选择货币"),
         "coinsActivatedLimitReached":
             MessageLookupByLibrary.simpleMessage("您已选择最大资产数量"),
-        "coinsAreActivated": m22,
-        "coinsAreActivatedSuccessfully": m23,
-        "coinsAreNotActivated": m24,
+        "coinsAreActivated": m24,
+        "coinsAreActivatedSuccessfully": m25,
+        "coinsAreNotActivated": m26,
         "comingSoon": MessageLookupByLibrary.simpleMessage("即将上线，敬请期待。。。"),
         "commingsoon": MessageLookupByLibrary.simpleMessage("交易明细加载中！"),
         "commingsoonGeneral": MessageLookupByLibrary.simpleMessage("详情载入中！"),
@@ -452,7 +461,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "contactCancel": MessageLookupByLibrary.simpleMessage("取消"),
         "contactDelete": MessageLookupByLibrary.simpleMessage("删除联系人"),
         "contactDeleteBtn": MessageLookupByLibrary.simpleMessage("删除"),
-        "contactDeleteWarning": m25,
+        "contactDeleteWarning": m27,
         "contactDiscardBtn": MessageLookupByLibrary.simpleMessage("放弃"),
         "contactEdit": MessageLookupByLibrary.simpleMessage("编辑"),
         "contactExit": MessageLookupByLibrary.simpleMessage("退出"),
@@ -475,7 +484,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "customFee": MessageLookupByLibrary.simpleMessage("定制费用"),
         "customFeeWarning":
             MessageLookupByLibrary.simpleMessage("选择定制费用前务必明确知晓自己的行为"),
-        "customSeedWarning": m26,
+        "customSeedWarning": m28,
         "dPow": MessageLookupByLibrary.simpleMessage("Komodo dPoW安全"),
         "date": MessageLookupByLibrary.simpleMessage("日期"),
         "decryptingWallet": MessageLookupByLibrary.simpleMessage("钱包解密中"),
@@ -487,8 +496,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteSpan3": MessageLookupByLibrary.simpleMessage(" 也将被停用"),
         "deleteWallet": MessageLookupByLibrary.simpleMessage("删除钱包"),
         "deletingWallet": MessageLookupByLibrary.simpleMessage("删除钱包中"),
-        "detailedFeesReceiveCoinTransactionFee": m27,
-        "detailedFeesSendCoinTransactionFee": m28,
+        "detailedFeesReceiveCoinTransactionFee": m29,
+        "detailedFeesSendCoinTransactionFee": m30,
         "detailedFeesSendTradingFeeTransactionFee":
             MessageLookupByLibrary.simpleMessage("发送交易费 交易费"),
         "detailedFeesTradingFee": MessageLookupByLibrary.simpleMessage("交易费"),
@@ -506,12 +515,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "dontWantPassword": MessageLookupByLibrary.simpleMessage("我不想要使用密碼"),
         "duration": MessageLookupByLibrary.simpleMessage("有效期"),
         "editContact": MessageLookupByLibrary.simpleMessage("编辑联系人"),
-        "emptyCoin": m29,
+        "emptyCoin": m31,
         "emptyExportPass": MessageLookupByLibrary.simpleMessage("加密密码不能为空"),
         "emptyImportPass": MessageLookupByLibrary.simpleMessage("密码不能为空"),
         "emptyName": MessageLookupByLibrary.simpleMessage("联系人名称不能为空"),
         "emptyWallet": MessageLookupByLibrary.simpleMessage("钱包名称不能为空"),
-        "enable": m30,
+        "enable": m32,
         "enableNotificationsForActivationProgress":
             MessageLookupByLibrary.simpleMessage("请启用通知以获取有关激活进度的更新。"),
         "enableTestCoins": MessageLookupByLibrary.simpleMessage("启用测试币"),
@@ -537,38 +546,38 @@ class MessageLookup extends MessageLookupByLibrary {
         "errorNotAValidAddress": MessageLookupByLibrary.simpleMessage("钱包地址错误"),
         "errorNotAValidAddressSegWit":
             MessageLookupByLibrary.simpleMessage("尚不支持Segwit地址"),
-        "errorNotEnoughGas": m31,
+        "errorNotEnoughGas": m33,
         "errorTryAgain": MessageLookupByLibrary.simpleMessage("出现错误, 請重试"),
         "errorTryLater": MessageLookupByLibrary.simpleMessage("出现错误，請稍後重试"),
         "errorValueEmpty": MessageLookupByLibrary.simpleMessage("价值太高或太低"),
         "errorValueNotEmpty": MessageLookupByLibrary.simpleMessage("请输入数据"),
         "estimateValue": MessageLookupByLibrary.simpleMessage("预估总价"),
-        "eulaParagraphe1": m32,
-        "eulaParagraphe10": m33,
-        "eulaParagraphe11": m34,
+        "eulaParagraphe1": m34,
+        "eulaParagraphe10": m35,
+        "eulaParagraphe11": m36,
         "eulaParagraphe12": MessageLookupByLibrary.simpleMessage(
             "When accessing or using the Services, You agree that You are solely responsible for your conduct while accessing and using our Services. Without limiting the generality of the foregoing, You agree that You will not:\n(a) use the Services in any manner that could interfere with, disrupt, negatively affect or inhibit other users from fully enjoying the Services, or that could damage, disable, overburden or impair the functioning of our Services in any manner;\n(b) use the Services to pay for, support or otherwise engage in any illegal activities, including, but not limited to illegal gambling, fraud, money laundering, or terrorist activities;\n(c) use any robot, spider, crawler, scraper or other automated means or interface not provided by us to access our Services or to extract data;\n(d) use or attempt to use another user’s Wallet or credentials without authorization;\n(e) attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that You are not authorized to access;\n(f) introduce to the Services any virus, Trojan, worms, logic bombs or other harmful material;\n(g) develop any third-party applications that interact with our Services without our prior written consent;\n(h) provide false, inaccurate, or misleading information; \n(i) encourage or induce any other person to engage in any of the activities prohibited under this Section."),
-        "eulaParagraphe13": m35,
-        "eulaParagraphe14": m36,
-        "eulaParagraphe15": m37,
-        "eulaParagraphe16": m38,
-        "eulaParagraphe17": m39,
-        "eulaParagraphe18": m40,
-        "eulaParagraphe19": m41,
-        "eulaParagraphe2": m42,
+        "eulaParagraphe13": m37,
+        "eulaParagraphe14": m38,
+        "eulaParagraphe15": m39,
+        "eulaParagraphe16": m40,
+        "eulaParagraphe17": m41,
+        "eulaParagraphe18": m42,
+        "eulaParagraphe19": m43,
+        "eulaParagraphe2": m44,
         "eulaParagraphe3": MessageLookupByLibrary.simpleMessage(
             "By entering into this User (each subject accessing or using the site) Agreement (this writing) You declare that You are an individual over the age of majority (at least 18 or older) and have the capacity to enter into this User Agreement and accept to be legally bound by the terms and conditions of this User Agreement, as incorporated herein and amended from time to time."),
         "eulaParagraphe4": MessageLookupByLibrary.simpleMessage(
             "We may change the terms of this User Agreement at any time. Any such changes will take effect when published in the application, or when You use the Services.\n\nRead the User Agreement carefully every time You use our Services. Your continued use of the Services shall signify your acceptance to be bound by the current User Agreement. Our failure or delay in enforcing or partially enforcing any provision of this User Agreement shall not be construed as a waiver of any."),
-        "eulaParagraphe5": m43,
-        "eulaParagraphe6": m44,
+        "eulaParagraphe5": m45,
+        "eulaParagraphe6": m46,
         "eulaParagraphe7": MessageLookupByLibrary.simpleMessage(
             "We are not responsible for seed-phrases residing in the Mobile Application. In no event shall we be held liable for any loss of any kind. It is your sole responsibility to maintain appropriate backups of your accounts and their seedprases."),
         "eulaParagraphe8": MessageLookupByLibrary.simpleMessage(
             "You should not act, or refrain from acting solely on the basis of the content of this application. \nYour access to this application does not itself create an adviser-client relationship between You and us. \nThe content of this application does not constitute a solicitation or inducement to invest in any financial products or services offered by us. \nAny advice included in this application has been prepared without taking into account your objectives, financial situation or needs. You should consider our Risk Disclosure Notice before making any decision on whether to acquire the product described in that document."),
         "eulaParagraphe9": MessageLookupByLibrary.simpleMessage(
             "We do not guarantee your continuous access to the application or that your access or use will be error-free. \nWe will not be liable in the event that the application is unavailable to You for any reason (for example, due to computer downtime ascribable to malfunctions, upgrades, server problems, precautionary or corrective maintenance activities or interruption in telecommunication supplies). "),
-        "eulaTitle1": m45,
+        "eulaTitle1": m47,
         "eulaTitle10":
             MessageLookupByLibrary.simpleMessage("ACCESS AND SECURITY"),
         "eulaTitle11": MessageLookupByLibrary.simpleMessage(
@@ -615,16 +624,17 @@ class MessageLookup extends MessageLookupByLibrary {
         "exportSuccessTitle": MessageLookupByLibrary.simpleMessage("项目成功导出"),
         "exportSwapsTitle": MessageLookupByLibrary.simpleMessage("交换"),
         "exportTitle": MessageLookupByLibrary.simpleMessage("导出"),
+        "failedToCancelActivation": m48,
         "fakeBalanceAmt": MessageLookupByLibrary.simpleMessage("虚假余额"),
         "faqTitle": MessageLookupByLibrary.simpleMessage("常见问题"),
         "faucetError": MessageLookupByLibrary.simpleMessage("错误"),
-        "faucetInProgress": m46,
+        "faucetInProgress": m49,
         "faucetName": MessageLookupByLibrary.simpleMessage("水龙头"),
         "faucetSuccess": MessageLookupByLibrary.simpleMessage("成功"),
         "faucetTimedOut": MessageLookupByLibrary.simpleMessage("请求超时"),
         "feedNewsTab": MessageLookupByLibrary.simpleMessage("新闻"),
         "feedNotFound": MessageLookupByLibrary.simpleMessage("无内容"),
-        "feedNotifTitle": m47,
+        "feedNotifTitle": m50,
         "feedReadMore": MessageLookupByLibrary.simpleMessage("阅读更多"),
         "feedTab": MessageLookupByLibrary.simpleMessage("Feed"),
         "feedTitle": MessageLookupByLibrary.simpleMessage("Feed新闻"),
@@ -633,7 +643,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "feedUpToDate": MessageLookupByLibrary.simpleMessage("已更新"),
         "feedUpdated": MessageLookupByLibrary.simpleMessage("Feed新闻已更新"),
         "feedback": MessageLookupByLibrary.simpleMessage("共享日志文件"),
-        "feesError": m48,
+        "feesError": m51,
         "filtersAll": MessageLookupByLibrary.simpleMessage("全部"),
         "filtersButton": MessageLookupByLibrary.simpleMessage("过滤器"),
         "filtersClearAll": MessageLookupByLibrary.simpleMessage("清除所有过滤器"),
@@ -654,9 +664,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "from": MessageLookupByLibrary.simpleMessage("起始日期"),
         "futureTransactions": MessageLookupByLibrary.simpleMessage(
             "我们将同步与您的公钥关联的激活后进行的未来交易。这是最快的选项，占用的存储空间最少。"),
-        "gasFee": m49,
+        "gasFee": m52,
         "gasLimit": MessageLookupByLibrary.simpleMessage("燃料上限"),
-        "gasNotActive": m50,
+        "gasNotActive": m53,
         "gasPrice": MessageLookupByLibrary.simpleMessage("燃料价格"),
         "generalPinNotActive": MessageLookupByLibrary.simpleMessage(
             "常规PIN保护未激活。\n伪装模式将失效\n请激活PIN保护"),
@@ -664,7 +674,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("重要提醒: 請在繼續之前備份助記詞 !"),
         "gettingTxWait": MessageLookupByLibrary.simpleMessage("正在获取交易，请稍候"),
         "goToPorfolio": MessageLookupByLibrary.simpleMessage("前往投资组合"),
-        "gweiError": m51,
+        "gweiError": m54,
         "helpLink": MessageLookupByLibrary.simpleMessage("帮助"),
         "helpTitle": MessageLookupByLibrary.simpleMessage("帮助和支持"),
         "hideBalance": MessageLookupByLibrary.simpleMessage("隐藏余额"),
@@ -702,7 +712,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "importSwapJsonDecodingError":
             MessageLookupByLibrary.simpleMessage("解码json文件时出错"),
         "importTitle": MessageLookupByLibrary.simpleMessage("导入"),
-        "incomingTransactionsProtectionSettings": m52,
+        "incomingTransactionsProtectionSettings": m55,
         "infoPasswordDialog":
             MessageLookupByLibrary.simpleMessage("使用安全密码，不要将其存储在同一设备上"),
         "infoTrade1": MessageLookupByLibrary.simpleMessage("無法撤銷交换请求！"),
@@ -710,23 +720,23 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("交换最长需要60分钟。不要关闭此应用程序！"),
         "infoWalletPassword":
             MessageLookupByLibrary.simpleMessage("安全起见，您必须为加密钱包设置密码。"),
-        "insufficientBalanceToPay": m53,
+        "insufficientBalanceToPay": m56,
         "insufficientText": MessageLookupByLibrary.simpleMessage("此订单最小交易量为"),
         "insufficientTitle": MessageLookupByLibrary.simpleMessage("交易量不足"),
         "internetRefreshButton": MessageLookupByLibrary.simpleMessage("刷新"),
         "internetRestored": MessageLookupByLibrary.simpleMessage("已重新连接互联网"),
-        "invalidCoinAddress": m54,
+        "invalidCoinAddress": m57,
         "invalidSwap": MessageLookupByLibrary.simpleMessage("无法继续交换"),
         "invalidSwapDetailsLink": MessageLookupByLibrary.simpleMessage("详细信息"),
-        "isUnavailable": m55,
+        "isUnavailable": m58,
         "japaneseLanguage": MessageLookupByLibrary.simpleMessage("日文"),
         "koreanLanguage": MessageLookupByLibrary.simpleMessage("韩国人"),
         "language": MessageLookupByLibrary.simpleMessage("语言"),
         "latestTxs": MessageLookupByLibrary.simpleMessage("最新交易"),
         "legalTitle": MessageLookupByLibrary.simpleMessage("合法的"),
         "less": MessageLookupByLibrary.simpleMessage("较少"),
-        "lessThanCaution": m56,
-        "limitError": m57,
+        "lessThanCaution": m59,
+        "limitError": m60,
         "loading": MessageLookupByLibrary.simpleMessage("載入中"),
         "loadingOrderbook": MessageLookupByLibrary.simpleMessage("正在加载订单记录"),
         "lockScreen": MessageLookupByLibrary.simpleMessage("屏幕已锁定"),
@@ -779,27 +789,27 @@ class MessageLookup extends MessageLookupByLibrary {
         "milliseconds": MessageLookupByLibrary.simpleMessage("毫秒"),
         "min": MessageLookupByLibrary.simpleMessage("最小"),
         "minOrder": MessageLookupByLibrary.simpleMessage("最小交易量"),
-        "minValue": m58,
-        "minValueBuy": m59,
-        "minValueOrder": m60,
-        "minValueSell": m61,
-        "minVolumeInput": m62,
+        "minValue": m61,
+        "minValueBuy": m62,
+        "minValueOrder": m63,
+        "minValueSell": m64,
+        "minVolumeInput": m65,
         "minVolumeIsTDH": MessageLookupByLibrary.simpleMessage("必须低于售出量"),
         "minVolumeTitle": MessageLookupByLibrary.simpleMessage("所需最小量"),
         "minVolumeToggle": MessageLookupByLibrary.simpleMessage("使用自定义最小量"),
         "minimizingWillTerminate":
             MessageLookupByLibrary.simpleMessage("警告：最小化 iOS 上的应用程序将终止激活过程。"),
         "minutes": MessageLookupByLibrary.simpleMessage("分钟"),
-        "mobileDataWarning": m63,
+        "mobileDataWarning": m66,
         "moreInfo": MessageLookupByLibrary.simpleMessage("更多信息"),
         "moreTab": MessageLookupByLibrary.simpleMessage("更多"),
-        "multiActivateGas": m64,
+        "multiActivateGas": m67,
         "multiBaseAmtPlaceholder": MessageLookupByLibrary.simpleMessage("数量"),
         "multiBasePlaceholder": MessageLookupByLibrary.simpleMessage("货币"),
         "multiBaseSelectTitle": MessageLookupByLibrary.simpleMessage("卖出"),
         "multiConfirmCancel": MessageLookupByLibrary.simpleMessage("取消"),
         "multiConfirmConfirm": MessageLookupByLibrary.simpleMessage("确认"),
-        "multiConfirmTitle": m65,
+        "multiConfirmTitle": m68,
         "multiCreate": MessageLookupByLibrary.simpleMessage("创建"),
         "multiCreateOrder": MessageLookupByLibrary.simpleMessage("订单"),
         "multiCreateOrders": MessageLookupByLibrary.simpleMessage("订单"),
@@ -810,8 +820,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "multiFixErrors": MessageLookupByLibrary.simpleMessage("请在继续之前修复所有错误"),
         "multiInvalidAmt": MessageLookupByLibrary.simpleMessage("数量无效"),
         "multiInvalidSellAmt": MessageLookupByLibrary.simpleMessage("售出量无效"),
-        "multiLowGas": m66,
-        "multiLowerThanFee": m67,
+        "multiLowGas": m69,
+        "multiLowerThanFee": m70,
         "multiMaxSellAmt": MessageLookupByLibrary.simpleMessage("最大售出量为"),
         "multiMinReceiveAmt": MessageLookupByLibrary.simpleMessage("最小接收量为"),
         "multiMinSellAmt": MessageLookupByLibrary.simpleMessage("最小售出量为"),
@@ -835,7 +845,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "noItemsToExport": MessageLookupByLibrary.simpleMessage("未选择项目"),
         "noItemsToImport": MessageLookupByLibrary.simpleMessage("未选择项目"),
         "noMatchingOrders": MessageLookupByLibrary.simpleMessage("无匹配订单"),
-        "noOrder": m68,
+        "noOrder": m71,
         "noOrderAvailable": MessageLookupByLibrary.simpleMessage("点击创建订单"),
         "noOrders": MessageLookupByLibrary.simpleMessage("没有订单，请先交易"),
         "noRewardYet": MessageLookupByLibrary.simpleMessage("没有奖励可领取-请一小时后重试"),
@@ -845,26 +855,26 @@ class MessageLookup extends MessageLookupByLibrary {
         "noTxs": MessageLookupByLibrary.simpleMessage("没有交易"),
         "nonNumericInput": MessageLookupByLibrary.simpleMessage("该值必须是数字"),
         "none": MessageLookupByLibrary.simpleMessage("没有任何"),
-        "notEnoughGas": m69,
+        "notEnoughGas": m72,
         "notEnoughtBalanceForFee":
             MessageLookupByLibrary.simpleMessage("手续费余额不足-减少交易量"),
         "noteOnOrder": MessageLookupByLibrary.simpleMessage("备注：不能取消已匹配的订单"),
         "notePlaceholder": MessageLookupByLibrary.simpleMessage("添加备注"),
         "noteTitle": MessageLookupByLibrary.simpleMessage("备注"),
         "nothingFound": MessageLookupByLibrary.simpleMessage("无内容"),
-        "notifSwapCompletedText": m70,
+        "notifSwapCompletedText": m73,
         "notifSwapCompletedTitle":
             MessageLookupByLibrary.simpleMessage("交换已完成"),
-        "notifSwapFailedText": m71,
+        "notifSwapFailedText": m74,
         "notifSwapFailedTitle": MessageLookupByLibrary.simpleMessage("交换失败"),
-        "notifSwapStartedText": m72,
+        "notifSwapStartedText": m75,
         "notifSwapStartedTitle": MessageLookupByLibrary.simpleMessage("已开始新交换"),
         "notifSwapStatusTitle": MessageLookupByLibrary.simpleMessage("交换状态已更改"),
-        "notifSwapTimeoutText": m73,
+        "notifSwapTimeoutText": m76,
         "notifSwapTimeoutTitle": MessageLookupByLibrary.simpleMessage("交换超时"),
-        "notifTxText": m74,
+        "notifTxText": m77,
         "notifTxTitle": MessageLookupByLibrary.simpleMessage("应记交易"),
-        "numberAssets": m75,
+        "numberAssets": m78,
         "officialPressRelease": MessageLookupByLibrary.simpleMessage("官方新闻稿"),
         "okButton": MessageLookupByLibrary.simpleMessage("好的"),
         "oldLogsDelete": MessageLookupByLibrary.simpleMessage("删除"),
@@ -873,13 +883,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "openMessage": MessageLookupByLibrary.simpleMessage("打开错误消息"),
         "orderBookLess": MessageLookupByLibrary.simpleMessage("较少的"),
         "orderBookMore": MessageLookupByLibrary.simpleMessage("更多的"),
-        "orderCancel": m76,
+        "orderCancel": m79,
         "orderCreated": MessageLookupByLibrary.simpleMessage("订单已创建"),
         "orderCreatedInfo": MessageLookupByLibrary.simpleMessage("订单已成功创建"),
         "orderDetailsAddress": MessageLookupByLibrary.simpleMessage("地址"),
         "orderDetailsCancel": MessageLookupByLibrary.simpleMessage("取消"),
-        "orderDetailsExpedient": m77,
-        "orderDetailsExpensive": m78,
+        "orderDetailsExpedient": m80,
+        "orderDetailsExpensive": m81,
         "orderDetailsFor": MessageLookupByLibrary.simpleMessage("与"),
         "orderDetailsIdentical": MessageLookupByLibrary.simpleMessage("CEX相同"),
         "orderDetailsMin": MessageLookupByLibrary.simpleMessage("最小量"),
@@ -891,7 +901,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("单击打开详细信息，然后长按选择订购"),
         "orderDetailsSpend": MessageLookupByLibrary.simpleMessage("花费"),
         "orderDetailsTitle": MessageLookupByLibrary.simpleMessage("详细信息"),
-        "orderFilled": m79,
+        "orderFilled": m82,
         "orderMatched": MessageLookupByLibrary.simpleMessage("已匹配订单"),
         "orderMatching": MessageLookupByLibrary.simpleMessage("订单匹配中"),
         "orderTypePartial": MessageLookupByLibrary.simpleMessage("订单"),
@@ -899,9 +909,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "orders": MessageLookupByLibrary.simpleMessage("订单"),
         "ordersActive": MessageLookupByLibrary.simpleMessage("活跃"),
         "ordersHistory": MessageLookupByLibrary.simpleMessage("历史记录"),
-        "ordersTableAmount": m80,
-        "ordersTablePrice": m81,
-        "ordersTableTotal": m82,
+        "ordersTableAmount": m83,
+        "ordersTablePrice": m84,
+        "ordersTableTotal": m85,
         "overwrite": MessageLookupByLibrary.simpleMessage("覆盖"),
         "ownOrder": MessageLookupByLibrary.simpleMessage("这是您个人的订单"),
         "paidFromBalance": MessageLookupByLibrary.simpleMessage("用余额支付："),
@@ -923,8 +933,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "paymentUriDetailsDeny": MessageLookupByLibrary.simpleMessage("取消"),
         "paymentUriDetailsTitle":
             MessageLookupByLibrary.simpleMessage("已请求的付款"),
-        "paymentUriInactiveCoin": m83,
+        "paymentUriInactiveCoin": m86,
         "placeOrder": MessageLookupByLibrary.simpleMessage("下单"),
+        "pleaseAcceptAllCoinActivationRequests":
+            MessageLookupByLibrary.simpleMessage("请接受所有特殊硬币激活请求或取消选择硬币。"),
         "pleaseAddCoin": MessageLookupByLibrary.simpleMessage("请添加货币"),
         "pleaseRestart":
             MessageLookupByLibrary.simpleMessage("请重启应用程序后重试，或按下面的按钮。"),
@@ -944,15 +956,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "pubkey": MessageLookupByLibrary.simpleMessage("公钥"),
         "qrCodeScanner": MessageLookupByLibrary.simpleMessage("二维码扫描仪"),
         "question_1": MessageLookupByLibrary.simpleMessage("你们会保存我的私钥吗？"),
-        "question_10": m84,
-        "question_2": m85,
+        "question_10": m87,
+        "question_2": m88,
         "question_3": MessageLookupByLibrary.simpleMessage("每次原子交换需要多长时间？"),
         "question_4": MessageLookupByLibrary.simpleMessage("在交换期间我要保持在线吗"),
-        "question_5": m86,
+        "question_5": m89,
         "question_6": MessageLookupByLibrary.simpleMessage("你们会提供用户支持吗？"),
         "question_7": MessageLookupByLibrary.simpleMessage("你们有地区限制吗？"),
-        "question_8": m87,
-        "question_9": m88,
+        "question_8": m90,
+        "question_9": m91,
         "rebrandingAnnouncement": MessageLookupByLibrary.simpleMessage(
             "这是一个新时代！我们已正式将名称从“AtomicDEX”更改为“Komodo Wallet”"),
         "receive": MessageLookupByLibrary.simpleMessage("接收"),
@@ -981,7 +993,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsReadMore":
             MessageLookupByLibrary.simpleMessage("阅读有关KMD活跃用户奖励的更多信息"),
         "rewardsReceive": MessageLookupByLibrary.simpleMessage("接收"),
-        "rewardsSuccess": m89,
+        "rewardsSuccess": m92,
         "rewardsTableFiat": MessageLookupByLibrary.simpleMessage("法币"),
         "rewardsTableRewards": MessageLookupByLibrary.simpleMessage("奖励，KMD"),
         "rewardsTableStatus": MessageLookupByLibrary.simpleMessage("状态"),
@@ -989,9 +1001,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "rewardsTableTitle": MessageLookupByLibrary.simpleMessage("奖励信息"),
         "rewardsTableUXTO":
             MessageLookupByLibrary.simpleMessage("UTXO 数量\nKMD"),
-        "rewardsTimeDays": m90,
-        "rewardsTimeHours": m91,
-        "rewardsTimeMin": m92,
+        "rewardsTimeDays": m93,
+        "rewardsTimeHours": m94,
+        "rewardsTimeMin": m95,
         "rewardsTitle": MessageLookupByLibrary.simpleMessage("奖励信息"),
         "russianLanguage": MessageLookupByLibrary.simpleMessage("俄语"),
         "saveMerged": MessageLookupByLibrary.simpleMessage("保存合并"),
@@ -1040,7 +1052,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "searchForTicker": MessageLookupByLibrary.simpleMessage("搜索货币代码"),
         "seconds": MessageLookupByLibrary.simpleMessage("秒"),
         "security": MessageLookupByLibrary.simpleMessage("证券"),
-        "seeOrders": m93,
+        "seeOrders": m96,
         "seeTxHistory": MessageLookupByLibrary.simpleMessage("查看交易记录"),
         "seedPhrase": MessageLookupByLibrary.simpleMessage("助记词"),
         "seedPhraseTitle": MessageLookupByLibrary.simpleMessage("您的新助記詞"),
@@ -1069,33 +1081,33 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingLanguageTitle": MessageLookupByLibrary.simpleMessage("语言"),
         "settings": MessageLookupByLibrary.simpleMessage("设置"),
         "share": MessageLookupByLibrary.simpleMessage("分享"),
-        "shareAddress": m94,
-        "shouldScanPastTransaction": m95,
+        "shareAddress": m97,
+        "shouldScanPastTransaction": m98,
         "showAddress": MessageLookupByLibrary.simpleMessage("显示地址"),
         "showDetails": MessageLookupByLibrary.simpleMessage("显示详细信息"),
         "showMyOrders": MessageLookupByLibrary.simpleMessage("显示我的订单"),
-        "showingOrders": m96,
+        "showingOrders": m99,
         "signInWithPassword": MessageLookupByLibrary.simpleMessage("使用密码登录"),
         "signInWithSeedPhrase":
             MessageLookupByLibrary.simpleMessage("忘记密码？用助记词恢复钱包"),
         "simple": MessageLookupByLibrary.simpleMessage("简单"),
         "simpleTradeActivate": MessageLookupByLibrary.simpleMessage("激活"),
-        "simpleTradeBuyHint": m97,
+        "simpleTradeBuyHint": m100,
         "simpleTradeBuyTitle": MessageLookupByLibrary.simpleMessage("买入"),
         "simpleTradeClose": MessageLookupByLibrary.simpleMessage("关闭"),
-        "simpleTradeMaxActiveCoins": m98,
-        "simpleTradeNotActive": m99,
+        "simpleTradeMaxActiveCoins": m101,
+        "simpleTradeNotActive": m102,
         "simpleTradeRecieve": MessageLookupByLibrary.simpleMessage("接收"),
-        "simpleTradeSellHint": m100,
+        "simpleTradeSellHint": m103,
         "simpleTradeSellTitle": MessageLookupByLibrary.simpleMessage("卖出"),
         "simpleTradeSend": MessageLookupByLibrary.simpleMessage("发送"),
         "simpleTradeShowLess": MessageLookupByLibrary.simpleMessage("收起"),
         "simpleTradeShowMore": MessageLookupByLibrary.simpleMessage("显示更多"),
-        "simpleTradeUnableActivate": m101,
+        "simpleTradeUnableActivate": m104,
         "skip": MessageLookupByLibrary.simpleMessage("跳过"),
         "snackbarDismiss": MessageLookupByLibrary.simpleMessage("不予考虑"),
-        "soundCantPlayThatMsg": m102,
-        "soundPlayedWhen": m103,
+        "soundCantPlayThatMsg": m105,
+        "soundPlayedWhen": m106,
         "soundSettingsLink": MessageLookupByLibrary.simpleMessage("声音"),
         "soundSettingsTitle": MessageLookupByLibrary.simpleMessage("声音设置"),
         "soundsDialogTitle": MessageLookupByLibrary.simpleMessage("声音"),
@@ -1111,15 +1123,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "step": MessageLookupByLibrary.simpleMessage("步骤"),
         "success": MessageLookupByLibrary.simpleMessage("成功"),
         "support": MessageLookupByLibrary.simpleMessage("支持"),
-        "supportLinksDesc": m104,
+        "supportLinksDesc": m107,
         "swap": MessageLookupByLibrary.simpleMessage("交换"),
         "swapCurrent": MessageLookupByLibrary.simpleMessage("现状"),
         "swapDetailTitle": MessageLookupByLibrary.simpleMessage("确认兑换细节"),
         "swapEstimated": MessageLookupByLibrary.simpleMessage("预估"),
         "swapFailed": MessageLookupByLibrary.simpleMessage("交换失败"),
-        "swapGasActivate": m105,
-        "swapGasAmount": m106,
-        "swapGasAmountRequired": m107,
+        "swapGasActivate": m108,
+        "swapGasAmount": m109,
+        "swapGasAmountRequired": m110,
         "swapOngoing": MessageLookupByLibrary.simpleMessage("正在交换"),
         "swapProgress": MessageLookupByLibrary.simpleMessage("进度详情"),
         "swapStarted": MessageLookupByLibrary.simpleMessage("已开始"),
@@ -1131,7 +1143,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "syncFromSaplingActivation":
             MessageLookupByLibrary.simpleMessage("从树苗激活同步"),
         "syncNewTransactions": MessageLookupByLibrary.simpleMessage("同步新交易"),
-        "syncTransactionsQuestion": m108,
+        "syncTransactionsQuestion": m111,
         "tagAVX20": MessageLookupByLibrary.simpleMessage("AVX20"),
         "tagBEP20": MessageLookupByLibrary.simpleMessage("BEP20"),
         "tagERC20": MessageLookupByLibrary.simpleMessage("ERC20"),
@@ -1183,21 +1195,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "txLimitExceeded":
             MessageLookupByLibrary.simpleMessage("请求过多。超出交易历史请求限制。请稍后重试"),
         "txNotConfirmed": MessageLookupByLibrary.simpleMessage("未确认"),
-        "txleft": m109,
+        "txleft": m112,
         "ukrainianLanguage": MessageLookupByLibrary.simpleMessage("乌克兰"),
         "unlock": MessageLookupByLibrary.simpleMessage("解锁"),
         "unlockFunds": MessageLookupByLibrary.simpleMessage("解锁基金"),
-        "unlockSuccess": m110,
+        "unlockSuccess": m113,
         "unspendable": MessageLookupByLibrary.simpleMessage("不可交易"),
         "updatesAvailable": MessageLookupByLibrary.simpleMessage("已有新版本"),
         "updatesChecking": MessageLookupByLibrary.simpleMessage("正在检查更新"),
-        "updatesCurrentVersion": m111,
+        "updatesCurrentVersion": m114,
         "updatesNotifAvailable":
             MessageLookupByLibrary.simpleMessage("已有新版本。请更新。"),
-        "updatesNotifAvailableVersion": m112,
+        "updatesNotifAvailableVersion": m115,
         "updatesNotifTitle": MessageLookupByLibrary.simpleMessage("可更新"),
         "updatesSkip": MessageLookupByLibrary.simpleMessage("暂时跳过"),
-        "updatesTitle": m113,
+        "updatesTitle": m116,
         "updatesUpToDate": MessageLookupByLibrary.simpleMessage("准备更新"),
         "updatesUpdate": MessageLookupByLibrary.simpleMessage("已更新"),
         "uriInsufficientBalanceSpan1":
@@ -1218,9 +1230,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "warningOkBtn": MessageLookupByLibrary.simpleMessage("好的"),
         "warningShareLogs": MessageLookupByLibrary.simpleMessage(
             "警告-在特殊情况下，此登录数据包含敏感信息，可用于消费交换失败的货币！"),
-        "weFailedTo": m114,
-        "weFailedToActivate": m115,
-        "welcomeInfo": m116,
+        "weFailedTo": m117,
+        "weFailedToActivate": m118,
+        "welcomeInfo": m119,
         "welcomeLetSetUp": MessageLookupByLibrary.simpleMessage("让我们开始吧"),
         "welcomeTitle": MessageLookupByLibrary.simpleMessage("欢迎"),
         "welcomeWallet": MessageLookupByLibrary.simpleMessage("钱包"),
@@ -1229,13 +1241,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "willTakeTime": MessageLookupByLibrary.simpleMessage(
             "这将需要一段时间，并且应用程序必须保持在前台。\n在激活过程中终止应用程序可能会导致问题。"),
         "withdraw": MessageLookupByLibrary.simpleMessage("提取"),
-        "withdrawCameraAccessText": m117,
+        "withdrawCameraAccessText": m120,
         "withdrawCameraAccessTitle":
             MessageLookupByLibrary.simpleMessage("被拒绝使用"),
         "withdrawConfirm": MessageLookupByLibrary.simpleMessage("确认提取"),
         "withdrawConfirmError":
             MessageLookupByLibrary.simpleMessage("出现错误。请稍后重试。"),
-        "withdrawValue": m118,
+        "withdrawValue": m121,
         "wrongCoinSpan1": MessageLookupByLibrary.simpleMessage("您正在尝试扫描付款二维码"),
         "wrongCoinSpan2": MessageLookupByLibrary.simpleMessage("但您在"),
         "wrongCoinSpan3": MessageLookupByLibrary.simpleMessage("提取页面"),
@@ -1249,7 +1261,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "you have an order that new orders can match with":
             MessageLookupByLibrary.simpleMessage("你有一个新订单可以匹配的订单"),
         "youAreSending": MessageLookupByLibrary.simpleMessage("您正在发送："),
-        "youWillReceiveClaim": m119,
+        "youWillReceiveClaim": m122,
         "youWillReceived": MessageLookupByLibrary.simpleMessage("您将收到："),
         "yourWallet": MessageLookupByLibrary.simpleMessage("您的钱包")
       };

--- a/lib/localizations.dart
+++ b/lib/localizations.dart
@@ -1891,7 +1891,7 @@ class AppLocalizations {
 
   // Rebranding
   String get rebrandingAnnouncement => Intl.message(
-      "It's a new era! We have officially changed our name from 'AtomicDEX' to 'Komodo Wallet'",
+      "It's a new era! We have officially rebranded from 'AtomicDEX' to 'Komodo Wallet'",
       name: 'rebrandingAnnouncement');
 
   String get officialPressRelease =>

--- a/lib/localizations.dart
+++ b/lib/localizations.dart
@@ -1323,6 +1323,7 @@ class AppLocalizations {
   String invalidCoinAddress(String coin) => Intl.message(
         'Invalid $coin address',
         args: [coin],
+        name: 'invalidCoinAddress',
       );
   String multiActivateGas(String coin) =>
       Intl.message('Activate $coin and top-up balance first',
@@ -1931,15 +1932,15 @@ class AppLocalizations {
   String get selectDate => Intl.message('Select a Date', name: 'selectDate');
   String get startDate => Intl.message('Start Date', name: 'startDate');
   String get futureTransactions => Intl.message(
-        'We will sync future transactions made after activation associated with your public key.',
+        'We will sync future transactions made after activation associated with your public key. This is the quickest option and takes up the least amount of storage.',
         name: 'futureTransactions',
       );
   String get allPastTransactions => Intl.message(
-        'Your wallet will show all past transactions associated with your public key. This will take significant storage and time as all blocks will be downloaded and scanned.',
+        'Your wallet will show any past transactions. This will take significant storage and time as all blocks will be downloaded and scanned.',
         name: 'allPastTransactions',
       );
   String get pastTransactionsFromDate => Intl.message(
-        'Your wallet will show all past transactions associated with your public key made after the specified date.',
+        'Your wallet will show your past transactions made after the specified date.',
         name: 'pastTransactionsFromDate',
       );
   // ---

--- a/lib/localizations.dart
+++ b/lib/localizations.dart
@@ -1266,6 +1266,13 @@ class AppLocalizations {
         name: 'weFailedToActivate',
         args: [coinAbbr],
       );
+
+  String failedToCancelActivation(String coinAbbr) => Intl.message(
+        'Failed to cancel activation of $coinAbbr',
+        name: 'failedToCancelActivation',
+        args: [coinAbbr],
+      );
+
   String isUnavailable(String coinAbbr) => Intl.message(
         '$coinAbbr is unavailable :(',
         name: 'isUnavailable',
@@ -1903,6 +1910,26 @@ class AppLocalizations {
         'Scan for past $coin transactions?',
         name: 'shouldScanPastTransaction',
         args: [coin],
+      );
+
+  String get activationCancelled =>
+      Intl.message('Coin activation cancelled', name: 'activationCancelled');
+
+  String coinActivationSuccessfull(String coin) => Intl.message(
+        'Successfully activated $coin',
+        name: 'coinActivationSuccessfull',
+        args: [coin],
+      );
+
+  String coinActivationCancelled(String coin) => Intl.message(
+        '$coin activation cancelled',
+        name: 'coinActivationCancelled',
+        args: [coin],
+      );
+
+  String get pleaseAcceptAllCoinActivationRequests => Intl.message(
+        'Please accept all special coin activation requests or deselect the coins.',
+        name: 'pleaseAcceptAllCoinActivationRequests',
       );
 
   String get cancelActivation =>

--- a/lib/localizations.dart
+++ b/lib/localizations.dart
@@ -1320,6 +1320,10 @@ class AppLocalizations {
       Intl.message('Min sell amount is', name: 'multiMinSellAmt');
   String get multiInvalidAmt =>
       Intl.message('Invalid amount', name: 'multiInvalidAmt');
+  String invalidCoinAddress(String coin) => Intl.message(
+        'Invalid $coin address',
+        args: [coin],
+      );
   String multiActivateGas(String coin) =>
       Intl.message('Activate $coin and top-up balance first',
           name: 'multiActivateGas', args: <Object>[coin]);
@@ -1892,6 +1896,54 @@ class AppLocalizations {
 
   String get officialPressRelease =>
       Intl.message('Official press release', name: 'officialPressRelease');
+
+// --- Asyncronous coin activations (requires syncing)
+  String shouldScanPastTransaction(String coin) => Intl.message(
+        'Scan for past $coin transactions?',
+        name: 'shouldScanPastTransaction',
+        args: [coin],
+      );
+
+  String get cancelActivation =>
+      Intl.message('Cancel Activation', name: 'cancelActivation');
+  String get cancelActivationQuestion => Intl.message(
+        'Are you sure you want to cancel activation?',
+        name: 'cancelActivationQuestion',
+      );
+  String get cofirmCancelActivation => Intl.message(
+        'Are you sure you want to cancel activation?',
+        name: 'cofirmCancelActivation',
+      );
+
+  String syncTransactionsQuestion(String name) => Intl.message(
+        'Which $name transactions would you like to sync?',
+        name: 'syncTransactionsQuestion',
+        args: [name],
+      );
+  String get syncNewTransactions =>
+      Intl.message('Sync new transactions', name: 'syncNewTransactions');
+  String get syncFromDate =>
+      Intl.message('Sync from specified date', name: 'syncFromDate');
+  String get syncFromSaplingActivation => Intl.message(
+        'Sync from sapling activation',
+        name: 'syncFromSaplingActivation',
+      );
+  String get selectDate => Intl.message('Select a Date', name: 'selectDate');
+  String get startDate => Intl.message('Start Date', name: 'startDate');
+  String get futureTransactions => Intl.message(
+        'We will sync future transactions made after activation associated with your public key.',
+        name: 'futureTransactions',
+      );
+  String get allPastTransactions => Intl.message(
+        'Your wallet will show all past transactions associated with your public key. This will take significant storage and time as all blocks will be downloaded and scanned.',
+        name: 'allPastTransactions',
+      );
+  String get pastTransactionsFromDate => Intl.message(
+        'Your wallet will show all past transactions associated with your public key made after the specified date.',
+        name: 'pastTransactionsFromDate',
+      );
+  // ---
+
 }
 
 class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_api.dart
@@ -228,7 +228,6 @@ class ZCoinActivationApi {
 
       if (shouldEmitStatus) {
         lastEmittedStatus = taskStatus;
-        // yield taskStatus;
         yield taskStatus;
       }
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -10,8 +10,8 @@ import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_sta
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_notifications.dart';
 import 'package:komodo_dex/packages/z_coin_activation/models/z_coin_activation_prefs.dart';
 import 'package:komodo_dex/packages/z_coin_activation/models/z_coin_status.dart';
+import 'package:komodo_dex/utils/log.dart';
 
-// TODO: Localize messages
 class ZCoinActivationBloc
     extends Bloc<ZCoinActivationEvent, ZCoinActivationState>
     with ActivationEta {
@@ -56,7 +56,7 @@ class ZCoinActivationBloc
         onData: (coinStatus) {
           if (coinStatus.isFailed) {
             return ZCoinActivationFailure(
-              'Failed to activate ZHTLC coins, please try again later',
+              ZCoinActivationFailureReason.failedAfterStart,
             );
           }
 
@@ -91,7 +91,7 @@ class ZCoinActivationBloc
             );
           }
           if (coinStatus.isActivated) {
-            return ZCoinActivationSuccess('Completed ZHTLC activation');
+            return ZCoinActivationSuccess();
           }
           return ZCoinActivationInProgess(
             progress: shouldShowNewProgress ? overallProgress : lastProgress,
@@ -101,8 +101,13 @@ class ZCoinActivationBloc
           );
         },
         onError: (e, s) {
-          debugPrint('Failed to activate coins: $e');
-          return ZCoinActivationFailure('Failed to activate coins');
+          Log(
+            'ZCoinActivationBloc:_handleActivationRequested',
+            'Failed to activate coins: $e',
+          );
+          return ZCoinActivationFailure(
+            ZCoinActivationFailureReason.failedAfterStart,
+          );
         },
       );
 
@@ -113,12 +118,14 @@ class ZCoinActivationBloc
         // And this emit might remove another important notification
         // emit(ZCoinActivationSuccess('ZHTLC coins activation process ended'));
       } else {
-        emit(ZCoinActivationFailure('Failed to activate coins'));
+        emit(
+          ZCoinActivationFailure(ZCoinActivationFailureReason.failedAfterStart),
+        );
       }
     } catch (e) {
       debugPrint('Failed to start activation: $e');
       emit(
-        ZCoinActivationFailure('Failed to start activation'),
+        ZCoinActivationFailure(ZCoinActivationFailureReason.startFailed),
       );
     } finally {
       await _clearNotification();
@@ -135,7 +142,7 @@ class ZCoinActivationBloc
     } catch (e) {
       debugPrint('Failed to set requested coins: $e');
       emit(
-        ZCoinActivationFailure('Failed to set requested coins'),
+        ZCoinActivationFailure(ZCoinActivationFailureReason.startFailed),
       );
     }
   }
@@ -158,7 +165,7 @@ class ZCoinActivationBloc
       ZCoinActivationState newState;
       if (isAllCoinsEnabled) {
         newState = isActivationInProgress
-            ? ZCoinActivationSuccess('Activation in progress...')
+            ? ZCoinActivationSuccess()
             : ZCoinActivationKnownState(isAllCoinsEnabled);
       } else if (isActivationInProgress) {
         newState = state as ZCoinActivationInProgess;
@@ -174,7 +181,7 @@ class ZCoinActivationBloc
     } catch (e) {
       debugPrint('Failed to get activation status: $e');
       emit(
-        ZCoinActivationFailure('Failed to get activation status'),
+        ZCoinActivationFailure(ZCoinActivationFailureReason.failedAfterStart),
       );
     }
   }
@@ -185,11 +192,11 @@ class ZCoinActivationBloc
   ) async {
     try {
       await _repository.cancelAllZCoinActivations();
-      emit(ZCoinActivationFailure('Cancelling ZHTLC activation...'));
+      emit(ZCoinActivationFailure(ZCoinActivationFailureReason.cancelled));
     } catch (e) {
       debugPrint('Failed to cancel ZHTLC activation: $e');
       emit(
-        ZCoinActivationFailure('Failed to cancel ZHTLC activation'),
+        ZCoinActivationFailure(ZCoinActivationFailureReason.failedToCancel),
       );
     }
   }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
@@ -34,15 +34,21 @@ class ZCoinActivationInProgess extends ZCoinActivationState {
 }
 
 class ZCoinActivationSuccess extends ZCoinActivationState {
-  ZCoinActivationSuccess(this.message);
-
-  final String message;
+  ZCoinActivationSuccess();
 }
 
 class ZCoinActivationFailure extends ZCoinActivationState {
-  const ZCoinActivationFailure(this.message);
+  const ZCoinActivationFailure(this.reason);
 
-  final String message;
+  final ZCoinActivationFailureReason reason;
+}
+
+enum ZCoinActivationFailureReason {
+  startFailed,
+  cancelled,
+  failedToCancel,
+  failedAfterStart,
+  failedOther,
 }
 
 class ZCoinActivationStatusLoading extends ZCoinActivationState {}

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -34,6 +34,8 @@ class ZCoinStatusWidget extends StatefulWidget {
 class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
   static bool get canNotify => ZCoinProgressNotifications.canNotify;
 
+  AppLocalizations get localisations => AppLocalizations.of(context);
+
   @override
   initState() {
     super.initState();
@@ -52,6 +54,8 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final protocolTag = localisations.tagZHTLC;
+
     return BlocBuilder<ZCoinActivationBloc, ZCoinActivationState>(
       builder: (context, state) {
         bool isActivationInProgress = state is ZCoinActivationInProgess;
@@ -60,9 +64,8 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
           final progressState = state as ZCoinActivationInProgess;
           return ListTile(
             onTap: () => _showInProgressDialog(context),
-            title: Text(AppLocalizations.of(context).activating('ZHTLC')),
-            subtitle: Text(
-                AppLocalizations.of(context).doNotCloseTheAppTapForMoreInfo),
+            title: Text(localisations.activating(protocolTag)),
+            subtitle: Text(localisations.doNotCloseTheAppTapForMoreInfo),
             leading: Icon(
               Icons.warning,
               color: Colors.red,
@@ -80,7 +83,7 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
         final bool isStatusLoading = state is ZCoinActivationStatusLoading;
 
         return ListTile(
-          title: Text(AppLocalizations.of(context).activation('ZCoin (ZHTLC)')),
+          title: Text(localisations.activation('PIRATE ($protocolTag)')),
           tileColor: Theme.of(context).primaryColor,
           leading: isStatusLoading
               ? CircularProgressIndicator()
@@ -95,10 +98,8 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
               : state is ZCoinActivationStatusChecked
                   ? Text(
                       state.isActivated
-                          ? AppLocalizations.of(context)
-                              .coinsAreActivated('ZHTLC')
-                          : AppLocalizations.of(context)
-                              .coinsAreNotActivated('ZHTLC'),
+                          ? localisations.coinsAreActivated(protocolTag)
+                          : localisations.coinsAreNotActivated(protocolTag),
                     )
                   : null,
           selected: false,
@@ -120,7 +121,9 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
     final scaffold = ScaffoldMessenger.maybeOf(context);
     if (scaffold == null) return;
 
-    final l10n = AppLocalizations.of(context);
+    final localisations = AppLocalizations.of(context);
+
+    final protocolTag = localisations.tagZHTLC;
 
     final theme = Theme.of(context);
 
@@ -142,7 +145,7 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
             TextButton(
               onPressed: () => scaffold.hideCurrentMaterialBanner(),
               child: Text(
-                l10n.okButton,
+                localisations.okButton,
                 style: TextStyle().copyWith(color: theme.colorScheme.onError),
               ),
             ),
@@ -159,12 +162,12 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
             Icons.check_circle,
             color: theme.colorScheme.secondary,
           ),
-          content: Text(AppLocalizations.of(context)
-              .coinsAreActivatedSuccessfully('ZHTLC')),
+          content:
+              Text(localisations.coinsAreActivatedSuccessfully(protocolTag)),
           actions: [
             TextButton(
               onPressed: () => scaffold.hideCurrentMaterialBanner(),
-              child: Text(l10n.okButton),
+              child: Text(localisations.okButton),
             ),
           ],
         ),
@@ -179,8 +182,7 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
               elevation: 1,
               content: Row(
                 children: [
-                  Text(AppLocalizations.of(context)
-                      .activationInProgress('ZHTLC')),
+                  Text(localisations.activationInProgress(protocolTag)),
                   SizedBox(width: 8),
                   SizedBox.square(
                     dimension: 24,
@@ -199,11 +201,11 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
               actions: [
                 TextButton(
                   onPressed: () => scaffold.hideCurrentMaterialBanner(),
-                  child: Text(l10n.okButton),
+                  child: Text(localisations.okButton),
                 ),
                 TextButton(
                   onPressed: () => _showInProgressDialog(context),
-                  child: Text(AppLocalizations.of(context).moreInfo),
+                  child: Text(localisations.moreInfo),
                 ),
               ],
             ),
@@ -223,11 +225,11 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
 }
 
 Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
-  final appL10n = AppLocalizations.of(context);
-
   SyncType _syncType = SyncType.newTransactions;
   DateTime _lastDate = DateTime.now().subtract(Duration(days: 1));
   DateTime _selectedDate = _lastDate;
+
+  final localisations = AppLocalizations.of(context);
 
   return showDialog<Map<String, dynamic>>(
     context: context,
@@ -236,7 +238,9 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
       return StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
           return AlertDialog(
-            title: Text('Scan for past Z-Coin (ZHTLC) transactions?'),
+            title: Text(
+              localisations.syncTransactionsQuestion(localisations.tagZHTLC),
+            ),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10),
               side: BorderSide(
@@ -246,12 +250,8 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
             content: SingleChildScrollView(
               child: ListBody(
                 children: [
-                  Text(
-                    'You have selected to activate a ZHTLC asset. Which transactions would you like to sync?',
-                  ),
-                  // Radio list tiles
                   RadioListTile<SyncType>(
-                    title: const Text('Sync new transactions'),
+                    title: Text(localisations.syncNewTransactions),
                     value: SyncType.newTransactions,
                     groupValue: _syncType,
                     onChanged: (SyncType value) {
@@ -261,7 +261,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                     },
                   ),
                   RadioListTile<SyncType>(
-                    title: const Text('Sync from specified date'),
+                    title: Text(localisations.syncFromDate),
                     value: SyncType.specifiedDate,
                     groupValue: _syncType,
                     onChanged: (SyncType value) {
@@ -271,7 +271,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                     },
                   ),
                   RadioListTile<SyncType>(
-                    title: const Text('Sync from sapling activation'),
+                    title: Text(localisations.syncFromSaplingActivation),
                     value: SyncType.fullSync,
                     groupValue: _syncType,
                     onChanged: (SyncType value) {
@@ -299,11 +299,11 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                                     _selectedDate = pickedDate;
                                   });
                               },
-                              child: Text('Select Date'),
+                              child: Text(localisations.selectDate),
                             ),
                             // Display the selected date
                             Text(
-                              "Start Date: ${DateFormat('yyyy-MM-dd').format(_selectedDate)}",
+                              "${localisations.startDate}: ${DateFormat('yyyy-MM-dd').format(_selectedDate)}",
                             ),
                           ],
                         )
@@ -313,15 +313,15 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                   // Sync Type Description
                   if (_syncType == SyncType.newTransactions)
                     Text(
-                      'Your wallet will show future transactions made after activation associated with your public key.',
+                      localisations.futureTransactions,
                     ),
                   if (_syncType == SyncType.fullSync)
                     Text(
-                      'Your wallet will show all past transactions associated with your public key. This will take significant storage and time as all blocks will be downloaded and scanned.',
+                      localisations.allPastTransactions,
                     ),
                   if (_syncType == SyncType.specifiedDate)
                     Text(
-                      'Your wallet will show all past transactions associated with your public key made after the specified date.',
+                      localisations.pastTransactionsFromDate,
                     ),
 
                   if (Platform.isIOS) ...[
@@ -333,7 +333,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       ),
                       dense: true,
                       title: Text(
-                        AppLocalizations.of(context).minimizingWillTerminate,
+                        localisations.minimizingWillTerminate,
                         style: TextStyle(color: Colors.amber),
                       ),
                     )
@@ -362,9 +362,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                                 ),
                                 SizedBox(width: 8),
                                 Expanded(
-                                  child: Text(
-                                    AppLocalizations.of(context).willTakeTime,
-                                  ),
+                                  child: Text(localisations.willTakeTime),
                                 ),
                               ],
                             ),
@@ -379,7 +377,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
               TextButton(
                 onPressed: () =>
                     Navigator.pop<Map<String, dynamic>>(context, null),
-                child: Text(appL10n.cancelButton),
+                child: Text(localisations.cancelButton),
               ),
               TextButton(
                 onPressed: () => Navigator.pop<Map<String, dynamic>>(
@@ -389,7 +387,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                     'zhtlcSyncStartDate': _selectedDate
                   },
                 ),
-                child: Text(appL10n.confirm),
+                child: Text(localisations.confirm),
               ),
             ],
           );
@@ -413,33 +411,33 @@ void _showInProgressDialog(BuildContext context) {
         return Container();
       }
 
-      final appL10n = AppLocalizations.of(context);
+      final localisations = AppLocalizations.of(context);
 
       final etaString = state?.eta?.inMinutes == null
-          ? appL10n.loading
-          : '${state.eta.inMinutes}${appL10n.minutes}';
+          ? localisations.loading
+          : '${state.eta.inMinutes}${localisations.minutes}';
       return AlertDialog(
         title: Text(
-            '${appL10n.warning}: ${AppLocalizations.of(context).activationInProgress('ZHTLC')}'),
+          '${localisations.warning}: ${localisations.activationInProgress(localisations.tagZHTLC)}',
+        ),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             if (!ZCoinProgressNotifications.canNotify) ...[
               Text(
-                AppLocalizations.of(context)
-                    .enableNotificationsForActivationProgress,
+                localisations.enableNotificationsForActivationProgress,
                 style: TextStyle(color: Colors.amber),
               ),
               SizedBox(height: 16),
             ],
-            Text(AppLocalizations.of(context).willTakeTime),
+            Text(localisations.willTakeTime),
             SizedBox(height: 16),
             Text(
-              '${appL10n.rewardsTableTime}: $etaString',
+              '${localisations.rewardsTableTime}: $etaString',
             ),
             SizedBox(height: 16),
             Text(
-              '${appL10n.swapProgress}: ${(state.progress * 100).round()}%',
+              '${localisations.swapProgress}: ${(state.progress * 100).round()}%',
             ),
             SizedBox(height: 4),
             LinearProgressIndicator(
@@ -452,22 +450,21 @@ void _showInProgressDialog(BuildContext context) {
             onPressed: () {
               showConfirmationDialog(
                 context: context,
-                title: 'Stop Activation',
-                message:
-                    'Are you sure you want to stop the activation process?',
+                title: localisations.cancelActivationQuestion,
+                message: localisations.cofirmCancelActivation,
                 onConfirm: () {
                   context
                       .read<ZCoinActivationBloc>()
                       .add(ZCoinActivationCancelRequested());
                 },
-                confirmButtonText: 'Stop',
+                confirmButtonText: localisations.cancelActivation,
               );
             },
-            child: Text('Stop'),
+            child: Text(localisations.cancelActivation),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: Text(appL10n.close),
+            child: Text(localisations.close),
           ),
         ],
         shape: RoundedRectangleBorder(

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -192,9 +192,7 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
                   ),
                   if (state.progress != null && state.progress > 0) ...[
                     SizedBox(width: 8),
-                    Text(
-                      '${(state.progress * 100).round()}%',
-                    ),
+                    Text('${(state.progress * 100).round()}%'),
                   ]
                 ],
               ),
@@ -303,7 +301,8 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                             ),
                             // Display the selected date
                             Text(
-                              "${localisations.startDate}: ${DateFormat('yyyy-MM-dd').format(_selectedDate)}",
+                              '${localisations.startDate}: '
+                              "${DateFormat('yyyy-MM-dd').format(_selectedDate)}",
                             ),
                           ],
                         )
@@ -312,17 +311,13 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                   SizedBox(height: 16),
                   // Sync Type Description
                   if (_syncType == SyncType.newTransactions)
-                    Text(
-                      localisations.futureTransactions,
-                    ),
+                    Text(localisations.futureTransactions),
+
                   if (_syncType == SyncType.fullSync)
-                    Text(
-                      localisations.allPastTransactions,
-                    ),
+                    Text(localisations.allPastTransactions),
+
                   if (_syncType == SyncType.specifiedDate)
-                    Text(
-                      localisations.pastTransactionsFromDate,
-                    ),
+                    Text(localisations.pastTransactionsFromDate),
 
                   if (Platform.isIOS) ...[
                     SizedBox(height: 16),
@@ -334,7 +329,9 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       dense: true,
                       title: Text(
                         localisations.minimizingWillTerminate,
-                        style: TextStyle(color: Colors.amber),
+                        style: DefaultTextStyle.of(context)
+                            .style
+                            .apply(color: Colors.amber),
                       ),
                     )
                   ],
@@ -418,7 +415,8 @@ void _showInProgressDialog(BuildContext context) {
           : '${state.eta.inMinutes}${localisations.minutes}';
       return AlertDialog(
         title: Text(
-          '${localisations.warning}: ${localisations.activationInProgress(localisations.tagZHTLC)}',
+          '${localisations.warning}: '
+          '${localisations.activationInProgress(localisations.tagZHTLC)}',
         ),
         content: Column(
           mainAxisSize: MainAxisSize.min,
@@ -432,17 +430,13 @@ void _showInProgressDialog(BuildContext context) {
             ],
             Text(localisations.willTakeTime),
             SizedBox(height: 16),
-            Text(
-              '${localisations.rewardsTableTime}: $etaString',
-            ),
+            Text('${localisations.rewardsTableTime}: $etaString'),
             SizedBox(height: 16),
             Text(
               '${localisations.swapProgress}: ${(state.progress * 100).round()}%',
             ),
             SizedBox(height: 4),
-            LinearProgressIndicator(
-              value: state.progress,
-            ),
+            LinearProgressIndicator(value: state.progress),
           ],
         ),
         actions: [

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -135,7 +135,9 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
       updateNotice = scaffold.showMaterialBanner(
         MaterialBanner(
           elevation: 1,
-          content: Text(state.message),
+          content: Text(
+            localiseFailedReason(localisations, state.reason),
+          ),
           leading: Icon(
             Icons.error,
             color: Colors.red,
@@ -219,6 +221,28 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
         }
       },
     );
+  }
+
+  static String localiseFailedReason(
+    AppLocalizations localisations,
+    ZCoinActivationFailureReason reason,
+  ) {
+    final tag = localisations.tagZHTLC;
+    switch (reason) {
+      case ZCoinActivationFailureReason.startFailed:
+      case ZCoinActivationFailureReason.failedAfterStart:
+      case ZCoinActivationFailureReason.failedOther:
+        return localisations.weFailedTo(tag);
+
+      case ZCoinActivationFailureReason.failedToCancel:
+        return localisations.failedToCancelActivation(tag);
+
+      case ZCoinActivationFailureReason.cancelled:
+        return localisations.coinActivationCancelled(tag);
+
+      default:
+        return localisations.weFailedTo(tag);
+    }
   }
 }
 

--- a/lib/screens/portfolio/activate/select_coins_page.dart
+++ b/lib/screens/portfolio/activate/select_coins_page.dart
@@ -329,6 +329,8 @@ class _SelectCoinsPageState extends State<SelectCoinsPage> {
   }
 
   void _pressDoneButton() async {
+    final localisations = AppLocalizations.of(context);
+
     final numCoinsEnabled = coinsBloc.coinBalance.length;
     final numCoinsTryingEnable =
         coinsBloc.coinBeforeActivation.where((c) => c.isActive).toList().length;
@@ -341,23 +343,22 @@ class _SelectCoinsPageState extends State<SelectCoinsPage> {
         context: context,
         builder: (BuildContext context) {
           return CustomSimpleDialog(
-            title:
-                Text(AppLocalizations.of(context).enablingTooManyAssetsTitle),
+            title: Text(localisations.enablingTooManyAssetsTitle),
             children: [
-              Text(AppLocalizations.of(context).enablingTooManyAssetsSpan1 +
+              Text(localisations.enablingTooManyAssetsSpan1 +
                   numCoinsEnabled.toString() +
-                  AppLocalizations.of(context).enablingTooManyAssetsSpan2 +
+                  localisations.enablingTooManyAssetsSpan2 +
                   numCoinsTryingEnable.toString() +
-                  AppLocalizations.of(context).enablingTooManyAssetsSpan3 +
+                  localisations.enablingTooManyAssetsSpan3 +
                   maxCoinPerPlatform.toString() +
-                  AppLocalizations.of(context).enablingTooManyAssetsSpan4),
+                  localisations.enablingTooManyAssetsSpan4),
               SizedBox(height: 12),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   ElevatedButton(
                     onPressed: () => dialogBloc.closeDialog(context),
-                    child: Text(AppLocalizations.of(context).warningOkBtn),
+                    child: Text(localisations.warningOkBtn),
                   ),
                 ],
               ),
@@ -373,9 +374,8 @@ class _SelectCoinsPageState extends State<SelectCoinsPage> {
         ScaffoldMessenger.maybeOf(context)?.showSnackBar(
           SnackBar(
             content: Text(
-              // AppLocalizations.of(context).zCoinActivationNotAcceptedTitle,
-              'Coin Activation Cancelled\n'
-              'Please accept all activation requests to continue or deselect coins to activate.',
+              '${localisations.activationCancelled}\n'
+              '${localisations.pleaseAcceptAllCoinActivationRequests}',
             ),
             duration: const Duration(seconds: 2),
           ),

--- a/lib/screens/portfolio/coin_detail/coin_detail.dart
+++ b/lib/screens/portfolio/coin_detail/coin_detail.dart
@@ -434,7 +434,7 @@ class _CoinDetailState extends State<CoinDetail> {
                   padding: const EdgeInsets.all(16.0),
                   child: Center(
                       child: Text(
-                    snapshot.data.error.message,
+                    (snapshot.data as ErrorCode).error.message,
                     style: Theme.of(context).textTheme.bodyText1,
                     textAlign: TextAlign.center,
                   )),

--- a/lib/screens/portfolio/coin_detail/steps_withdraw.dart/amount_address_step/address_field.dart
+++ b/lib/screens/portfolio/coin_detail/steps_withdraw.dart/amount_address_step/address_field.dart
@@ -76,6 +76,8 @@ class _AddressFieldState extends State<AddressField> {
 
   @override
   Widget build(BuildContext context) {
+    final localisations = AppLocalizations.of(context);
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 16),
       child: Column(
@@ -135,7 +137,7 @@ class _AddressFieldState extends State<AddressField> {
                       return AppLocalizations.of(context).errorValueNotEmpty;
                     }
                     if (!mm2Validated) {
-                      return 'Invalid ${widget.coin.abbr} address';
+                      return localisations.invalidCoinAddress(widget.coin.abbr);
                     }
 
                     return null;


### PR DESCRIPTION
Changelog:
- Localise the messages used for the ZHTLC activation feature.

What to test:
- Check all UI text elements associated with ZHTLC coins in the main language (English) and, preferably, also a secondary language you understand. 