### PR TITLE
Fix ARRR/ZHTLC Send Max not working

### DIFF
--- a/lib/model/get_withdraw.dart
+++ b/lib/model/get_withdraw.dart
@@ -39,6 +39,7 @@ class GetWithdraw {
             'params': {
               'coin': coin ?? '',
               'to': to ?? '',
+              'max': max ?? false,
               if (amount != null) 'amount': amount,
             }
           }


### PR DESCRIPTION
Somehow the `max` field was missing at the ZHTLC-specific withdraw function. Adding that fixes the issue where the `max` field is not set and the fee is not being calculated automatically.