### PR TITLE
Fix orderbook minimum volume calculation

### DIFF
--- a/lib/model/orderbook.dart
+++ b/lib/model/orderbook.dart
@@ -89,8 +89,10 @@ class Ask {
     this.price,
     this.priceFract,
     this.maxvolume,
+    this.maxRelVolume,
     this.maxvolumeFract,
     this.minVolume,
+    this.minRelVolume,
     this.pubkey,
     this.age,
     this.zcredits,
@@ -107,21 +109,41 @@ class Ask {
       priceFract: json['price']['fraction'],
       maxvolume: deci(json['base_max_volume']['decimal']),
       maxvolumeFract: json['base_max_volume']['fraction'],
+      maxRelVolume: deci(json['rel_max_volume']['decimal']),
       minVolume: fract2rat(json['base_min_volume']['fraction']) ??
           Rational.parse(json['base_min_volume']['decimal']),
+      minRelVolume: fract2rat(json['rel_min_volume']['fraction']) ??
+          Rational.parse(json['rel_min_volume']['decimal']),
       pubkey: json['pubkey'] ?? '',
       age: json['age'] ?? 0,
       zcredits: json['zcredits'] ?? 0,
     );
   }
 
+  /// The coin being bought (rel coin in the request).
   String coin;
   String address;
+
+  /// The price of 1 rel coin (coin being bought) in terms of the base coin
+  /// (coin being sold). E.g. If asking for WBTC, the price is the amount of
+  /// KMD needed to buy 1 WBTC.
   String price;
   Map<String, dynamic> priceFract;
+
+  /// The maximum amount of the base coin that can be sold
   Map<String, dynamic> maxvolumeFract;
+
+  /// The maximum amount of the base coin that can be sold
   Decimal maxvolume;
+
+  /// The maximum amount of [coin] that can be bought
+  Decimal maxRelVolume;
+
+  /// The minimum amount of the base coin that can be sold
   Rational minVolume;
+
+  /// The minimum amount of [coin] that can be bought
+  Rational minRelVolume;
   String pubkey;
   int age;
   int zcredits;
@@ -140,8 +162,12 @@ class Ask {
           'decimal': maxvolume.toString(),
           'fraction': maxvolumeFract,
         },
+        'rel_max_volume': {'decimal': maxRelVolume.toString()},
         'base_min_volume': {
           'fraction': rat2fract(minVolume),
+        },
+        'rel_min_volume': {
+          'fraction': rat2fract(minRelVolume),
         },
         'pubkey': pubkey ?? '',
         'age': age ?? 0,

--- a/lib/screens/dex/trade/pro/create/receive/matching_bids_table.dart
+++ b/lib/screens/dex/trade/pro/create/receive/matching_bids_table.dart
@@ -1,15 +1,16 @@
-import 'package:rational/rational.dart';
 import 'package:flutter/material.dart';
-import '../../../../../../blocs/swap_bloc.dart';
-import '../../../../../../model/order_book_provider.dart';
-import '../../../../../dex/trade/pro/create/receive/bid_details_dialog.dart';
-import '../../../../../dex/trade/pro/create/receive/not_enough_volume_dialog.dart';
 import 'package:provider/provider.dart';
+import 'package:rational/rational.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../../../../blocs/swap_bloc.dart';
 import '../../../../../../localizations.dart';
 import '../../../../../../model/addressbook_provider.dart';
+import '../../../../../../model/order_book_provider.dart';
 import '../../../../../../model/orderbook.dart';
 import '../../../../../../utils/utils.dart';
