### PR TITLE
update proxy and candles urls

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -200,8 +200,8 @@ class AppConfig {
   // endpoint source code:
   // https://github.com/KomodoPlatform/CexPricesEndpoint
   String get candlestickTickersList =>
-      'https://komodo.earth:3333/api/v1/ohlc/tickers_list';
-  String get candlestickData => 'https://komodo.earth:3333/api/v1/ohlc';
+      'https://candles.komodo.earth/api/v1/ohlc/tickers_list';
+  String get candlestickData => 'https://candles.komodo.earth/api/v1/ohlc';
 
   // At the moment (8/24/2020) tx history is disabled on parity nodes,
   // so we switching ETH/ERC20, BNB/BEP20 tx history to
@@ -212,27 +212,48 @@ class AppConfig {
   // '/api/v1/erc_tx_history/{token}/{address}' - ERC20 transaction history
   // endpoint source code:
   // https://github.com/KomodoPlatform/etherscan-mm2-proxy
-  String get ethUrl => 'https://komodo.earth:3334/api/v1/eth_tx_history';
-  String get ercUrl => 'https://komodo.earth:3334/api/v2/erc_tx_history';
-  String get bnbUrl => 'https://komodo.earth:3334/api/v1/bnb_tx_history';
-  String get bepUrl => 'https://komodo.earth:3334/api/v2/bep_tx_history';
-  String get maticUrl => 'https://komodo.earth:3334/api/v1/plg_tx_history';
-  String get plgUrl => 'https://komodo.earth:3334/api/v2/plg_tx_history';
-  String get fantomUrl => 'https://komodo.earth:3334/api/v1/ftm_tx_history';
-  String get ftmUrl => 'https://komodo.earth:3334/api/v2/ftm_tx_history';
-  String get oneUrl => 'https://komodo.earth:3334/api/v1/hrc_tx_history';
-  String get hrcUrl => 'https://komodo.earth:3334/api/v2/hrc_tx_history';
-  String get movrUrl => 'https://komodo.earth:3334/api/v1/moonriver_tx_history';
-  String get mvrUrl => 'https://komodo.earth:3334/api/v2/moonriver_tx_history';
-  String get htUrl => 'https://komodo.earth:3334/api/v1/heco_tx_history';
-  String get hcoUrl => 'https://komodo.earth:3334/api/v2/heco_tx_history';
-  String get kcsUrl => 'https://komodo.earth:3334/api/v1/krc_tx_history';
-  String get krcUrl => 'https://komodo.earth:3334/api/v2/krc_tx_history';
-  String get etcUrl => 'https://komodo.earth:3334/api/v1/etc_tx_history';
-  String get sbchUrl => 'https://komodo.earth:3334/api/v1/sbch_tx_history';
-  String get ubqUrl => 'https://komodo.earth:3334/api/v1/ubq_tx_history';
-  String get avaxUrl => 'https://komodo.earth:3334/api/v1/avx_tx_history';
-  String get avxUrl => 'https://komodo.earth:3334/api/v2/avx_tx_history';
+  String get ethUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/eth_tx_history';
+  String get ercUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/erc_tx_history';
+  String get bnbUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/bnb_tx_history';
+  String get bepUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/bep_tx_history';
+  String get maticUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/plg_tx_history';
+  String get plgUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/plg_tx_history';
+  String get fantomUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/ftm_tx_history';
+  String get ftmUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/ftm_tx_history';
+  String get oneUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/hrc_tx_history';
+  String get hrcUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/hrc_tx_history';
+  String get movrUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/moonriver_tx_history';
+  String get mvrUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/moonriver_tx_history';
+  String get htUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/heco_tx_history';
+  String get hcoUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/heco_tx_history';
+  String get kcsUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/krc_tx_history';
+  String get krcUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/krc_tx_history';
+  String get etcUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/etc_tx_history';
+  String get sbchUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/sbch_tx_history';
+  String get ubqUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/ubq_tx_history';
+  String get avaxUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v1/avx_tx_history';
+  String get avxUrl =>
+      'https://etherscan-proxy.komodo.earth/api/v2/avx_tx_history';
 
   /// We're using different rpc ports for different wallet packages
   /// in order to allow multiple wallets to run simultaneously.


### PR DESCRIPTION
Just a little housekeeping.

komodo.earth:3334  -> etherscan-proxy.komodo.earth
komodo.earth:3333 -> candles.komodo.earth

Old urls still work, for now. This repo is the last one still using the old ones. No rush on review / merge, but should be included in the next release. 

To test:
- confirm candle charts still display
- confirm evm trasaction histories are updating correctly.