### PR TITLE
Fix swap steps hanging

### DIFF
--- a/lib/blocs/swap_history_bloc.dart
+++ b/lib/blocs/swap_history_bloc.dart
@@ -49,6 +49,9 @@ class SwapHistoryBloc implements BlocBase {
         case 'MakerPaymentSpent':
           status = Status.SWAP_SUCCESSFUL;
           break;
+        case 'MakerPaymentSpentByWatcher':
+          status = Status.SWAP_SUCCESSFUL;
+          break;
         case 'TakerPaymentSpent':
           status = Status.SWAP_SUCCESSFUL;
           break;

--- a/lib/model/recent_swaps.dart
+++ b/lib/model/recent_swaps.dart
@@ -225,7 +225,7 @@ class SwapEEL {
   });
 
   factory SwapEEL.fromJson(Map<String, dynamic> json) => SwapEEL(
-        data: json['data'] == null ? null : SwapEF.fromJson(json['data']),
+        data: json['data'] is Map ? SwapEF.fromJson(json['data']) : null,
         type: json['type'] ?? '',
       );
 

--- a/lib/screens/dex/orders/swap/detailed_swap_steps.dart
+++ b/lib/screens/dex/orders/swap/detailed_swap_steps.dart
@@ -69,8 +69,8 @@ class _DetailedSwapStepsState extends State<DetailedSwapSteps> {
         if (index + 1 > swap.result.successEvents.length) {
           return SwapStepStatus.failed;
         }
-        if (swap.result.events[index].event.type ==
-            swap.result.successEvents[index]) {
+        if (swap.result.successEvents
+            .any((String e) => e == swap.result.events[index].event.type)) {
           return SwapStepStatus.success;
         } else {
           return SwapStepStatus.failed;


### PR DESCRIPTION
Solves https://github.com/KomodoPlatform/komodo-wallet-mobile/issues/98

- Some swap states had different JSON structure that were unexpected for the front-end code. It was receiving an Array instead of Map at some events.
- `MakerPaymentSpentByWatcher` was not recognized as a success step.

Needs good testing.