+import '../../../../../dex/trade/pro/create/receive/bid_details_dialog.dart';
+import '../../../../../dex/trade/pro/create/receive/not_enough_volume_dialog.dart';
 
 class MatchingBidsTable extends StatefulWidget {
   const MatchingBidsTable({
@@ -285,7 +286,7 @@ class _MatchingBidsTableState extends State<MatchingBidsTable> {
     final Rational maxSellAmt = swapBloc.maxTakerVolume ??
         Rational.parse(swapBloc.sellCoinBalance.balance.balance.toString());
     final bool isEnoughVolume =
-        !(bid.minVolume != null && maxSellAmt < (bid.minVolume * bid.priceRat));
+        !(bid.minVolume != null && maxSellAmt < bid.minVolume);
 
     if (isEnoughVolume) {
       Navigator.of(context).pop();

--- a/lib/screens/dex/trade/pro/create/receive/not_enough_volume_dialog.dart
+++ b/lib/screens/dex/trade/pro/create/receive/not_enough_volume_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '../../../../../../blocs/dialog_bloc.dart';
 import '../../../../../../blocs/swap_bloc.dart';
 import '../../../../../../localizations.dart';
@@ -38,7 +39,7 @@ void openNotEnoughVolumeDialog(BuildContext context, Ask ask) {
                       SizedBox(width: 4),
                       Text(
                           '${ask.coin} ' +
-                              cutTrailingZeros(formatPrice(ask.minVolume)),
+                              cutTrailingZeros(formatPrice(ask.minRelVolume)),
                           style: TextStyle(
                             color: Theme.of(context).primaryColorDark,
                             fontWeight: FontWeight.w400,
@@ -64,7 +65,7 @@ void openNotEnoughVolumeDialog(BuildContext context, Ask ask) {
                 SizedBox(width: 2),
                 Text(
                     cutTrailingZeros(formatPrice(
-                        ask.minVolume.toDouble() * double.parse(ask.price))),
+                        ask.minRelVolume.toDouble() * double.parse(ask.price))),
                     style: TextStyle(
                       fontSize: 12,
                       color: Theme.of(context).disabledColor,

--- a/lib/screens/dex/trade/pro/create/trade_form_validator.dart
+++ b/lib/screens/dex/trade/pro/create/trade_form_validator.dart
@@ -1,5 +1,5 @@
-import '../../../../dex/trade/pro/create/trade_form.dart';
 import 'package:rational/rational.dart';
+
 import '../../../../../blocs/coins_bloc.dart';
 import '../../../../../blocs/main_bloc.dart';
 import '../../../../../blocs/swap_bloc.dart';
@@ -8,6 +8,7 @@ import '../../../../../model/coin_balance.dart';
 import '../../../../../model/orderbook.dart';
 import '../../../../../model/trade_preimage.dart';
 import '../../../../../utils/utils.dart';
+import '../../../../dex/trade/pro/create/trade_form.dart';
 
 class TradeFormValidator {
   final CoinBalance sellBalance = swapBloc.sellCoinBalance;
@@ -57,7 +58,7 @@ class TradeFormValidator {
       return appLocalizations.minValueBuy(
           swapBloc.receiveCoinBalance.coin.abbr, '$minVolumeReceive');
     } else if (matchingBid != null && matchingBid.minVolume != null) {
-      if (amountReceive != null && amountReceive < matchingBid.minVolume) {
+      if (amountReceive != null && amountReceive < matchingBid.minRelVolume) {
         return appLocalizations.minValueOrder(
           swapBloc.receiveCoinBalance.coin.abbr,
           cutTrailingZeros(formatPrice(matchingBid.minVolume)),

--- a/lib/screens/markets/build_order_details.dart
+++ b/lib/screens/markets/build_order_details.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
-import '../../app_config/app_config.dart';
+import 'package:provider/provider.dart';
 import 'package:rational/rational.dart';
+
+import '../../app_config/app_config.dart';
+import '../../app_config/theme_data.dart';
 import '../../blocs/coins_bloc.dart';
 import '../../localizations.dart';
 import '../../model/addressbook_provider.dart';
 import '../../model/cex_provider.dart';
 import '../../model/order_book_provider.dart';
 import '../../model/orderbook.dart';
-import '../addressbook/addressbook_page.dart';
 import '../../utils/utils.dart';
 import '../../widgets/cex_data_marker.dart';
-import '../../app_config/theme_data.dart';
-import 'package:provider/provider.dart';
+import '../addressbook/addressbook_page.dart';
 
 class BuildOrderDetails extends StatefulWidget {
   const BuildOrderDetails(this.order, {this.sellAmount});
@@ -315,8 +316,9 @@ class _BuildOrderDetailsState extends State<BuildOrderDetails> {
   }
 
   Widget _buildMinVolume() {
-    if (widget.order.minVolume == null) return SizedBox();
-    if (widget.order.minVolume <= Rational.parse('0.00777')) return SizedBox();
+    if (widget.order.minRelVolume == null) return SizedBox();
+    if (widget.order.minRelVolume <= Rational.parse('0.00777'))
+      return SizedBox();
 
     return Row(
       children: <Widget>[
@@ -332,7 +334,7 @@ class _BuildOrderDetailsState extends State<BuildOrderDetails> {
               Text(
                 '${AppLocalizations.of(context).orderDetailsMin} '
                 '${widget.order.coin} '
-                '${cutTrailingZeros(formatPrice(widget.order.minVolume))}',
+                '${cutTrailingZeros(formatPrice(widget.order.minRelVolume))}',
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w400,


### PR DESCRIPTION
Base and Rel coins minimum volumes were swapped when selecting from the Orderbook. 
- Added missing Orderbook RPC fields for rel min and max volume
- Fixed the advanced swap minimum volume calculations and values

Before:
![Screenshot_1722548914](https://github.com/user-attachments/assets/783625e3-bdee-436d-8511-5a4cf1cc50ee)

After:
![Screenshot_1722549158](https://github.com/user-attachments/assets/b0b373b0-77b3-4fc2-ba7d-d740aba27841)