### PR TITLE
ZHTLC Hide Cancel button for Resyncing Progress

### DIFF
--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -26,6 +26,14 @@ class ZCoinActivationBloc
     ZCoinActivationApi(),
   );
 
+  Future<bool> isResyncing() async {
+    final enabledCoinsCount = (await _repository.getEnabledZCoins()).length;
+    final coinsToActivateCount =
+        (await _repository.getRequestedActivatedCoins()).length;
+
+    return enabledCoinsCount == coinsToActivateCount;
+  }
+
   Future<void> _handleActivationRequested(
     ZCoinActivationRequested event,
     Emitter<ZCoinActivationState> emit,

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -27,13 +27,12 @@ class ZCoinActivationBloc
   );
 
   Future<bool> isResyncing() async {
-    final List<String> enabledCoins = (await _repository.getEnabledZCoins())
+    final enabledCoins = (await _repository.getEnabledZCoins())
         .map((coin) => coin.toLowerCase())
         .toList();
-    final List<String> coinsToActivate =
-        (await _repository.getRequestedActivatedCoins())
-            .map((coin) => coin.toLowerCase())
-            .toList();
+    final coinsToActivate = (await _repository.getRequestedActivatedCoins())
+        .map((coin) => coin.toLowerCase())
+        .toList();
 
     return coinsToActivate.every((coin) => enabledCoins.contains(coin));
   }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -27,11 +27,15 @@ class ZCoinActivationBloc
   );
 
   Future<bool> isResyncing() async {
-    final enabledCoinsCount = (await _repository.getEnabledZCoins()).length;
-    final coinsToActivateCount =
-        (await _repository.getRequestedActivatedCoins()).length;
+    final List<String> enabledCoins = (await _repository.getEnabledZCoins())
+        .map((coin) => coin.toLowerCase())
+        .toList();
+    final List<String> coinsToActivate =
+        (await _repository.getRequestedActivatedCoins())
+            .map((coin) => coin.toLowerCase())
+            .toList();
 
-    return enabledCoinsCount == coinsToActivateCount;
+    return coinsToActivate.every((coin) => enabledCoins.contains(coin));
   }
 
   Future<void> _handleActivationRequested(

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -418,7 +418,9 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
   );
 }
 
-void _showInProgressDialog(BuildContext context) {
+Future<void> _showInProgressDialog(BuildContext context) async {
+  final isResyncing = await context.read<ZCoinActivationBloc>().isResyncing();
+
   showDialog<void>(
     context: context,
     builder: (context) {
@@ -464,22 +466,23 @@ void _showInProgressDialog(BuildContext context) {
           ],
         ),
         actions: [
-          TextButton(
-            onPressed: () {
-              showConfirmationDialog(
-                context: context,
-                title: localisations.cancelActivationQuestion,
-                message: localisations.cofirmCancelActivation,
-                onConfirm: () {
-                  context
-                      .read<ZCoinActivationBloc>()
-                      .add(ZCoinActivationCancelRequested());
-                },
-                confirmButtonText: localisations.cancelActivation,
-              );
-            },
-            child: Text(localisations.cancelActivation),
-          ),
+          if (!isResyncing)
+            TextButton(
+              onPressed: () {
+                showConfirmationDialog(
+                  context: context,
+                  title: localisations.cancelActivationQuestion,
+                  message: localisations.cofirmCancelActivation,
+                  onConfirm: () {
+                    context
+                        .read<ZCoinActivationBloc>()
+                        .add(ZCoinActivationCancelRequested());
+                  },
+                  confirmButtonText: localisations.cancelActivation,
+                );
+              },
+              child: Text(localisations.cancelActivation),
+            ),
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: Text(localisations.close),


### PR DESCRIPTION
Currently, the resyncing is cancellable on the progress pop-up. 

With these changes, we show the cancel/stop button only if `all the coins to activate` exist in the `enabled coins list`.