### PR TITLE
Fix advanced swap order book showing incorrect values

### DIFF
--- a/lib/model/orderbook.dart
+++ b/lib/model/orderbook.dart
@@ -150,8 +150,18 @@ class Ask {
 
   Rational getReceiveAmount(Rational amountToSell) {
     Rational buyAmount = amountToSell / fract2rat(priceFract);
-    if (buyAmount >= fract2rat(maxvolumeFract))
-      buyAmount = fract2rat(maxvolumeFract);
+    final Rational buyBaseAmount = buyAmount * fract2rat(priceFract);
+
+    final Rational maxVolumeBase = fract2rat(maxvolumeFract);
+    final Rational maxVolumeRel =
+        fract2rat(maxvolumeFract) / fract2rat(priceFract);
+
+    final bool askRelGreaterThanMaxRelVolume = buyAmount >= maxVolumeRel;
+    final bool askBaseGreaterThanMaxBaseVolume = buyBaseAmount >= maxVolumeBase;
+
+    if (askRelGreaterThanMaxRelVolume || askBaseGreaterThanMaxBaseVolume) {
+      buyAmount = maxVolumeRel;
+    }
     return buyAmount;
   }
 

--- a/lib/screens/dex/trade/pro/create/receive/matching_bids_table.dart
+++ b/lib/screens/dex/trade/pro/create/receive/matching_bids_table.dart
@@ -120,6 +120,10 @@ class _MatchingBidsTableState extends State<MatchingBidsTable> {
   }
 
   TableRow _tableRow(Ask bid, int index) {
+    /// Convert the USD equivalent of the bid volume to the receive coin amount
+    final double _bidVolume = bid.maxvolume.toDouble();
+    final double convertedVolume = _bidVolume / bid.priceRat.toDouble();
+
     return TableRow(
       children: [
         TableRowInkWell(
@@ -192,7 +196,7 @@ class _MatchingBidsTableState extends State<MatchingBidsTable> {
                   color: Theme.of(context).highlightColor,
                 ))),
             child: Text(
-              formatPrice(bid.maxvolume.toDouble()),
+              formatPrice(convertedVolume),
               style:
                   Theme.of(context).textTheme.bodyText2.copyWith(fontSize: 13),
             ),
@@ -215,7 +219,7 @@ class _MatchingBidsTableState extends State<MatchingBidsTable> {
                   color: Theme.of(context).highlightColor,
                 ))),
             child: Text(
-              formatPrice(bid.maxvolume.toDouble() * double.parse(bid.price)),
+              formatPrice(convertedVolume * double.parse(bid.price)),
               style:
                   Theme.of(context).textTheme.bodyText2.copyWith(fontSize: 13),
             ),


### PR DESCRIPTION
Fixes #118 by 
 - converting the USD-based max volume to the coin amount, and 
 - limiting the received amount to the maximum volume of the Rel coin. 

The maximum volume of the base coin is used with the `orderbook` v2 endpoint, leading to incorrect values where the received coin is displayed as more than the maximum volume or less than the requested volume. 

**Before**: 
<img width="473" alt="image" src="https://github.com/KomodoPlatform/komodo-wallet-mobile/assets/11577022/cc1d374c-4027-4ba5-af25-6fa7131cba15">

**After**: 
<img width="466" alt="image" src="https://github.com/KomodoPlatform/komodo-wallet-mobile/assets/11577022/05f824c3-d06e-4007-8a58-c9a5dad96d05">

**Desktop**: 
<img width="798" alt="image" src="https://github.com/KomodoPlatform/komodo-wallet-mobile/assets/11577022/0131234d-8ba8-4215-bbd8-d1bdb78126bf">