### PR TITLE
update rates url

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -188,7 +188,7 @@ class AppConfig {
   // endpoint source code:
   // https://github.com/KomodoPlatform/mobile_endpoints_proxy/blob/main/main.py#L113
   String get fiatPricesEndpoint =>
-      'https://rates.komodo.earth/api/v1/usd_rates';
+      'https://defi-stats.komodo.earth/api/v3/rates/fixer_io';
 
   // endpoint source code:
   // https://github.com/KomodoPlatform/mobile_endpoints_proxy/blob/main/main.py#L95


### PR DESCRIPTION
Replaced https://rates.komodo.earth/api/v1/usd_rates with https://defi-stats.komodo.earth/api/v3/rates/fixer_io

To test:
- Change from USD to a few other fiats and confirm the values are sane