### PR TITLE
Migrate BestOrders to mmrpc 2.0

### DIFF
--- a/lib/model/best_order.dart
+++ b/lib/model/best_order.dart
@@ -12,11 +12,13 @@ class BestOrders {
     if (json['result'] == null) return bestOrders;
 
     final Market action = bestOrders.request.action;
+    final Map<String, dynamic> resultOrders = (json['result']
+        as Map<String, dynamic>)['orders'] as Map<String, dynamic>;
 
-    json['result'].forEach((String ticker, dynamic items) {
+    resultOrders.forEach((String ticker, dynamic items) {
       bestOrders.result ??= {};
       final List<BestOrder> list = [];
-      for (dynamic item in items) {
+      for (final Map<String, dynamic> item in items) {
         item['action'] = action;
         item['other_coin'] =
             action == Market.SELL ? bestOrders.request.coin : ticker;
@@ -45,15 +47,20 @@ class BestOrder {
   });
 
   factory BestOrder.fromJson(Map<String, dynamic> json) {
+    final Map<String, dynamic> price = json['price'];
+    final Map<String, dynamic> maxVolume = json['base_max_volume'];
+    final Map<String, dynamic> minVolume = json['base_min_volume'];
+    final Map<String, dynamic> address = json['address'];
+
     return BestOrder(
-      price: fract2rat(json['price_fraction']) ?? Rational.parse(json['price']),
-      maxVolume: fract2rat(json['max_volume_fraction']) ??
-          Rational.parse(json['maxvolume']),
-      minVolume: fract2rat(json['min_volume_fraction']) ??
-          Rational.parse(json['min_volume']),
+      price: fract2rat(price['fraction']) ?? Rational.parse(price['decimal']),
+      maxVolume: fract2rat(maxVolume['fraction']) ??
+          Rational.parse(maxVolume['decimal']),
+      minVolume: fract2rat(minVolume['fraction']) ??
+          Rational.parse(minVolume['decimal']),
       coin: json['coin'],
       otherCoin: json['other_coin'],
-      address: json['address'],
+      address: address['address_data'],
       action: json['action'],
     );
   }

--- a/lib/model/get_best_orders.dart
+++ b/lib/model/get_best_orders.dart
@@ -8,6 +8,7 @@ class GetBestOrders {
   GetBestOrders({
     this.userpass,
     this.method = 'best_orders',
+    this.mmrpc = '2.0',
     this.coin,
     this.volume,
     this.action,
@@ -15,6 +16,7 @@ class GetBestOrders {
 
   String userpass;
   String method;
+  String mmrpc;
   String coin;
   Rational volume;
   Market action;
@@ -22,11 +24,14 @@ class GetBestOrders {
   Map<String, dynamic> toJson() => <String, dynamic>{
         'method': method,
         'userpass': userpass,
-        'coin': coin,
-        'volume': {
-          'numer': volume.numerator.toString(),
-          'denom': volume.denominator.toString(),
-        },
-        'action': action == Market.BUY ? 'buy' : 'sell',
+        'mmrpc': mmrpc,
+        'params': {
+          'coin': coin,
+          'action': action == Market.BUY ? 'buy' : 'sell',
+          'request_by': {
+            'type': 'volume',
+            'value': volume.toDecimalString(),
+          }
+        }
       };
 }


### PR DESCRIPTION
- Leaving the `BestOrder` and `BestOrders` attributes unchanged to minimise the impact
- Use base max and min volume to replace `max_volume_fraction`