### PR TITLE
Bug - Fix iOS ARRR Broken After App Resume

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,11 +26,6 @@
 		<string>ko</string>
 		<string>uk</string>
 	</array>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UISceneConfigurations</key>
-		<dict/>
-	</dict>
 	<key>CFBundleName</key>
 	<string>komodo_dex</string>
 	<key>CFBundlePackageType</key>
@@ -78,6 +73,11 @@
 	<string>Location services are not required by this application, please contact the app provider if you see this message.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photo Library general access is required for backup functionality.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../model/feed_provider.dart';
@@ -17,6 +19,28 @@ class AppConfig {
 
   int get batteryLevelLow => 30; // show warnign on swap confirmation page
   int get batteryLevelCritical => 20; // swaps disabled
+
+  final String minDartVersion = '2.14.0';
+
+  bool get isDartSdkVersionSupported {
+    final currentVersion = RegExp(r'(\d+\.\d+\.\d+)')
+        .firstMatch(Platform.version)
+        ?.group(1)
+        ?.split('.')
+        ?.map((e) => int.parse(e))
+        ?.toList();
+
+    final minVersion =
+        minDartVersion.split('.').map((e) => int.parse(e)).toList();
+
+    if (currentVersion == null) return false;
+
+    for (var i = 0; i < minVersion.length; i++) {
+      if (currentVersion[i] < minVersion[i]) return false;
+    }
+
+    return true;
+  }
 
   // Brand config below
 

--- a/lib/blocs/coins_bloc.dart
+++ b/lib/blocs/coins_bloc.dart
@@ -461,7 +461,7 @@ class CoinsBloc implements BlocBase {
 
   /// Handle the coins user has picked for activation.
   /// Also used for coin activations during the application startup.
-  Future<void> enableCoins(List<Coin> coins) async {
+  Future<void> enableCoins(List<Coin> coins, {initialization = false}) async {
     await pauseUntil(() => !_coinsLock, maxMs: 3000);
     _coinsLock = true;
 
@@ -482,6 +482,9 @@ class CoinsBloc implements BlocBase {
         .where((c) => c.type == CoinType.zhtlc)
         .map((c) => c.abbr)
         .toList();
+
+    // Allow for resyncing of existing coins at app launch or resuming
+    _zCoinRepository.willInitialize = initialization;
 
     await _zCoinRepository.addRequestedActivatedCoins(requestedZCoins);
 

--- a/lib/blocs/coins_bloc.dart
+++ b/lib/blocs/coins_bloc.dart
@@ -72,6 +72,9 @@ class CoinsBloc implements BlocBase {
 
   dynamic transactions;
 
+  Transactions get transactionsOrNull =>
+      transactions is Transactions ? transactions : null;
+
   // Streams to handle the list coin
   final StreamController<dynamic> _transactionsController =
       StreamController<dynamic>.broadcast();
@@ -406,18 +409,16 @@ class CoinsBloc implements BlocBase {
       if (transactions is Transactions) {
         transactions.camouflageIfNeeded();
 
-        if (fromId == null || fromId.isEmpty) {
+        if (fromId?.isEmpty ?? true) {
           this.transactions = transactions;
         } else {
           this.transactions.result.fromId = transactions.result.fromId;
           this.transactions.result.limit = transactions.result.limit;
           this.transactions.result.skipped = transactions.result.skipped;
           this.transactions.result.total = transactions.result.total;
-          this
-              .transactions
-              .result
-              .transactions
-              .addAll(transactions.result.transactions);
+          this.transactions.result.transactions
+            ..addAll(transactions.result.transactions)
+            ..sort((a, b) => b.time.compareTo(a.time));
         }
         _inTransactions.add(this.transactions);
       } else if (transactions is ErrorCode) {

--- a/lib/blocs/coins_bloc.dart
+++ b/lib/blocs/coins_bloc.dart
@@ -483,9 +483,6 @@ class CoinsBloc implements BlocBase {
         .map((c) => c.abbr)
         .toList();
 
-    // Allow for resyncing of existing coins at app launch or resuming
-    _zCoinRepository.willInitialize = initialization;
-
     await _zCoinRepository.addRequestedActivatedCoins(requestedZCoins);
 
     // await _zCoinRepository.setRequestedActivatedCoins(requestedZCoins);
@@ -827,7 +824,7 @@ class CoinsBloc implements BlocBase {
 
       if (transactions is Transactions) {
         transactions.camouflageIfNeeded();
-        if (transactions.result.transactions.isNotEmpty) {
+        if ((transactions.result?.transactions ?? []).isNotEmpty) {
           return transactions.result.transactions[0];
         }
         return null;

--- a/lib/blocs/coins_bloc.dart
+++ b/lib/blocs/coins_bloc.dart
@@ -570,9 +570,6 @@ class CoinsBloc implements BlocBase {
 
     updateOneCoin(cb);
 
-    final isZCash = coin.type == CoinType.zhtlc;
-
-    // await syncCoinsStateWithApi(!isZCash);
     await syncCoinsStateWithApi();
 
     if (currentActiveCoin?.coin?.abbr == coin.abbr) {

--- a/lib/blocs/coins_bloc.dart
+++ b/lib/blocs/coins_bloc.dart
@@ -314,6 +314,10 @@ class CoinsBloc implements BlocBase {
           .removeWhere((CoinBalance item) => coin.abbr == item.coin.abbr);
       updateCoins(coinBalance);
       await deactivateCoins(<Coin>[coin]);
+
+      if (coin.type == CoinType.zhtlc) {
+        await _zCoinRepository.legacyCoinsBlocDisableLocallyCallback(coin.abbr);
+      }
     }
   }
 

--- a/lib/localizations.dart
+++ b/lib/localizations.dart
@@ -1934,13 +1934,10 @@ class AppLocalizations {
 
   String get cancelActivation =>
       Intl.message('Cancel Activation', name: 'cancelActivation');
+
   String get cancelActivationQuestion => Intl.message(
         'Are you sure you want to cancel activation?',
         name: 'cancelActivationQuestion',
-      );
-  String get cofirmCancelActivation => Intl.message(
-        'Are you sure you want to cancel activation?',
-        name: 'cofirmCancelActivation',
       );
 
   String syncTransactionsQuestion(String name) => Intl.message(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -223,7 +223,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   void _requestResync() {
     context
         .read<ZCoinActivationBloc>()
-        .add(ZCoinActivationRequested(resync: true));
+        .add(ZCoinActivationRequested(isResync: true));
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,12 @@ import 'widgets/shared_preferences_builder.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  // Ensure the Dart version is >= 2.14.0
+  assert(appConfig.isDartSdkVersionSupported, '''
+    Your Dart SDK version is not supported. 
+    Please update your Dart SDK to >= ${appConfig.minDartVersion}.
+  ''');
+
   await applicationDocumentsDirectory;
   await Log.init();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,20 @@
 import 'dart:async';
+
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_bloc/flutter_bloc.dart' as real_bloc;
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_event.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_state.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_notifications.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
 import 'package:komodo_dex/services/mm.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import '../app_config/app_config.dart';
 import '../blocs/authenticate_bloc.dart';
 import '../blocs/coins_bloc.dart';
@@ -39,14 +44,10 @@ import '../services/mm_service.dart';
 import '../utils/log.dart';
 import '../widgets/bloc_provider.dart';
 import '../widgets/build_red_dot.dart';
-import 'package:local_auth/local_auth.dart';
-import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-
 import 'app_config/theme_data.dart';
 import 'model/multi_order_provider.dart';
-import 'packages/rebranding/rebranding_provider.dart';
 import 'model/startup_provider.dart';
+import 'packages/rebranding/rebranding_provider.dart';
 import 'utils/utils.dart';
 import 'widgets/shared_preferences_builder.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -211,9 +211,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         Log('main', 'lifecycle: resumed');
         mainBloc.isInBackground = false;
         lockService.lockSignal(context);
-        await mmSe.handleWakeUp().whenComplete(() {
-          if (mmSe.running) _requestResync();
-        });
+        final didNeedWakeUp = await mmSe.wakeUpSuspendedApi();
+
+        if (didNeedWakeUp) _requestResync();
 
         break;
     }

--- a/lib/model/cex_provider.dart
+++ b/lib/model/cex_provider.dart
@@ -377,7 +377,10 @@ class CexPrices {
     _init();
   }
 
+  bool isInitialized = false;
+
   Future<void> _init() async {
+    if (isInitialized) return;
     prefs = await SharedPreferences.getInstance();
     activeCurrency = prefs.getInt('activeCurrency') ?? 0;
     _selectedFiat = prefs.getString('selectedFiat') ?? 'USD';
@@ -389,6 +392,8 @@ class CexPrices {
       updatePrices();
       updateRates();
     });
+
+    isInitialized = true;
   }
 
   List<String> currencies;
@@ -617,7 +622,8 @@ class CexPrices {
 
     Map<String, dynamic> json;
     try {
-      json = jsonDecode(_body);
+      final isJsonString = _body.startsWith('{');
+      json = isJsonString ? jsonDecode(_body) : null;
     } catch (e) {
       Log('cex_provider', 'Failed to parse prices json: $e');
     }
@@ -696,14 +702,16 @@ class CexPrices {
 
     _fetchingPrices = false;
 
+    if (_body == null) return false;
+
     Map<String, dynamic> json;
     try {
       json = jsonDecode(_body);
     } catch (e) {
       Log('cex_provider', 'Failed to parse prices json: $e');
     }
-
     if (json == null) return false;
+
     if (json['error'] != null) {
       Log('cex_provider', 'Prices endpoint error: ${json['error']}');
       return false;

--- a/lib/model/cex_provider.dart
+++ b/lib/model/cex_provider.dart
@@ -616,8 +616,11 @@ class CexPrices {
           return;
         },
       );
-      if (_body == null) return false;
-      _body = _res.body;
+      _body = _res?.body;
+      if (_body == null) {
+        _fetchingPrices = false;
+        return false;
+      }
     } catch (e) {
       Log('cex_provider', 'Failed to fetch usd prices: $e');
     }

--- a/lib/model/cex_provider.dart
+++ b/lib/model/cex_provider.dart
@@ -441,6 +441,9 @@ class CexPrices {
         },
       );
       _body = _res.body;
+
+      if (_body == null)
+        return Log('cex_provider', 'Failed to fetch rates: $_res');
     } catch (e) {
       Log('cex_provider', 'Failed to fetch rates: $e');
     }
@@ -613,6 +616,7 @@ class CexPrices {
           return;
         },
       );
+      if (_body == null) return false;
       _body = _res.body;
     } catch (e) {
       Log('cex_provider', 'Failed to fetch usd prices: $e');
@@ -621,6 +625,7 @@ class CexPrices {
     _fetchingPrices = false;
 
     Map<String, dynamic> json;
+
     try {
       final isJsonString = _body.startsWith('{');
       json = isJsonString ? jsonDecode(_body) : null;

--- a/lib/model/get_tx_history.dart
+++ b/lib/model/get_tx_history.dart
@@ -7,10 +7,7 @@ import 'dart:convert';
 import 'package:komodo_dex/model/coin_type.dart';
 
 import '../blocs/coins_bloc.dart';
-import '../model/coin_type.dart';
-import '../services/mm_service.dart';
 import '../utils/utils.dart';
-
 import 'coin.dart';
 
 String getTxHistoryToJson(GetTxHistory data) => json.encode(data.toJson());
@@ -34,35 +31,34 @@ class GetTxHistory {
     // slp coins uses the rpc 2.0 methods
     Coin coinToEnable = coinsBloc.getKnownCoinByAbbr(coin);
 
-    bool v2Coins = isSlp(coinToEnable) ||
-        coinToEnable.type == CoinType.iris ||
-        coinToEnable.type == CoinType.cosmos;
-    return v2Coins
+    final type = coinToEnable.type;
+
+    if (type == CoinType.zhtlc) method = 'z_coin_tx_history';
+
+    final isV2Coin = isSlp(coinToEnable) ||
+        [CoinType.iris, CoinType.cosmos, CoinType.zhtlc].contains(type);
+
+    return isV2Coin
         ? <String, dynamic>{
             'userpass': userpass ?? '',
             'method': method ?? '',
             'mmrpc': '2.0',
             'params': {
               'coin': coin ?? '',
-            }
-          }
-        : coinToEnable.type == CoinType.zhtlc
-            ? <String, dynamic>{
-                'userpass': mmSe.userpass ?? '',
-                'method': 'z_coin_tx_history',
-                'mmrpc': '2.0',
-                'params': {
-                  'coin': coin ?? '',
-                  'limit': limit ?? 0,
+              'limit': limit ?? 0,
+              if (fromId != null)
+                'paging_options': {
+                  'FromId': int.tryParse(fromId ?? '') ?? fromId,
                 },
-              }
-            : <String, dynamic>{
-                'userpass': userpass ?? '',
-                'method': method ?? '',
-                'coin': coin ?? '',
-                'limit': limit ?? 0,
-                'from_id': fromId,
-                'decimals': coinToEnable.decimals
-    };
+            },
+          }
+        : <String, dynamic>{
+            'userpass': userpass ?? '',
+            'method': method ?? '',
+            'coin': coin ?? '',
+            'limit': limit ?? 0,
+            'from_id': fromId,
+            'decimals': coinToEnable.decimals,
+          };
   }
 }

--- a/lib/model/transaction_data.dart
+++ b/lib/model/transaction_data.dart
@@ -126,10 +126,18 @@ class FeeDetails {
     );
 
     try {
-      // QRC20 tokens
-      feeDetails.totalFee = cutTrailingZeros(formatPrice(
-          double.parse(json['miner_fee']) +
-              double.parse(json['total_gas_fee'])));
+      final minerFee =
+          json['miner_fee'] == null ? null : double.tryParse(json['miner_fee']);
+
+      final totalGasFee = json['total_gas_fee'] == null
+          ? null
+          : double.tryParse(json['total_gas_fee']);
+
+      if (minerFee != null || totalGasFee != null) {
+        final total = minerFee ?? 0.0 + totalGasFee ?? 0.0;
+        // QRC20 tokens
+        feeDetails.totalFee = cutTrailingZeros(formatPrice(total));
+      }
     } catch (_) {}
 
     return feeDetails;

--- a/lib/model/transactions.dart
+++ b/lib/model/transactions.dart
@@ -45,20 +45,31 @@ class Result {
     this.transactions,
   });
 
-  static Result fromJson(Map<String, dynamic> json) => json == null
-      ? null
-      : Result(
-          fromId: json['from_id'] ?? '',
-          limit: json['limit'] ?? 0,
-          skipped: json['skipped'] ?? 0,
-          total: json['total'] ?? 0,
-          currentBlock: json['current_block'] ?? 0,
-          syncStatus: json['sync_status'] == null
-              ? SyncStatus()
-              : SyncStatus.fromJson(json['sync_status']),
-          transactions: List<Transaction>.from(
-              json['transactions'].map((dynamic x) => Transaction.fromJson(x))),
-        );
+  static Result fromJson(Map<String, dynamic> json) {
+    if (json == null) return null;
+
+    final fromIdRaw = json['from_id'] ??
+        (json['paging_options'] != null &&
+                json['paging_options']['FromId'] != null
+            ? json['paging_options']['FromId']
+            : null);
+
+    final fromId = fromIdRaw is int ? fromIdRaw.toString() : fromIdRaw;
+
+    return Result(
+      fromId: fromId,
+      limit: json['limit'] ?? 0,
+      skipped: json['skipped'] ?? 0,
+      total: json['total'] ?? 0,
+      currentBlock: json['current_block'] ?? 0,
+      syncStatus: json['sync_status'] == null
+          ? SyncStatus()
+          : SyncStatus.fromJson(json['sync_status']),
+      transactions: List<Transaction>.from(
+        json['transactions'].map((dynamic x) => Transaction.fromJson(x)),
+      ),
+    );
+  }
 
   String fromId;
   int currentBlock;

--- a/lib/model/transactions.dart
+++ b/lib/model/transactions.dart
@@ -45,18 +45,20 @@ class Result {
     this.transactions,
   });
 
-  factory Result.fromJson(Map<String, dynamic> json) => Result(
-        fromId: json['from_id'] ?? '',
-        limit: json['limit'] ?? 0,
-        skipped: json['skipped'] ?? 0,
-        total: json['total'] ?? 0,
-        currentBlock: json['current_block'] ?? 0,
-        syncStatus: json['sync_status'] == null
-            ? SyncStatus()
-            : SyncStatus.fromJson(json['sync_status']),
-        transactions: List<Transaction>.from(
-            json['transactions'].map((dynamic x) => Transaction.fromJson(x))),
-      );
+  static Result fromJson(Map<String, dynamic> json) => json == null
+      ? null
+      : Result(
+          fromId: json['from_id'] ?? '',
+          limit: json['limit'] ?? 0,
+          skipped: json['skipped'] ?? 0,
+          total: json['total'] ?? 0,
+          currentBlock: json['current_block'] ?? 0,
+          syncStatus: json['sync_status'] == null
+              ? SyncStatus()
+              : SyncStatus.fromJson(json['sync_status']),
+          transactions: List<Transaction>.from(
+              json['transactions'].map((dynamic x) => Transaction.fromJson(x))),
+        );
 
   String fromId;
   int currentBlock;

--- a/lib/packages/rebranding/rebranding_dialog.dart
+++ b/lib/packages/rebranding/rebranding_dialog.dart
@@ -5,6 +5,8 @@ import 'package:komodo_dex/packages/rebranding/rebranding_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
+// TODO: Remove the code after the rebranding notice has expired. See date
+// specified in [appConfig.isRebrandingExpired?].
 class RebrandingDialog extends StatefulWidget {
   final bool isModal;
 

--- a/lib/packages/rebranding/rebranding_provider.dart
+++ b/lib/packages/rebranding/rebranding_provider.dart
@@ -2,13 +2,24 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class RebrandingProvider extends ChangeNotifier {
+  RebrandingProvider();
+
+  // TODO! Remove code/assets for rebranding after the date below
+  final rebrandingExpirationDate = DateTime(2023, 12, 1);
+  bool get isRebrandingExpired =>
+      DateTime.now().isAfter(rebrandingExpirationDate);
+
   bool _closedPermanently = false;
   bool _closedThisSession = false;
   SharedPreferences _prefs;
 
   Future<void> get prefsLoaded => _loadPrefs();
 
-  RebrandingProvider();
+  bool get shouldShowRebrandingDialog =>
+      !isRebrandingExpired && !closedPermanently && !closedThisSession;
+
+  bool get shouldShowRebrandingNews =>
+      !isRebrandingExpired && !closedPermanently;
 
   Future<void> _loadPrefs() async {
     _prefs = await SharedPreferences.getInstance();

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -37,8 +37,9 @@ class ZCoinActivationBloc
       return;
     }
 
-    final toActivate = await _repository.getRequestedActivatedCoins();
-    final toActivateInitalCount = toActivate.length;
+    final pendingCoinsToActivate =
+        await _repository.getRequestedActivatedCoins();
+    final totalCoinsToActivateCount = pendingCoinsToActivate.length.toInt();
 
     try {
       final zhtlcActivationPrefs = await loadZhtlcActivationPrefs();
@@ -68,16 +69,18 @@ class ZCoinActivationBloc
             );
           }
 
-          if (coinStatus.isActivated) {
-            toActivate.remove(coinStatus.coin);
-          }
-          final coinsRemainingCount = toActivate.length;
+          final completedCoinsCount =
+              totalCoinsToActivateCount - pendingCoinsToActivate.length;
 
           double overallProgress = calculateOverallProgress(
-            coinsRemainingCount,
-            toActivateInitalCount,
+            completedCoinsCount,
+            totalCoinsToActivateCount,
             coinStatus.progress,
           );
+
+          if (coinStatus.isActivated) {
+            pendingCoinsToActivate.remove(coinStatus.coin);
+          }
 
           overallProgress = calculateSmoothProgress(overallProgress);
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -48,11 +48,7 @@ class ZCoinActivationBloc
       return;
     }
 
-    final isResync = event.resync;
-
-    final toActivate = isResync
-        ? await _repository.getEnabledZCoins()
-        : await _repository.outstandingZCoinActivations();
+    final toActivate = await _repository.getRequestedActivatedCoins();
     final toActivateInitalCount = toActivate.length;
 
     try {
@@ -68,7 +64,7 @@ class ZCoinActivationBloc
         ),
       );
       await emit.forEach<ZCoinStatus>(
-        event.resync
+        event.isResync
             ? _repository.resyncZCoins()
             : _repository.activateRequestedZCoins(),
         onData: (coinStatus) {

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart
@@ -25,17 +25,6 @@ class ZCoinActivationBloc
     ZCoinActivationApi(),
   );
 
-  Future<bool> isResyncing() async {
-    final enabledCoins = (await _repository.getEnabledZCoins())
-        .map((coin) => coin.toLowerCase())
-        .toList();
-    final coinsToActivate = (await _repository.getRequestedActivatedCoins())
-        .map((coin) => coin.toLowerCase())
-        .toList();
-
-    return coinsToActivate.every((coin) => enabledCoins.contains(coin));
-  }
-
   Future<void> _handleActivationRequested(
     ZCoinActivationRequested event,
     Emitter<ZCoinActivationState> emit,
@@ -59,6 +48,7 @@ class ZCoinActivationBloc
         ZCoinActivationInProgess(
           progress: 0,
           message: 'Starting activation',
+          isResync: event.isResync,
           eta: null,
           startTime: DateTime.now(),
         ),
@@ -110,6 +100,7 @@ class ZCoinActivationBloc
           return ZCoinActivationInProgess(
             progress: shouldShowNewProgress ? overallProgress : lastProgress,
             message: 'Activating ${coinStatus.coin}',
+            isResync: event.isResync,
             eta: eta,
             startTime: previousInProgressState?.startTime ?? DateTime.now(),
           );

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
@@ -13,22 +13,22 @@ mixin ActivationEta {
       ),
     );
 
-    final hasEnoughEntries = _activationEntries.length >= 6 &&
+    final hasEnoughEntries = _activationEntries.length >= 4 &&
         _activationEntries.first.timeStamp
                 .difference(_activationEntries.last.timeStamp)
                 .inSeconds
                 .abs() >
-            50;
-
-    _activationEntries.retainWhere((entry) {
-      final elapsedSeconds =
-          DateTime.now().difference(entry.timeStamp).inSeconds;
-      return elapsedSeconds <= 60 || !hasEnoughEntries;
-    });
+            30;
 
     if (!hasEnoughEntries) {
       return null;
     }
+
+    _activationEntries.retainWhere((entry) {
+      final elapsedSeconds =
+          DateTime.now().difference(entry.timeStamp).inSeconds.abs();
+      return elapsedSeconds <= 120;
+    });
 
     double averageChangePerSecond = 0;
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
@@ -127,10 +127,20 @@ mixin ProgressCalculator {
   }
 
   double calculateOverallProgress(
-      int coinsRemainingCount, int initialCount, double coinProgress) {
-    return (1 -
-            (coinsRemainingCount / initialCount) +
-            (coinProgress / initialCount))
-        .clamp(0.0, 1.0);
+      int completedCoins, int totalCoins, double currentCoinProgress) {
+    // Fraction of the total progress that each coin represents.
+    double coinShare = 1.0 / totalCoins;
+
+    // Progress contributed by the coins that have already been fully activated.
+    double completedCoinsProgress = completedCoins * coinShare;
+
+    // Represents the progress of the coin currently being activated.
+    double inProgressCoinContribution = currentCoinProgress * coinShare;
+
+    // Calculating the overall progress
+    double val =
+        (completedCoinsProgress + inProgressCoinContribution).clamp(0.0, 1.0);
+
+    return val;
   }
 }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
@@ -5,6 +5,10 @@ import 'package:meta/meta.dart';
 mixin ActivationEta {
   final List<_ActivationEntry> _activationEntries = [];
 
+  void resetEta() {
+    _activationEntries.clear();
+  }
+
   Duration calculateETA(double progress) {
     _activationEntries.add(
       _ActivationEntry(
@@ -79,4 +83,54 @@ class _ActivationEntry {
 
   final double progress;
   final DateTime timeStamp;
+}
+
+mixin ProgressCalculator {
+  DateTime _lastProgressUpdate;
+  double _lastProgressValue = 0.0;
+
+  void resetProgress() {
+    _lastProgressUpdate = null;
+    _lastProgressValue = 0.0;
+  }
+
+  double calculateSmoothProgress(double currentProgress) {
+    if (currentProgress == 1.0) return 1.0;
+
+    final now = DateTime.now();
+
+    // If this is the first calculation, set the baseline
+    if (_lastProgressUpdate == null || currentProgress == 1) {
+      _lastProgressUpdate = now;
+      _lastProgressValue = currentProgress;
+      return currentProgress;
+    }
+
+    final timeDifference = now.difference(_lastProgressUpdate).inSeconds;
+
+    // Calculate the maximum allowed progress increase
+    final maxProgressIncrease = 0.01 * (timeDifference / 0.5);
+
+    // Determine the new progress based on the allowed increase
+    double newProgress = _lastProgressValue + maxProgressIncrease;
+
+    // Ensure the new progress does not exceed the current reported progress
+    if (newProgress > currentProgress) {
+      newProgress = currentProgress;
+    }
+
+    // Update the last progress and timestamp
+    _lastProgressValue = newProgress;
+    _lastProgressUpdate = now;
+
+    return newProgress;
+  }
+
+  double calculateOverallProgress(
+      int coinsRemainingCount, int initialCount, double coinProgress) {
+    return (1 -
+            (coinsRemainingCount / initialCount) +
+            (coinProgress / initialCount))
+        .clamp(0.0, 1.0);
+  }
 }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_eta_mixin.dart
@@ -17,7 +17,7 @@ mixin ActivationEta {
       ),
     );
 
-    final hasEnoughEntries = _activationEntries.length >= 4 &&
+    final hasEnoughEntries = _activationEntries.length >= 6 &&
         _activationEntries.first.timeStamp
                 .difference(_activationEntries.last.timeStamp)
                 .inSeconds

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
@@ -17,6 +17,4 @@ class ZCoinActivationSetRequestedCoins extends ZCoinActivationEvent {
   final List<String> coins;
 }
 
-class ZCoinActivationStatusRequested extends ZCoinActivationEvent {}
-
 class ZCoinActivationCancelRequested extends ZCoinActivationEvent {}

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
@@ -3,7 +3,11 @@ abstract class ZCoinActivationEvent {
 }
 
 /// Activates any requested ZCoins not already activated
-class ZCoinActivationRequested extends ZCoinActivationEvent {}
+class ZCoinActivationRequested extends ZCoinActivationEvent {
+  const ZCoinActivationRequested({this.resync = false});
+
+  final bool resync;
+}
 
 /// Sets the list of requested ZCoins to activate.
 /// Must call [ZCoinActivationRequested] to activate the coins.

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_event.dart
@@ -4,9 +4,9 @@ abstract class ZCoinActivationEvent {
 
 /// Activates any requested ZCoins not already activated
 class ZCoinActivationRequested extends ZCoinActivationEvent {
-  const ZCoinActivationRequested({this.resync = false});
+  const ZCoinActivationRequested({this.isResync = false});
 
-  final bool resync;
+  final bool isResync;
 }
 
 /// Sets the list of requested ZCoins to activate.

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -46,8 +46,6 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
             if (!isRegistered) {
               await coinsBloc.setupCoinAfterActivation(coin);
             }
-
-            await removeRequestedActivatedCoins([currentCoinTicker]);
           } else if (update.status == ActivationTaskStatus.failed) {
             await removeRequestedActivatedCoins([currentCoinTicker]);
             await api.removeTaskId(currentCoinTicker);
@@ -99,12 +97,6 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
     final requestedCoins = (await getRequestedActivatedCoins()).toSet();
 
     final activatedZCoins = (await getEnabledZCoins()).toSet();
-
-    final coinsAlreadyActivated = activatedZCoins.intersection(requestedCoins);
-
-    if (coinsAlreadyActivated.isNotEmpty) {
-      await removeRequestedActivatedCoins(coinsAlreadyActivated.toList());
-    }
 
     return requestedCoins.difference(activatedZCoins).toList();
   }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -18,8 +18,8 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
   static Future<String> get taskIdKey async =>
       'activationTaskId_${(await Db.getCurrentWallet()).id}';
 
-  Stream<ZCoinStatus> resyncEnabledZCoins() async* {
-    final enabledZCoins = await getEnabledZCoins();
+  Stream<ZCoinStatus> resyncZCoins() async* {
+    final enabledZCoins = await getRequestedActivatedCoins();
 
     yield* _activateZCoins(enabledZCoins, resyncOnly: true);
   }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -181,4 +181,18 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
 
     return status;
   }
+
+  /// Returns a list of activated coins according to our local database.
+  ///
+  /// This is not related to the activation status of the coins on the API. The
+  /// current API activation status could be `true` or `false`.
+  Future<List<String>> zCoinsTickersWithPreviousActivation() async {
+    final knownZCoins = (await getKnownZCoins()).map((c) => c.abbr).toSet();
+
+    final allActivatedCoins = (await Db.getCoinsFromDb()).toSet();
+
+    final previouslyActivated = knownZCoins.intersection(allActivatedCoins);
+
+    return previouslyActivated.toList();
+  }
 }

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_repository.dart
@@ -92,6 +92,21 @@ class ZCoinActivationRepository with RequestedZCoinsStorage {
     }
   }
 
+  // This is a workaround for the legacy coins bloc. It's not a good practice.
+  Future<void> legacyCoinsBlocDisableLocallyCallback(
+    String ticker,
+  ) async {
+    try {
+      await api.cancelCoinActivation(ticker);
+      await removeRequestedActivatedCoins([ticker]);
+    } catch (e) {
+      Log(
+        'z_coin_activation_repository:cancelAllZCoinActivations',
+        'Failed to cancel ZCoin activations: $e',
+      );
+    }
+  }
+
   @override
   Future<List<String>> outstandingZCoinActivations() async {
     final requestedCoins = (await getRequestedActivatedCoins()).toSet();

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
@@ -29,8 +29,12 @@ class ZCoinActivationInProgess extends ZCoinActivationState {
 
   final double progress;
   final String message;
-  final Duration eta; // nullable
-  final DateTime startTime; // nullable
+
+  /// Nullable
+  final Duration eta;
+
+  /// Nullable
+  final DateTime startTime;
 }
 
 class ZCoinActivationSuccess extends ZCoinActivationState {

--- a/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_activation_state.dart
@@ -23,12 +23,18 @@ class ZCoinActivationInProgess extends ZCoinActivationState {
   const ZCoinActivationInProgess({
     @required this.progress,
     @required this.message,
+    @required this.isResync,
     this.eta,
     this.startTime,
   });
 
   final double progress;
   final String message;
+
+  /// Describes whether the activation is the initial activation after selecting
+  /// coins to activate (false) or a resync  after the initial
+  /// activation (true). e.g. when restarting the app.
+  final bool isResync;
 
   /// Nullable
   final Duration eta;

--- a/lib/packages/z_coin_activation/bloc/z_coin_notifications.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_notifications.dart
@@ -121,6 +121,7 @@ class ZCoinProgressNotifications {
       showProgress: true,
       maxProgress: 100,
       onlyAlertOnce: true,
+      playSound: false,
       progress: progressInt,
     );
 

--- a/lib/packages/z_coin_activation/bloc/z_coin_requested_activation_storage.dart
+++ b/lib/packages/z_coin_activation/bloc/z_coin_requested_activation_storage.dart
@@ -45,8 +45,15 @@ mixin RequestedZCoinsStorage {
     await setRequestedActivatedCoins(updatedList.toList());
   }
 
+  /// Returns true if all requested coins are enabled.
+  /// Returns false if not all requested coins are enabled.
+  /// Returns null if no coins are requested.
   Future<bool> isAllRequestedZCoinsEnabled() async {
-    return (await outstandingZCoinActivations()).isEmpty;
+    final requestedCoins = await getRequestedActivatedCoins();
+
+    return requestedCoins.isEmpty
+        ? null
+        : (await outstandingZCoinActivations()).isEmpty;
   }
 
   Future<List<String>> outstandingZCoinActivations();

--- a/lib/packages/z_coin_activation/models/z_coin_status.dart
+++ b/lib/packages/z_coin_activation/models/z_coin_status.dart
@@ -29,9 +29,11 @@ class ZCoinStatus {
   final String message;
   final double progress;
 
-  bool get isActivated => status == ActivationTaskStatus.active;
+  bool get isActivated =>
+      status == ActivationTaskStatus.active ||
+      message.contains('is activated already');
 
-  bool get isFailed => status == ActivationTaskStatus.failed;
+  bool get isFailed => status == ActivationTaskStatus.failed && !isActivated;
 
   bool get isInProgress => status == ActivationTaskStatus.inProgress;
 

--- a/lib/packages/z_coin_activation/widgets/rotating_progress_indicator.dart
+++ b/lib/packages/z_coin_activation/widgets/rotating_progress_indicator.dart
@@ -19,6 +19,8 @@ class _RotatingCircularProgressIndicatorState
   Animation<double> progressAnimation;
   Animation<double> rotationAnimation;
 
+  final ValueNotifier<double> _targetValue = ValueNotifier<double>(null);
+
   @override
   void initState() {
     super.initState();
@@ -38,29 +40,31 @@ class _RotatingCircularProgressIndicatorState
       vsync: this,
     );
 
+    _updateProgressAnimation(widget.value);
+    progressController.value = widget.value;
+  }
+
+  void _updateProgressAnimation(double targetValue) {
     progressAnimation = Tween<double>(
-      begin: 0,
-      end: widget.value,
+      begin: progressController.value,
+      end: targetValue,
     ).animate(CurvedAnimation(
       parent: progressController,
       curve: Curves.easeOut,
-    ));
-
-    progressController.value = widget.value;
+    ))
+      ..addListener(() {
+        if (progressAnimation.isCompleted) {
+          progressController.value = progressAnimation.value;
+        }
+      });
+    progressController.forward(from: 0);
   }
 
   @override
   void didUpdateWidget(RotatingCircularProgressIndicator oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.value != oldWidget.value) {
-      progressAnimation = Tween<double>(
-        begin: progressController.value,
-        end: widget.value,
-      ).animate(CurvedAnimation(
-        parent: progressController,
-        curve: Curves.easeOut,
-      ));
-      progressController.forward(from: progressController.value);
+      _updateProgressAnimation(widget.value);
     }
   }
 
@@ -68,6 +72,7 @@ class _RotatingCircularProgressIndicatorState
   void dispose() {
     rotationController.dispose();
     progressController.dispose();
+    _targetValue.dispose();
     super.dispose();
   }
 

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:intl/intl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:komodo_dex/blocs/settings_bloc.dart';
 import 'package:komodo_dex/localizations.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_event.dart';
@@ -326,17 +327,17 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       ),
                     ),
                   ),
-
-                  RadioListTile<SyncType>(
-                    title: Text(localisations.syncFromSaplingActivation),
-                    value: SyncType.fullSync,
-                    groupValue: _syncType,
-                    onChanged: (SyncType value) {
-                      setState(() {
-                        _syncType = value;
-                      });
-                    },
-                  ),
+                  if (settingsBloc.enableTestCoins)
+                    RadioListTile<SyncType>(
+                      title: Text(localisations.syncFromSaplingActivation),
+                      value: SyncType.fullSync,
+                      groupValue: _syncType,
+                      onChanged: (SyncType value) {
+                        setState(() {
+                          _syncType = value;
+                        });
+                      },
+                    ),
 
                   SizedBox(height: 16),
                   // Sync Type Description

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -416,9 +416,7 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
 }
 
 Future<void> _showInProgressDialog(BuildContext context) async {
-  final isResyncing = await context.read<ZCoinActivationBloc>().isResyncing();
-
-  showDialog<void>(
+  return showDialog<void>(
     context: context,
     builder: (context) {
       final state =
@@ -465,7 +463,7 @@ Future<void> _showInProgressDialog(BuildContext context) async {
           ],
         ),
         actions: [
-          if (!isResyncing)
+          if (!state.isResync)
             TextButton(
               onPressed: () =>
                   _showConfirmCancelActivationDialog(context).ignore(),

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -467,32 +467,51 @@ Future<void> _showInProgressDialog(BuildContext context) async {
         actions: [
           if (!isResyncing)
             TextButton(
-              onPressed: () {
-                showConfirmationDialog(
-                  context: context,
-                  title: localisations.cancelActivationQuestion,
-                  message: localisations.cofirmCancelActivation,
-                  onConfirm: () {
-                    context
-                        .read<ZCoinActivationBloc>()
-                        .add(ZCoinActivationCancelRequested());
-                  },
-                  confirmButtonText: localisations.cancelActivation,
-                );
-              },
-              child: Text(localisations.cancelActivation),
+              onPressed: () =>
+                  _showConfirmCancelActivationDialog(context).ignore(),
+              child: Text(
+                localisations.cancelActivation,
+                style: DefaultTextStyle.of(context)
+                    .style
+                    .copyWith(color: Theme.of(context).errorColor),
+              ),
             ),
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: Text(localisations.close),
           ),
         ],
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(10),
-          side: BorderSide(
-            color: Theme.of(context).colorScheme.error,
+      );
+    },
+  );
+}
+
+Future<bool> _showConfirmCancelActivationDialog(BuildContext context) async {
+  final localisations = AppLocalizations.of(context);
+
+  return showDialog<bool>(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(localisations.cancelActivation),
+        content: Text(localisations.cancelActivationQuestion),
+        actions: <Widget>[
+          TextButton(
+            child: Text(localisations.close),
+            onPressed: () {
+              Navigator.of(context).pop(false);
+            },
           ),
-        ),
+          ElevatedButton(
+            child: Text(localisations.confirm),
+            onPressed: () {
+              context
+                  .read<ZCoinActivationBloc>()
+                  .add(ZCoinActivationCancelRequested());
+              Navigator.of(context).pop(true);
+            },
+          ),
+        ],
       );
     },
   );

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:flutter/foundation.dart';
-import 'package:intl/intl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
 import 'package:komodo_dex/blocs/settings_bloc.dart';
 import 'package:komodo_dex/localizations.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart';
@@ -13,7 +14,6 @@ import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_notifications.
 import 'package:komodo_dex/packages/z_coin_activation/models/z_coin_activation_prefs.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/rotating_progress_indicator.dart';
 import 'package:komodo_dex/services/mm_service.dart';
-import 'package:komodo_dex/widgets/confirmation_dialog.dart';
 
 class ZCoinStatusWidget extends StatefulWidget {
   const ZCoinStatusWidget({Key key}) : super(key: key);

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -443,7 +443,7 @@ Future<void> _showInProgressDialog(BuildContext context) async {
       final localisations = AppLocalizations.of(context);
 
       final etaString = state?.eta?.inMinutes == null
-          ? localisations.loading
+          ? null
           : '${state.eta.inMinutes}${localisations.minutes}';
       return AlertDialog(
         title: Text(
@@ -462,12 +462,14 @@ Future<void> _showInProgressDialog(BuildContext context) async {
             ],
             Text(localisations.willTakeTime),
             SizedBox(height: 16),
-            Text('${localisations.rewardsTableTime}: $etaString'),
-            SizedBox(height: 16),
+            if (etaString != null) ...[
+              Text('${localisations.rewardsTableTime}: $etaString'),
+              SizedBox(height: 16),
+            ],
             Text(
               '${localisations.swapProgress}: ${(state.progress * 100).round()}%',
             ),
-            SizedBox(height: 4),
+            SizedBox(height: 8),
             LinearProgressIndicator(value: state.progress),
           ],
         ),

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -292,6 +292,41 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       });
                     },
                   ),
+
+                  // Date Picker shown if sync type is specified date
+                  AnimatedContainer(
+                    height: _syncType == SyncType.specifiedDate ? 80 : 0,
+                    duration: Duration(milliseconds: 300),
+                    curve: Curves.easeInOut,
+                    child: ClipRRect(
+                      child: Column(
+                        children: [
+                          ElevatedButton(
+                            onPressed: () async {
+                              final DateTime pickedDate = await showDatePicker(
+                                context: context,
+                                initialDate: _selectedDate,
+                                firstDate: DateTime(2000),
+                                lastDate: DateTime.now(),
+                              );
+                              if (pickedDate != null &&
+                                  pickedDate != _selectedDate)
+                                setState(() {
+                                  _selectedDate = pickedDate;
+                                });
+                            },
+                            child: Text(localisations.selectDate),
+                          ),
+                          // Display the selected date
+                          Text(
+                            '${localisations.startDate}: '
+                            "${DateFormat('yyyy-MM-dd').format(_selectedDate)}",
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+
                   RadioListTile<SyncType>(
                     title: Text(localisations.syncFromSaplingActivation),
                     value: SyncType.fullSync,
@@ -302,35 +337,6 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
                       });
                     },
                   ),
-                  // Date Picker
-                  _syncType == SyncType.specifiedDate
-                      ? Column(
-                          children: [
-                            ElevatedButton(
-                              onPressed: () async {
-                                final DateTime pickedDate =
-                                    await showDatePicker(
-                                  context: context,
-                                  initialDate: _selectedDate,
-                                  firstDate: DateTime(2000),
-                                  lastDate: DateTime.now(),
-                                );
-                                if (pickedDate != null &&
-                                    pickedDate != _selectedDate)
-                                  setState(() {
-                                    _selectedDate = pickedDate;
-                                  });
-                              },
-                              child: Text(localisations.selectDate),
-                            ),
-                            // Display the selected date
-                            Text(
-                              '${localisations.startDate}: '
-                              "${DateFormat('yyyy-MM-dd').format(_selectedDate)}",
-                            ),
-                          ],
-                        )
-                      : SizedBox.shrink(),
 
                   SizedBox(height: 16),
                   // Sync Type Description
@@ -345,19 +351,13 @@ Future<Map<String, dynamic>> _showConfirmationDialog(BuildContext context) {
 
                   if (Platform.isIOS) ...[
                     SizedBox(height: 16),
-                    ListTile(
-                      leading: Icon(
-                        Icons.warning,
-                        color: Colors.amber,
-                      ),
-                      dense: true,
-                      title: Text(
-                        localisations.minimizingWillTerminate,
-                        style: DefaultTextStyle.of(context)
-                            .style
-                            .apply(color: Colors.amber),
-                      ),
-                    )
+                    Text(
+                      localisations.minimizingWillTerminate,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyText2
+                          .copyWith(color: Colors.amber),
+                    ),
                   ],
                   if (_syncType == SyncType.fullSync ||
                       _syncType == SyncType.specifiedDate)

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -102,12 +102,6 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
                     )
                   : null,
           selected: false,
-          trailing: IconButton(
-            icon: Icon(
-              Icons.refresh,
-              color: Colors.white,
-            ),
-          ),
         );
       },
     );

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -14,6 +14,7 @@ import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_notifications.
 import 'package:komodo_dex/packages/z_coin_activation/models/z_coin_activation_prefs.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/rotating_progress_indicator.dart';
 import 'package:komodo_dex/services/mm_service.dart';
+import 'package:komodo_dex/widgets/animated_linear_progress_indicator.dart';
 
 class ZCoinStatusWidget extends StatefulWidget {
   const ZCoinStatusWidget({Key key}) : super(key: key);
@@ -462,7 +463,10 @@ Future<void> _showInProgressDialog(BuildContext context) async {
               '${localisations.swapProgress}: ${(state.progress * 100).round()}%',
             ),
             SizedBox(height: 8),
-            LinearProgressIndicator(value: state.progress),
+            AnimatedLinearProgressIndicator(
+              key: Key('z_coin_status_linear_progress_indicator'),
+              value: state.progress,
+            ),
           ],
         ),
         actions: [

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -431,9 +432,11 @@ Future<void> _showInProgressDialog(BuildContext context) async {
 
       final localisations = AppLocalizations.of(context);
 
-      final etaString = state?.eta?.inMinutes == null
-          ? null
-          : '${state.eta.inMinutes}${localisations.minutes}';
+      final etaString = state?.eta?.inMinutes != null
+          ? '${state.eta.inMinutes}${localisations.minutes}'
+          : kDebugMode
+              ? '¯\\_(ツ)_/¯'
+              : null;
       return AlertDialog(
         title: Text(
           '${localisations.warning}: '

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -107,9 +107,6 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
               Icons.refresh,
               color: Colors.white,
             ),
-            onPressed: () => context
-                .read<ZCoinActivationBloc>()
-                .add(ZCoinActivationStatusRequested()),
           ),
         );
       },

--- a/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
+++ b/lib/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart
@@ -64,13 +64,11 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
         if (isActivationInProgress) {
           final progressState = state as ZCoinActivationInProgess;
           return ListTile(
-            onTap: () => _showInProgressDialog(context),
             title: Text(localisations.activating(protocolTag)),
+            dense: true,
+            onTap: () => _showInProgressDialog(context),
             subtitle: Text(localisations.doNotCloseTheAppTapForMoreInfo),
-            leading: Icon(
-              Icons.warning,
-              color: Colors.red,
-            ),
+            leading: Icon(Icons.hourglass_full_rounded),
             tileColor: Theme.of(context).primaryColor,
             trailing: SizedBox(
               child: RotatingCircularProgressIndicator(
@@ -119,7 +117,14 @@ class _ZCoinStatusWidgetState extends State<ZCoinStatusWidget> {
   }
 
   static void listener(BuildContext context, ZCoinActivationState state) {
-    final scaffold = ScaffoldMessenger.maybeOf(context);
+    ScaffoldMessengerState scaffold;
+
+    try {
+      ScaffoldMessenger.maybeOf(context);
+    } catch (e) {
+      return;
+    }
+
     if (scaffold == null) return;
 
     final localisations = AppLocalizations.of(context);

--- a/lib/screens/dex/trade/simple/create/coins_list.dart
+++ b/lib/screens/dex/trade/simple/create/coins_list.dart
@@ -57,32 +57,34 @@ class _CoinsListState extends State<CoinsList> {
       children: [
         if (widget.type == Market.BUY) ...{
           Container(
-              padding: EdgeInsets.only(bottom: 5),
-              child: Icon(
-                Icons.arrow_left,
-                color: Theme.of(context).textTheme.bodyText1.color,
-              )),
+            padding: EdgeInsets.only(bottom: 5),
+            child: Icon(
+              Icons.arrow_left,
+              color: Theme.of(context).textTheme.bodyText1.color,
+            ),
+          ),
         },
         Expanded(
           child: Container(
-              height: 106,
-              padding: EdgeInsets.fromLTRB(0, 10, 0, 4),
-              alignment: Alignment(0, 1),
-              child: Text(
-                message,
-                textAlign: widget.type == Market.BUY
-                    ? TextAlign.left
-                    : TextAlign.right,
-                style: Theme.of(context).textTheme.bodyText1,
-              )),
+            height: 106,
+            padding: EdgeInsets.fromLTRB(0, 10, 0, 4),
+            alignment: Alignment(0, 1),
+            child: Text(
+              message,
+              textAlign:
+                  widget.type == Market.BUY ? TextAlign.left : TextAlign.right,
+              style: Theme.of(context).textTheme.bodyText1,
+            ),
+          ),
         ),
         if (widget.type == Market.SELL) ...{
           Container(
-              padding: EdgeInsets.only(bottom: 5),
-              child: Icon(
-                Icons.arrow_right,
-                color: Theme.of(context).textTheme.bodyText1.color,
-              )),
+            padding: EdgeInsets.only(bottom: 5),
+            child: Icon(
+              Icons.arrow_right,
+              color: Theme.of(context).textTheme.bodyText1.color,
+            ),
+          ),
           SizedBox(width: 6),
         }
       ],

--- a/lib/screens/feed/news/news_tab.dart
+++ b/lib/screens/feed/news/news_tab.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:komodo_dex/packages/rebranding/rebranding_dialog.dart';
+import 'package:komodo_dex/packages/rebranding/rebranding_provider.dart';
+import 'package:provider/provider.dart';
+
 import '../../../localizations.dart';
 import '../../../model/feed_provider.dart';
 import '../../feed/news/build_news_item.dart';
-import 'package:provider/provider.dart';
 
 class NewsTab extends StatefulWidget {
   @override
@@ -18,6 +20,8 @@ class _NewsTabState extends State<NewsTab> {
   Widget build(BuildContext context) {
     _feedProvider = Provider.of<FeedProvider>(context);
     _news = _feedProvider.getNews();
+
+    final rebrandingProvider = context.watch<RebrandingProvider>();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_feedProvider.hasNewItems) {
@@ -48,7 +52,8 @@ class _NewsTabState extends State<NewsTab> {
 
     return Column(
       children: <Widget>[
-        RebrandingDialog(isModal: false),
+        if (rebrandingProvider.shouldShowRebrandingNews)
+          RebrandingDialog(isModal: false),
         _buildUpdateIndicator(),
         Expanded(
           child: RefreshIndicator(
@@ -81,11 +86,7 @@ class _NewsTabState extends State<NewsTab> {
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
                 itemCount: _news.length,
                 itemBuilder: (BuildContext context, int i) {
-                  return Column(
-                    children: <Widget>[
-                      BuildNewsItem(_news[i]),
-                    ],
-                  );
+                  return BuildNewsItem(_news[i]);
                 }),
           ),
         ),

--- a/lib/screens/portfolio/add_coin_fab.dart
+++ b/lib/screens/portfolio/add_coin_fab.dart
@@ -31,23 +31,34 @@ class _AddCoinFabState extends State<AddCoinFab> {
   bool tappedWhileLoading = false;
 
   StreamSubscription<CoinToActivate> _coinSubscription;
+  final Completer<bool> _shouldShowAddCoinButtonCompleter = Completer<bool>();
 
   bool get _isShowLoading => _isLoading && tappedWhileLoading;
-
   bool get _isLoading => _hasCoinsToAdd == null || _areCoinsLoading;
 
   @override
   void initState() {
     super.initState();
+
+    if (coinsBloc.currentActiveCoin != null) {
+      _areCoinsLoading = false;
+    }
+
     _coinSubscription = coinsBloc.outcurrentActiveCoin.listen((coinData) {
       setState(() {
         _areCoinsLoading = coinData != null;
       });
 
       _showAddCoinPageIfNeeded();
-    });
+    }, cancelOnError: false);
 
     _shouldShowAddCoinButton().then((value) {
+      if (!_shouldShowAddCoinButtonCompleter.isCompleted) {
+        _shouldShowAddCoinButtonCompleter.complete(value);
+      }
+    });
+
+    _shouldShowAddCoinButtonCompleter.future.then((value) {
       setState(() => _hasCoinsToAdd = value);
     }).whenComplete(() => _showAddCoinPageIfNeeded());
   }
@@ -58,9 +69,11 @@ class _AddCoinFabState extends State<AddCoinFab> {
     if (tappedWhileLoading && _hasCoinsToAdd == true) {
       _showAddCoinPage(context, _areCoinsLoading);
     }
-    setState(() {
-      tappedWhileLoading = false;
-    });
+
+    if (mounted)
+      setState(() {
+        tappedWhileLoading = false;
+      });
   }
 
   @override

--- a/lib/screens/portfolio/coin_detail/coin_detail.dart
+++ b/lib/screens/portfolio/coin_detail/coin_detail.dart
@@ -85,7 +85,6 @@ class _CoinDetailState extends State<CoinDetail> {
   Transaction latestTransaction;
 
   bool isRetryingActivation = false;
-  ScrollController scrollController = ScrollController();
 
   @override
   void initState() {
@@ -1063,7 +1062,7 @@ class _CoinDetailState extends State<CoinDetail> {
       AmountAddressStep(
         coinBalance: currentCoinBalance,
         paymentUriInfo: widget.paymentUriInfo,
-        scrollController: scrollController,
+        scrollController: _scrollController,
         onCancel: () {
           setState(() {
             isExpanded = false;
@@ -1071,8 +1070,8 @@ class _CoinDetailState extends State<CoinDetail> {
           });
         },
         onWithdrawPressed: () async {
-          scrollController.animateTo(
-            scrollController.position.minScrollExtent,
+          _scrollController.animateTo(
+            _scrollController.position.minScrollExtent,
             curve: Curves.easeOut,
             duration: const Duration(milliseconds: 300),
           );
@@ -1107,8 +1106,8 @@ class _CoinDetailState extends State<CoinDetail> {
                   setState(() {
                     isSendIsActive = false;
                   });
-                  scrollController.animateTo(
-                    scrollController.position.minScrollExtent,
+                  _scrollController.animateTo(
+                    _scrollController.position.minScrollExtent,
                     curve: Curves.easeOut,
                     duration: const Duration(milliseconds: 300),
                   );

--- a/lib/screens/portfolio/coin_detail/coin_detail.dart
+++ b/lib/screens/portfolio/coin_detail/coin_detail.dart
@@ -618,7 +618,7 @@ class _CoinDetailState extends State<CoinDetail> {
         if (currentCoinBalance.coin.protocol?.protocolData != null)
           _buildContractAddress(currentCoinBalance.coin.protocol),
         Padding(
-          padding: const EdgeInsets.symmetric(vertical: 48),
+          padding: const EdgeInsets.symmetric(vertical: 24),
           child: StreamBuilder<List<CoinBalance>>(
             initialData: coinsBloc.coinBalance,
             stream: coinsBloc.outCoins,
@@ -680,51 +680,36 @@ class _CoinDetailState extends State<CoinDetail> {
             },
           ),
         ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: <Widget>[
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(left: 16, right: 8),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Row(
+            children: [
+              Flexible(
                 child: _buildButtonLight(StatusButton.RECEIVE, mContext),
               ),
-            ),
-            if (currentCoinBalance.coin.abbr == 'KMD' &&
-                double.parse(currentCoinBalance.balance.getBalance()) >= 10)
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: _buildButtonLight(StatusButton.CLAIM, mContext),
-                ),
-              ),
-            if (appConfig.defaultTestCoins
-                    .contains(currentCoinBalance.coin.abbr) ||
-                currentCoinBalance.coin.abbr == 'ZOMBIE')
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 8),
+              SizedBox(width: 8),
+              if (appConfig.defaultTestCoins
+                      .contains(currentCoinBalance.coin.abbr) ||
+                  currentCoinBalance.coin.abbr == 'ZOMBIE') ...[
+                Flexible(
                   child: _buildButtonLight(StatusButton.FAUCET, mContext),
                 ),
-              ),
-            if (currentCoinBalance.coin.abbr == 'TKL' ||
-                currentCoinBalance.coin.abbr == 'MCL')
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: _buildButtonLight(StatusButton.PUBKEY, mContext),
-                ),
-              ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(right: 16),
+                SizedBox(width: 8),
+              ],
+              Flexible(
                 child: _buildButtonLight(StatusButton.SEND, mContext),
               ),
-            ),
-          ],
+              SizedBox(width: 8),
+              if (currentCoinBalance.coin.abbr == 'KMD' &&
+                  double.parse(currentCoinBalance.balance.getBalance()) >= 10)
+                Flexible(
+                  child: _buildButtonLight(StatusButton.CLAIM, mContext),
+                ),
+            ],
+          ),
         ),
-        const SizedBox(
-          height: 16,
-        )
+        const SizedBox(height: 16)
       ],
     );
   }
@@ -809,6 +794,29 @@ class _CoinDetailState extends State<CoinDetail> {
 
   Widget _buildButtonLight(StatusButton statusButton, BuildContext mContext) {
     String text = '';
+    Widget icon;
+
+    switch (statusButton) {
+      case StatusButton.RECEIVE:
+        icon = Icon(Icons.qr_code_rounded, color: Colors.green);
+        break;
+      case StatusButton.SEND:
+        icon = Icon(
+          Icons.north_east_rounded,
+          color: Colors.red,
+        );
+        break;
+      case StatusButton.PUBKEY:
+        icon = Icon(Icons.copy_rounded);
+        break;
+      case StatusButton.FAUCET:
+        icon = Icon(Icons.local_drink_rounded, color: Colors.blue);
+        break;
+      case StatusButton.CLAIM:
+        icon = Icon(Icons.card_giftcard_rounded);
+        break;
+    }
+
     switch (statusButton) {
       case StatusButton.RECEIVE:
         text = AppLocalizations.of(context).receive;
@@ -830,6 +838,7 @@ class _CoinDetailState extends State<CoinDetail> {
         return Stack(
           children: <Widget>[
             SecondaryButton(
+              icon: icon,
               key: Key('open-' + statusButton.name),
               text: text,
               textColor: Theme.of(context).textTheme.button.color,
@@ -860,6 +869,7 @@ class _CoinDetailState extends State<CoinDetail> {
     return SecondaryButton(
       key: Key('open-' + statusButton.name),
       text: text,
+      icon: icon,
       isDarkMode: Theme.of(context).brightness != Brightness.light,
       textColor: Theme.of(context).colorScheme.secondary,
       borderColor: Theme.of(context).colorScheme.secondary,

--- a/lib/screens/portfolio/coin_detail/tx_list_item.dart
+++ b/lib/screens/portfolio/coin_detail/tx_list_item.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:komodo_dex/screens/portfolio/coin_detail/warning_transaction_list_item.dart';
+import 'package:provider/provider.dart';
+
 import '../../../../blocs/settings_bloc.dart';
 import '../../../../model/cex_provider.dart';
 import '../../../../model/coin_balance.dart';
 import '../../../../model/transaction_data.dart';
 import '../../../../services/db/database.dart';
 import '../../../../utils/utils.dart';
-import 'package:provider/provider.dart';
-
 import '../transaction_detail.dart';
 
 class TransactionListItem extends StatefulWidget {
-  const TransactionListItem(
-      {this.transaction, this.currentCoinBalance, Key key})
-      : super(key: key);
+  const TransactionListItem({
+    this.transaction,
+    this.currentCoinBalance,
+    Key key,
+  }) : super(key: key);
 
   final Transaction transaction;
   final CoinBalance currentCoinBalance;
@@ -27,20 +28,44 @@ class _TransactionListItemState extends State<TransactionListItem> {
   CexProvider cexProvider;
   bool isNoteExpanded = false;
 
+  String note;
+
   double get transactionValue =>
       double.parse(widget.transaction.myBalanceChange);
 
   bool get isWarningTransaction =>
       transactionValue == 0 && isErcType(widget.currentCoinBalance.coin);
 
+  bool get isConfirmed => widget.transaction.confirmations > 0;
+
+  bool get isReceived => double.parse(widget.transaction.myBalanceChange) > 0;
+
+  /// Shows the shortened address of either the `to` field if the transaction is
+  /// a send (our balance decreased), or otherwise, show the `from` field if
+  /// it is a receive (our balance increased).
+  String get formattedAddress {
+    final addresses = isReceived
+        ? widget.transaction.from
+        : widget.transaction.getToAddress();
+
+    String formatted = addresses.map((e) => formatAddressShort(e)).join(',');
+
+    if (formatted.isEmpty) formatted = '**********';
+
+    return formatted;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    Db.getNote(widget.transaction.txHash).then((value) {
+      if (mounted) setState(() => note = flattenParagraphs(value));
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     cexProvider ??= Provider.of<CexProvider>(context);
-
-    final TextStyle subtitle = Theme.of(context)
-        .textTheme
-        .subtitle1
-        .copyWith(fontWeight: FontWeight.bold);
 
     if (isWarningTransaction) {
       return WarningTransactionListItem(
@@ -48,183 +73,74 @@ class _TransactionListItemState extends State<TransactionListItem> {
       );
     }
 
+    final hasNote = note?.isNotEmpty ?? false;
+
     return Card(
-        child: InkWell(
-      borderRadius: const BorderRadius.all(Radius.circular(4)),
-      onTap: () => Navigator.push<dynamic>(
-        context,
-        MaterialPageRoute<dynamic>(
-          builder: (BuildContext context) => TransactionDetail(
+      child: ListTile(
+        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        onTap: () => Navigator.push<dynamic>(
+          context,
+          MaterialPageRoute<dynamic>(
+            builder: (BuildContext context) => TransactionDetail(
               transaction: widget.transaction,
-              coinBalance: widget.currentCoinBalance),
+              coinBalance: widget.currentCoinBalance,
+            ),
+          ),
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Container(
-                    padding: const EdgeInsets.all(8.0),
-                    decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        border: Border.all(
-                            color: double.parse(
-                                        widget.transaction.myBalanceChange) >
-                                    0
-                                ? Colors.green
-                                : Colors.redAccent,
-                            width: 2)),
-                    child: double.parse(widget.transaction.myBalanceChange) > 0
-                        ? Icon(Icons.arrow_downward)
-                        : Icon(Icons.arrow_upward)),
-              ),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: <Widget>[
-                    Padding(
-                      padding:
-                          const EdgeInsets.only(left: 16, right: 16, top: 8),
-                      child: StreamBuilder<bool>(
-                          initialData: settingsBloc.showBalance,
-                          stream: settingsBloc.outShowBalance,
-                          builder: (BuildContext context,
-                              AsyncSnapshot<bool> snapshot) {
-                            final amount =
-                                deci(widget.transaction.myBalanceChange);
-                            String amountString = deci2s(amount);
-                            if (snapshot.hasData && snapshot.data == false) {
-                              amountString =
-                                  (amount.toDouble() < 0 ? '-' : '') + '**.**';
-                            }
-                            return AutoSizeText(
-                              '${amount.toDouble() > 0 ? '+' : ''}$amountString ${widget.currentCoinBalance.coin.abbr}',
-                              maxLines: 1,
-                              style: subtitle,
-                              textAlign: TextAlign.end,
-                            );
-                          }),
-                    ),
-                    StreamBuilder<bool>(
-                        initialData: settingsBloc.showBalance,
-                        stream: settingsBloc.outShowBalance,
-                        builder: (BuildContext context,
-                            AsyncSnapshot<bool> snapshot) {
-                          if (widget.currentCoinBalance.priceForOne == null) {
-                            return const Padding(
-                                padding: EdgeInsets.only(
-                                    left: 16, right: 16, bottom: 16, top: 8),
-                                child: SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2.0,
-                                  ),
-                                ));
-                          } else {
-                            final usdAmount =
-                                deci(widget.currentCoinBalance.priceForOne) *
-                                    deci(widget.transaction.myBalanceChange);
-                            if (usdAmount != deci(0)) {
-                              bool hidden = false;
-                              if (snapshot.hasData && snapshot.data == false) {
-                                hidden = true;
-                              }
-                              return Padding(
-                                padding: const EdgeInsets.only(
-                                    left: 16, right: 16, bottom: 16, top: 8),
-                                child: Text(
-                                  cexProvider.convert(
-                                    usdAmount.toDouble(),
-                                    hidden: hidden,
-                                  ),
-                                  style: Theme.of(context).textTheme.bodyText1,
-                                ),
-                              );
-                            }
-                            return SizedBox();
-                          }
-                        }),
-                  ],
-                ),
+        // Show date
+        title: Text(widget.transaction.getTimeFormat()),
+        isThreeLine: hasNote,
+        dense: false,
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: 4),
+            Text(
+              formattedAddress,
+              style: Theme.of(context).textTheme.caption,
+            ),
+            if (note != null) ...[
+              SizedBox(height: 4),
+              Text(
+                note,
+                maxLines: isNoteExpanded ? null : 2,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.caption,
               ),
             ],
-          ),
-          FutureBuilder<String>(
-              future: Db.getNote(widget.transaction.txHash),
-              builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
-                if (!snapshot.hasData) {
-                  return SizedBox();
+          ],
+        ),
+        leading: Icon(
+          isReceived ? Icons.arrow_downward : Icons.arrow_upward,
+          color: isReceived ? Colors.green : Colors.redAccent,
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            StreamBuilder<bool>(
+              initialData: settingsBloc.showBalance,
+              stream: settingsBloc.outShowBalance,
+              builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+                final amount = deci(widget.transaction.myBalanceChange);
+                String amountString = deci2s(amount);
+                if (snapshot.hasData && snapshot.data == false) {
+                  amountString = (amount.toDouble() < 0 ? '-' : '') + '**.**';
                 }
-                return InkWell(
-                  onTap: () {
-                    setState(() {
-                      isNoteExpanded = !isNoteExpanded;
-                    });
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 16.0, vertical: 8.0),
-                    child: Text(
-                      snapshot.data,
-                      maxLines: isNoteExpanded ? null : 1,
-                      overflow: isNoteExpanded ? null : TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodyText1,
-                    ),
-                  ),
+                return Text(
+                  '${amount.toDouble() > 0 ? '+' : ''}$amountString',
                 );
-              }),
-          Container(
-            color: Theme.of(context).scaffoldBackgroundColor,
-            height: 1,
-            width: double.infinity,
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: Text(
-                    widget.transaction.getTimeFormat(),
-                    style: Theme.of(context).textTheme.bodyText1.copyWith(
-                          color: Colors.grey,
-                        ),
-                  ),
-                ),
-                Expanded(child: SizedBox()),
-                Builder(
-                  builder: (BuildContext context) {
-                    return widget.transaction.confirmations > 0
-                        ? Container(
-                            height: 12,
-                            width: 12,
-                            decoration: BoxDecoration(
-                                borderRadius:
-                                    const BorderRadius.all(Radius.circular(16)),
-                                color: Colors.green),
-                          )
-                        : Container(
-                            height: 12,
-                            width: 12,
-                            decoration: BoxDecoration(
-                                borderRadius:
-                                    const BorderRadius.all(Radius.circular(16)),
-                                color: Colors.red),
-                          );
-                  },
-                )
-              ],
+              },
             ),
-          )
-        ],
+            SizedBox(width: 8),
+            Icon(
+              isConfirmed ? Icons.check_circle : Icons.hourglass_bottom,
+              color: isConfirmed
+                  ? Theme.of(context).colorScheme.secondaryVariant
+                  : Colors.amber,
+            ),
+          ],
+        ),
       ),
-    ));
+    );
   }
 }

--- a/lib/screens/portfolio/coin_detail/tx_list_item.dart
+++ b/lib/screens/portfolio/coin_detail/tx_list_item.dart
@@ -112,6 +112,7 @@ class _TransactionListItemState extends State<TransactionListItem> {
         ),
         leading: Icon(
           isReceived ? Icons.arrow_downward : Icons.arrow_upward,
+          size: 32,
           color: isReceived ? Colors.green : Colors.redAccent,
         ),
         trailing: Row(

--- a/lib/screens/portfolio/coin_detail/tx_list_item.dart
+++ b/lib/screens/portfolio/coin_detail/tx_list_item.dart
@@ -94,10 +94,10 @@ class _TransactionListItemState extends State<TransactionListItem> {
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(height: 4),
+            SizedBox(height: 6),
             Text(
               formattedAddress,
-              style: Theme.of(context).textTheme.caption,
+              style: Theme.of(context).textTheme.bodyText2,
             ),
             if (note != null) ...[
               SizedBox(height: 4),

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -9,11 +9,9 @@ import 'package:komodo_dex/blocs/authenticate_bloc.dart';
 import 'package:komodo_dex/packages/rebranding/rebranding_dialog.dart';
 import 'package:komodo_dex/packages/rebranding/rebranding_provider.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart';
-import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_event.dart';
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_state.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
 import 'package:komodo_dex/screens/portfolio/animated_asset_proportions_graph.dart';
-import 'package:komodo_dex/services/mm.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../blocs/coins_bloc.dart';
@@ -63,14 +61,6 @@ class _CoinsPageState extends State<CoinsPage> {
     _scrollController = ScrollController();
     _scrollController.addListener(_scrollListener);
     if (mmSe.running) coinsBloc.updateCoinBalances();
-
-    final bloc = BlocProvider.of<ZCoinActivationBloc>(context);
-
-    // Check every 5 seconds if mmSe is running. When it is running, emit the
-    // event [ZCoinActivationStatusRequested] and kill the timer.
-    MM.untilRpcIsUp().then(
-          (_) => bloc.add(ZCoinActivationStatusRequested()),
-        );
 
     // Subscribe to the outIsLogin stream
     _loginSubscription = authBloc.outIsLogin.listen((isLogin) async {

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -154,7 +154,6 @@ class _CoinsPageState extends State<CoinsPage> {
                                         fit: StackFit.passthrough,
                                         children: [
                                           Center(
-                                            // alignment: Alignment.center,
                                             child: AutoSizeText(
                                               amountText,
                                               maxFontSize: 24,
@@ -168,7 +167,6 @@ class _CoinsPageState extends State<CoinsPage> {
                                                     fontWeight: FontWeight.w600,
                                                   ),
                                             ),
-                                            // child: Text('Lorem'),
                                           ),
                                           Align(
                                             alignment: Alignment.centerRight,
@@ -216,23 +214,21 @@ class _CoinsPageState extends State<CoinsPage> {
               automaticallyImplyLeading: false,
             ),
             BlocBuilder<ZCoinActivationBloc, ZCoinActivationState>(
+              key: Key('bloc-builder-zcoin-activation'),
               builder: (context, state) {
                 final isActivationInProgress =
                     state is ZCoinActivationInProgess;
 
-                return SliverVisibility(
-                  visible: isActivationInProgress,
-                  sliver: isActivationInProgress
-                      ? SliverAppBar(
-                          automaticallyImplyLeading: false,
-                          backgroundColor:
-                              Theme.of(context).scaffoldBackgroundColor,
-                          flexibleSpace: Center(
-                            child: ZCoinStatusWidget(),
-                          ),
-                          pinned: false,
-                        )
-                      : SliverToBoxAdapter(child: SizedBox.shrink()),
+                return SliverToBoxAdapter(
+                  child: AnimatedCollapse(
+                    key: Key('animated-collapse-zcoin-status'),
+                    isCollapsed: !isActivationInProgress,
+                    fullHeight: 64,
+                    child: Card(
+                      child: ZCoinStatusWidget(),
+                      margin: EdgeInsets.zero,
+                    ),
+                  ),
                 );
               },
             ),

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -12,6 +12,7 @@ import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_blo
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_state.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
 import 'package:komodo_dex/screens/portfolio/animated_asset_proportions_graph.dart';
+import 'package:komodo_dex/widgets/animated_collapse.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../blocs/coins_bloc.dart';
@@ -220,12 +221,14 @@ class _CoinsPageState extends State<CoinsPage> {
                     state is ZCoinActivationInProgess;
 
                 return SliverToBoxAdapter(
+                  key: Key('sliver-to-box-adapter-zcoin-status'),
                   child: AnimatedCollapse(
-                    key: Key('animated-collapse-zcoin-status'),
                     isCollapsed: !isActivationInProgress,
                     fullHeight: 64,
                     child: Card(
-                      child: ZCoinStatusWidget(),
+                      child: ZCoinStatusWidget(
+                        key: Key('zcoin-status-widget'),
+                      ),
                       margin: EdgeInsets.zero,
                     ),
                   ),
@@ -258,31 +261,6 @@ class _CoinsPageState extends State<CoinsPage> {
       end: Alignment.topRight,
       stops: const <double>[0.01, 1],
       colors: colors,
-    );
-  }
-}
-
-class AnimatedCollapse extends StatelessWidget {
-  const AnimatedCollapse({
-    Key key,
-    @required this.fullHeight,
-    @required this.isCollapsed,
-    @required this.child,
-  }) : super(key: key);
-
-  final Widget child;
-
-  final bool isCollapsed;
-
-  final double fullHeight;
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 400),
-      curve: Curves.easeInOutExpo,
-      height: isCollapsed ? 0 : fullHeight,
-      child: child,
     );
   }
 }

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -13,6 +13,7 @@ import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_eve
 import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_state.dart';
 import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
 import 'package:komodo_dex/screens/portfolio/animated_asset_proportions_graph.dart';
+import 'package:komodo_dex/services/mm.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../blocs/coins_bloc.dart';
@@ -38,6 +39,8 @@ class _CoinsPageState extends State<CoinsPage> {
   double _heightSliver;
 
   StreamSubscription<bool> _loginSubscription;
+
+  Timer _timer;
 
   // Rebranding
   Future<void> showRebrandingDialog(BuildContext context) async {
@@ -65,12 +68,9 @@ class _CoinsPageState extends State<CoinsPage> {
 
     // Check every 5 seconds if mmSe is running. When it is running, emit the
     // event [ZCoinActivationStatusRequested] and kill the timer.
-    Timer.periodic(const Duration(seconds: 5), (timer) {
-      if (mmSe.running) {
-        bloc.add(ZCoinActivationStatusRequested());
-        timer.cancel();
-      }
-    });
+    MM.untilRpcIsUp().then(
+          (_) => bloc.add(ZCoinActivationStatusRequested()),
+        );
 
     // Subscribe to the outIsLogin stream
     _loginSubscription = authBloc.outIsLogin.listen((isLogin) async {
@@ -93,7 +93,8 @@ class _CoinsPageState extends State<CoinsPage> {
 
   @override
   void dispose() {
-    _loginSubscription.cancel();
+    _loginSubscription?.cancel()?.ignore();
+    _timer?.cancel();
     super.dispose();
   }
 

--- a/lib/screens/portfolio/coins_page.dart
+++ b/lib/screens/portfolio/coins_page.dart
@@ -71,9 +71,8 @@ class _CoinsPageState extends State<CoinsPage> {
         // Wait for the prefs to load
         await rebrandingNotifier.prefsLoaded;
 
-        if (!rebrandingNotifier.closedPermanently &&
-            !rebrandingNotifier.closedThisSession) {
-          showRebrandingDialog(context);
+        if (rebrandingNotifier.shouldShowRebrandingDialog) {
+          showRebrandingDialog(context).ignore();
         }
       }
     });

--- a/lib/screens/settings/setting_page.dart
+++ b/lib/screens/settings/setting_page.dart
@@ -57,7 +57,6 @@ class _SettingPageState extends State<SettingPage> {
 
   @override
   void initState() {
-    context.read<ZCoinActivationBloc>().add(ZCoinActivationStatusRequested());
     _getVersionApplication().then((String onValue) {
       setState(() {
         version = onValue;

--- a/lib/screens/settings/setting_page.dart
+++ b/lib/screens/settings/setting_page.dart
@@ -120,11 +120,6 @@ class _SettingPageState extends State<SettingPage> {
             _buildTitle(AppLocalizations.of(context).developerTitle),
             _buildEnableTestCoins(),
             SizedBox(height: 2),
-
-            //
-            ZCoinStatusWidget(),
-            SizedBox(height: 2),
-
             _buildTitle(version),
             if (appConfig.isUpdateCheckerEnabled) _buildUpdate(),
             const SizedBox(

--- a/lib/screens/settings/setting_page.dart
+++ b/lib/screens/settings/setting_page.dart
@@ -1,26 +1,36 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_bloc.dart';
-import 'package:komodo_dex/packages/z_coin_activation/bloc/z_coin_activation_event.dart';
-import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
-import 'package:komodo_dex/utils/log_storage.dart';
-
-import '../../app_config/app_config.dart';
-import '../../blocs/camo_bloc.dart';
-import '../../model/cex_provider.dart';
-import '../../model/swap.dart';
-import '../../model/swap_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:komodo_dex/packages/z_coin_activation/widgets/z_coin_status_list_tile.dart';
+import 'package:komodo_dex/utils/log_storage.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
+import 'package:share/share.dart';
+
+import '../../app_config/app_config.dart';
 import '../../blocs/authenticate_bloc.dart';
+import '../../blocs/camo_bloc.dart';
 import '../../blocs/dialog_bloc.dart';
 import '../../blocs/main_bloc.dart';
 import '../../blocs/settings_bloc.dart';
 import '../../blocs/wallet_bloc.dart';
 import '../../localizations.dart';
+import '../../model/cex_provider.dart';
+import '../../model/swap.dart';
+import '../../model/swap_provider.dart';
 import '../../model/updates_provider.dart';
 import '../../model/wallet_security_settings_provider.dart';
+import '../../services/mm_service.dart';
+import '../../utils/log.dart';
+import '../../utils/utils.dart';
+import '../../widgets/build_red_dot.dart';
+import '../../widgets/custom_simple_dialog.dart';
+import '../../widgets/eula_contents.dart';
+import '../../widgets/primary_button.dart';
+import '../../widgets/scrollable_dialog.dart';
+import '../../widgets/tac_contents.dart';
 import '../authentification/lock_screen.dart';
 import '../authentification/pin_page.dart';
 import '../authentification/show_delete_wallet_confirmation.dart';
@@ -31,19 +41,6 @@ import '../import-export/import_swap_page.dart';
 import '../settings/camo_pin_setup_page.dart';
 import '../settings/updates_page.dart';
 import '../settings/view_seed_unlock_page.dart';
-import '../../services/mm_service.dart';
-import '../../utils/log.dart';
-import '../../utils/utils.dart';
-import '../../widgets/build_red_dot.dart';
-import '../../widgets/custom_simple_dialog.dart';
-import '../../widgets/eula_contents.dart';
-import '../../widgets/primary_button.dart';
-import '../../widgets/scrollable_dialog.dart';
-import '../../widgets/tac_contents.dart';
-
-import 'package:provider/provider.dart';
-import 'package:share/share.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 
 class SettingPage extends StatefulWidget {
   @override

--- a/lib/services/mm.dart
+++ b/lib/services/mm.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:http/http.dart' show Response;

--- a/lib/services/mm_service.dart
+++ b/lib/services/mm_service.dart
@@ -467,7 +467,7 @@ class MMService {
       await coinsBloc.activateCoinKickStart();
       final active = await coinsBloc.electrumCoins();
 
-      await coinsBloc.enableCoins(active);
+      await coinsBloc.enableCoins(active, initialization: true);
 
       for (int i = 0; i < 2; i++) {
         await coinsBloc.retryActivatingSuspendedCoins();

--- a/lib/services/notif_service.dart
+++ b/lib/services/notif_service.dart
@@ -112,7 +112,7 @@ class NotifService {
             ));
         if (res is! Transactions) continue;
 
-        for (Transaction tx in res.result.transactions) {
+        for (Transaction tx in res.result?.transactions ?? []) {
           if (tx.to.contains(address)) {
             if (double.parse(tx.myBalanceChange) < 0) continue;
             transactions.add(tx);

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -960,3 +960,16 @@ bool isCoinPresent(Coin coin, String query, String filter) {
       (coin.abbr.toLowerCase().contains(query.trim().toLowerCase()) ||
           coin.name.toLowerCase().contains(query.trim().toLowerCase()));
 }
+
+String formatAddressShort(String address) {
+  if (address == null) return null;
+  if (address.length < 10) return address;
+  return address.substring(0, 5) +
+      '...' +
+      address.substring(address.length - 5);
+}
+
+String flattenParagraphs(String text) {
+  if (text == null) return null;
+  return text.replaceAll('\n', ' ').replaceAll('\r', ' ').replaceAll('\t', ' ');
+}

--- a/lib/widgets/animated_collapse.dart
+++ b/lib/widgets/animated_collapse.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+class AnimatedCollapse extends StatefulWidget {
+  const AnimatedCollapse({
+    Key key,
+    @required this.fullHeight,
+    @required this.isCollapsed,
+    @required this.child,
+  }) : super(key: key);
+
+  final Widget child;
+  final bool isCollapsed;
+  final double fullHeight;
+
+  @override
+  _AnimatedCollapseState createState() => _AnimatedCollapseState();
+}
+
+class _AnimatedCollapseState extends State<AnimatedCollapse>
+    with SingleTickerProviderStateMixin {
+  AnimationController _controller;
+  Animation<double> _heightAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 400),
+      vsync: this,
+    );
+
+    _heightAnimation = Tween<double>(
+      begin: widget.fullHeight,
+      end: 0,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOutExpo))
+      ..addListener(() {
+        setState(() {});
+      });
+
+    if (widget.isCollapsed) {
+      _controller.value = 1.0; // set to collapsed
+    }
+  }
+
+  @override
+  void didUpdateWidget(AnimatedCollapse oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isCollapsed != oldWidget.isCollapsed) {
+      if (widget.isCollapsed) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Container(
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(shape: BoxShape.rectangle),
+          height: _heightAnimation.value,
+          child: _heightAnimation.value == 0 ? null : widget.child,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/widgets/animated_linear_progress_indicator.dart
+++ b/lib/widgets/animated_linear_progress_indicator.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+class AnimatedLinearProgressIndicator extends StatefulWidget {
+  const AnimatedLinearProgressIndicator({
+    Key key,
+    @required this.value,
+    // this.duration = const Duration(milliseconds: 200),
+    this.duration = const Duration(milliseconds: 600),
+    this.trackColor,
+    this.progressColor,
+  }) : super(key: key);
+
+  /// Progress value between 0.0 and 1.0
+  final double value;
+  final Duration duration;
+  final Color trackColor;
+  final Color progressColor;
+
+  @override
+  _AnimatedLinearProgressIndicatorState createState() =>
+      _AnimatedLinearProgressIndicatorState();
+}
+
+class _AnimatedLinearProgressIndicatorState
+    extends State<AnimatedLinearProgressIndicator>
+    with TickerProviderStateMixin {
+  AnimationController _controller;
+  Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _animation = Tween<double>(
+      begin: widget.value,
+      end: widget.value,
+    ).animate(_controller)
+      ..addListener(() => setState(() {}));
+  }
+
+  @override
+  void didUpdateWidget(AnimatedLinearProgressIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.value != widget.value) {
+      _animation = Tween<double>(
+        begin: _animation.value,
+        end: widget.value,
+      ).animate(
+        CurvedAnimation(
+          parent: _controller,
+          curve: Curves.easeInOut,
+        ),
+      );
+      _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final linearProgressTheme = Theme.of(context).progressIndicatorTheme;
+    final displayedTrackColor = widget.trackColor ??
+        linearProgressTheme.linearTrackColor ??
+        Theme.of(context).colorScheme.background;
+
+    final displayedProgressColor =
+        widget.progressColor ?? linearProgressTheme.color;
+
+    final displayedHeight = linearProgressTheme.linearMinHeight ?? 4;
+
+    return CustomPaint(
+      painter: _ProgressBarPainter(
+        progress: _animation.value,
+        progressColor: displayedProgressColor,
+        trackColor: displayedTrackColor,
+      ),
+      child: Container(height: displayedHeight),
+    );
+  }
+}
+
+class _ProgressBarPainter extends CustomPainter {
+  _ProgressBarPainter({
+    @required this.progress,
+    @required this.trackColor,
+    @required this.progressColor,
+    //ignore: unused_element
+    this.borderRadius = Radius.zero,
+  }) : assert(progress != null && progress >= 0.0 && progress <= 1.0);
+
+  final double progress;
+  final Color trackColor;
+  final Color progressColor;
+  final Radius borderRadius;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final backgroundPaint = Paint()
+      ..color = trackColor
+      ..style = PaintingStyle.fill;
+
+    final progressPaint = Paint()
+      ..color = progressColor
+      ..style = PaintingStyle.fill;
+
+    final backgroundRect = RRect.fromRectAndRadius(
+      Rect.fromPoints(Offset.zero, Offset(size.width, size.height)),
+      borderRadius,
+    );
+    canvas.drawRRect(backgroundRect, backgroundPaint);
+
+    // Clamp the progress between 0 and 1 to avoid any issues.
+    final clampedProgress = progress.clamp(0.0, 1.0);
+
+    final progressRect = RRect.fromRectAndRadius(
+      Rect.fromPoints(
+        Offset.zero,
+        Offset(size.width * clampedProgress, size.height),
+      ),
+      borderRadius,
+    );
+    canvas.drawRRect(progressRect, progressPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _ProgressBarPainter oldDelegate) {
+    return oldDelegate.progress != progress;
+  }
+}

--- a/lib/widgets/animated_linear_progress_indicator.dart
+++ b/lib/widgets/animated_linear_progress_indicator.dart
@@ -5,7 +5,7 @@ class AnimatedLinearProgressIndicator extends StatefulWidget {
     Key key,
     @required this.value,
     // this.duration = const Duration(milliseconds: 200),
-    this.duration = const Duration(milliseconds: 600),
+    this.duration = const Duration(seconds: 1),
     this.trackColor,
     this.progressColor,
   }) : super(key: key);

--- a/lib/widgets/eager_floating_action_button.dart
+++ b/lib/widgets/eager_floating_action_button.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+/// An eager floating action button (FAB) that responds to taps even when it's not "ready".
+///
+/// The FAB, when tapped while not ready, will display a circular progress loader. If the FAB
+/// becomes ready after being tapped, the provided `onTap` callback will be triggered automatically.
+///
+/// Usage:
+///
+/// ```dart
+/// EagerFloatingActionButton(
+///   isReady: someCondition,
+///   onTap: () {
+///     // Handle FAB tap here.
+///   },
+///   child: Icon(Icons.add),
+/// )
+/// ```
+class EagerFloatingActionButton extends StatefulWidget {
+  /// Creates an instance of the eager floating action button.
+  const EagerFloatingActionButton({
+    @required this.onTap,
+    @required this.isReady,
+    this.child,
+    this.location,
+  });
+
+  /// The callback that is called when the FAB is tapped and is ready.
+  ///
+  /// If the FAB is tapped when not ready, this callback will be called once the FAB becomes ready.
+  final VoidCallback onTap;
+
+  /// Indicates whether the FAB is ready or not.
+  ///
+  /// If `false`, the FAB will show a circular progress loader when tapped.
+  final bool isReady;
+
+  /// The widget to display inside the FAB.
+  ///
+  /// Typically an [Icon].
+  final Widget child;
+
+  /// The location to place the FAB within the [Scaffold], if needed.
+  final FloatingActionButtonLocation location;
+
+  @override
+  _EagerFloatingActionButtonState createState() =>
+      _EagerFloatingActionButtonState();
+}
+
+class _EagerFloatingActionButtonState extends State<EagerFloatingActionButton> {
+  bool _isLoading = false;
+
+  @override
+  void didUpdateWidget(EagerFloatingActionButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.isReady == oldWidget.isReady) return;
+
+    if (!_isLoading) return;
+
+    if (widget.isReady && widget.onTap != null) {
+      widget.onTap();
+    }
+
+    if (widget.isReady) {
+      _isLoading = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isTappable = widget.onTap != null && _isLoading == false;
+
+    return FloatingActionButton(
+      onPressed: isTappable
+          ? () {
+              if (!widget.isReady) {
+                setState(() {
+                  _isLoading = true;
+                });
+              } else {
+                widget.onTap();
+              }
+            }
+          : null,
+      child: _isLoading
+          ? CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(
+                Theme.of(context).colorScheme.onPrimary,
+              ),
+            )
+          : widget.child,
+    );
+  }
+}

--- a/lib/widgets/secondary_button.dart
+++ b/lib/widgets/secondary_button.dart
@@ -6,6 +6,7 @@ class SecondaryButton extends StatelessWidget {
     @required this.onPressed,
     this.text,
     this.child,
+    this.icon,
     this.isDarkMode = true,
     this.borderColor = Colors.black,
     this.height,
@@ -16,6 +17,7 @@ class SecondaryButton extends StatelessWidget {
   final VoidCallback onPressed;
   final String text;
   final Widget child;
+  final Widget icon;
   final bool isDarkMode;
   final Color borderColor;
   final Color textColor;
@@ -24,41 +26,55 @@ class SecondaryButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget child;
-    bool isSend = false;
+    Widget finalChild = child;
+    bool isSend = text != null && text == 'SEND';
+
     if (text != null) {
-      if (text == 'SEND') {
-        isSend = true;
-      }
-      child = Text(
+      finalChild = Text(
         text.toUpperCase(),
         maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+        overflow: TextOverflow.fade,
       );
-    } else {
-      child = child;
     }
+
     return SizedBox(
       height: height,
-      width: double.infinity,
-      child: OutlinedButton(
-        key: isSend ? const Key('secondary-button-send') : null,
-        onPressed: onPressed,
-        style: OutlinedButton.styleFrom(
-          primary: Theme.of(context).brightness == Brightness.light
-              ? textColor
-              : Theme.of(context).colorScheme.onSurface,
-          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-          side: BorderSide(
-            color: Theme.of(context).brightness == Brightness.light
-                ? borderColor
-                : Colors.white,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(30.0),
-          ),
-        ),
-        child: child,
+
+      // Please don't do this. It makes it difficult work with the widget in
+      // situations where you want to constrain the button to take up as
+      // little space as possible. Instead, let the parent widget handle
+      // constraining the button.
+      width: width ?? double.infinity,
+      child: icon == null
+          ? OutlinedButton(
+              key: isSend ? const Key('secondary-button-send') : null,
+              onPressed: onPressed,
+              style: _getButtonStyle(context),
+              child: finalChild,
+            )
+          : OutlinedButton.icon(
+              key: isSend ? const Key('secondary-button-send') : null,
+              onPressed: onPressed,
+              style: _getButtonStyle(context),
+              icon: icon,
+              label: finalChild,
+            ),
+    );
+  }
+
+  ButtonStyle _getButtonStyle(BuildContext context) {
+    return OutlinedButton.styleFrom(
+      primary: Theme.of(context).brightness == Brightness.light
+          ? textColor
+          : Theme.of(context).colorScheme.onSurface,
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      side: BorderSide(
+        color: Theme.of(context).brightness == Brightness.light
+            ? borderColor
+            : Colors.white,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(30.0),
       ),
     );
   }

--- a/lib/widgets/secondary_button.dart
+++ b/lib/widgets/secondary_button.dart
@@ -34,6 +34,7 @@ class SecondaryButton extends StatelessWidget {
         text.toUpperCase(),
         maxLines: 1,
         overflow: TextOverflow.fade,
+        softWrap: false,
       );
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ version: 0.7.0+2
 publish_to: none
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.8.1 <3.0.0"
 
 # We're using specific (pinned) plugin versions in order to help us review the dependency upgrades.
 # KomodoPlatform plugin upgrades should be created as new branches, with PR into master;


### PR DESCRIPTION
Make the ZHTLC activation process more resilient to being interrupted and for app restarts. And other bugs which were later discovered.

## Changelog:
- Fix an issue where resuming the iOS app after minimizing it would cause ARRR/ZHTLC to deactivate. The app now resyncs ARRR after minimizing.
- ARRR/ZHTLC: Hide sapling activation mode unless test coins are enabled.
- Rename some methods/variables and remove unused code.
- Minor ZHTLC UI/UX improvements.
- Set expiry for rebranding notice (November 2023).
- Implement ZHTLC coin disable/deactivation.
- Fixed pagination. Previously only 10 transactions max were shown. Now it will show as many as your fingers can scroll.
- Fix issue where disabled ZHTLC coins would re-activate after restart.
- Simplify coin details transactions list page.
- So many other improvements. See commit history

## To test (on iOS and Android):
- Test successful initial activation of the various `ARRR`/`ZOMBIE` activation modes. Testing sapling mode activation is not required.
- For past-date sync mode: After successful activation, restart the app and check that ZHTLC resyncs and transactions show.
- Check that sapling activation mode only shows when test coins mode is enabled.
- (Optional since the user is warned against it) Test what happens if the app is restarted during initial activation and during resync. We should be able to drop the warnings to the user not to do this since we can safely handle it.